### PR TITLE
Add a watchlist to EntityChangeSubscriber

### DIFF
--- a/packages/EasyEntityChange/src/Doctrine/EntityChangeSubscriber.php
+++ b/packages/EasyEntityChange/src/Doctrine/EntityChangeSubscriber.php
@@ -43,14 +43,24 @@ final class EntityChangeSubscriber implements EventSubscriber
     private $updates = [];
 
     /**
+     * Stores an array of class names we're watching for updates. If null, we will watch for
+     * any changes, if an array, we will only dispatch when we see a change of the given classes.
+     *
+     * @var null|string[]
+     */
+    private $watchedClasses;
+
+    /**
      * Constructor.
      *
      * @param \EoneoPay\Externals\EventDispatcher\Interfaces\EventDispatcherInterface $dispatcher
+     * @param string[]|null $watchedClasses
      */
-    public function __construct(EventDispatcherInterface $dispatcher)
+    public function __construct(EventDispatcherInterface $dispatcher, ?array $watchedClasses = null)
     {
         $this->arr = new Arr();
         $this->dispatcher = $dispatcher;
+        $this->watchedClasses = $watchedClasses;
     }
 
     /**
@@ -222,6 +232,19 @@ final class EntityChangeSubscriber implements EventSubscriber
      */
     private function flagForDelete($entity): void
     {
+        // If the provided object isnt an object, we cant process the deletion (weird stuff going on).
+        if (\is_object($entity) === false) {
+            return;
+        }
+
+        $className = \get_class($entity);
+
+        // If we've got an array of watched classes, and we dont have a match, there is nothing
+        // to flag.
+        if (\is_array($this->watchedClasses) === true && \in_array($className, $this->watchedClasses, true) === false) {
+            return;
+        }
+
         $this->deletes[] = $entity;
     }
 
@@ -236,7 +259,15 @@ final class EntityChangeSubscriber implements EventSubscriber
      */
     private function flagForUpdate(object $entity, EntityManagerInterface $entityManager): void
     {
-        $meta = $entityManager->getClassMetadata(\get_class($entity));
+        $className = \get_class($entity);
+
+        // If we've got an array of watched classes, and we dont have a match, there is nothing
+        // to flag.
+        if (\is_array($this->watchedClasses) === true && \in_array($className, $this->watchedClasses, true) === false) {
+            return;
+        }
+
+        $meta = $entityManager->getClassMetadata($className);
         if ($meta->isIdentifierComposite) {
             // @codeCoverageIgnoreStart
             // we do not support composite identifiers for elasticsearch

--- a/packages/EasyEntityChange/tests/Doctrine/EntityChangeSubscriberTest.php
+++ b/packages/EasyEntityChange/tests/Doctrine/EntityChangeSubscriberTest.php
@@ -72,6 +72,49 @@ final class EntityChangeSubscriberTest extends AbstractTestCase
     }
 
     /**
+     * Test skipping unwatched classes.
+     *
+     * @return void
+     *
+     * @throws \EonX\EasyEntityChange\Exceptions\InvalidDispatcherException
+     */
+    public function testSkippingUnwatched(): void
+    {
+        $dispatcherStub = new EventDispatcherStub();
+        // Simulate a misconfigured dispatcher
+        $dispatcherStub->addReturn([]);
+
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $unitOfWork->expects(static::once())
+            ->method('getScheduledEntityInsertions')
+            ->willReturn([new stdClass()]);
+        $unitOfWork->expects(static::once())
+            ->method('getScheduledEntityUpdates')
+            ->willReturn([]);
+        $unitOfWork->expects(static::once())
+            ->method('getScheduledEntityDeletions')
+            ->willReturn([new stdClass()]);
+        $unitOfWork->expects(static::once())
+            ->method('getScheduledCollectionUpdates')
+            ->willReturn([]);
+        $unitOfWork->expects(static::once())
+            ->method('getScheduledCollectionDeletions')
+            ->willReturn([]);
+
+        $entityManager = $this->createMock(EntityManager::class);
+        $entityManager->expects(static::once())
+            ->method('getUnitOfWork')
+            ->willReturn($unitOfWork);
+        $eventArgs = new OnFlushEventArgs($entityManager);
+        $subscriber = new EntityChangeSubscriber($dispatcherStub, ['notStdClass']);
+        $subscriber->onFlush($eventArgs);
+
+        $subscriber->postFlush();
+
+        self::assertSame([], $dispatcherStub->getDispatched());
+    }
+
+    /**
      * Test events subscription.
      *
      * @return void


### PR DESCRIPTION
Adds a way to tell the EntityChangeSusbcriber which classes it should emit events for.

If the array is present (not null) the dispatched events will only contain details about the classes that are watched, otherwise no events will be emitted.