### PR TITLE
Rename eoneopay/utils to eonx-com/utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "packages/EasyDocker/bin/easy-docker"
     ],
     "require": {
-        "eoneopay/externals": "^1.0",
-        "eoneopay/utils": "^0.2",
+        "eonx-com/externals": "^1.0",
+        "eonx-com/utils": "^0.2",
         "ext-json": "*",
         "php": "^7.1",
         "symfony/expression-language": "^4.2",

--- a/packages/EasyApiToken/composer.json
+++ b/packages/EasyApiToken/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "eoneopay/utils": "^0.2"
+        "eonx-com/utils": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",

--- a/packages/EasyCfhighlander/composer.json
+++ b/packages/EasyCfhighlander/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "eoneopay/utils": "^0.2",
+        "eonx-com/utils": "^0.2",
         "symplify/package-builder": "^6.1",
         "twig/twig": "^2.8",
         "symfony/filesystem": "^4.2"

--- a/packages/EasyDocker/composer.json
+++ b/packages/EasyDocker/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1",
         "ext-json": "*",
-        "eoneopay/utils": "^0.2",
+        "eonx-com/utils": "^0.2",
         "symplify/package-builder": "^6.1",
         "twig/twig": "^2.8",
         "symfony/filesystem": "^4.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? | no 
| Tests pass?   | n/a
| Fixed tickets | none

This change renames the usage or eoneopay/utils to eonx-com/utils so consuming applications don't get namespace conflicts.