### PR TITLE
[EasyLogging] Check shouldReport if the exception is throwable

### DIFF
--- a/packages/EasyLogging/src/Bugsnag/BugsnagHandler.php
+++ b/packages/EasyLogging/src/Bugsnag/BugsnagHandler.php
@@ -61,7 +61,7 @@ final class BugsnagHandler extends AbstractProcessingHandler
         // Notify exception if context exception exists
         $exception = $record['context']['exception'] ?? null;
 
-        if ($exception !== null) {
+        if (($exception instanceof Throwable) === true) {
             // Do not combine if statements so we keep the notifyError feature if no exception in context
             if ($this->shouldReport($exception)) {
                 $this->client->notifyException($exception, $this->getNotifyCallback($record));

--- a/packages/EasyLogging/src/Bugsnag/BugsnagHandler.php
+++ b/packages/EasyLogging/src/Bugsnag/BugsnagHandler.php
@@ -8,6 +8,7 @@ use EonX\EasyLogging\Interfaces\ExternalLogClientInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Psr\Log\LogLevel;
+use Throwable;
 
 final class BugsnagHandler extends AbstractProcessingHandler
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | there are no tests
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Null checks dont work very well when you dont control what might be in $context['exception']. Check if it is actually throwable.