### PR TITLE
[EasyDecision] Implement optional name on expression language rule

### DIFF
--- a/packages/EasyDecision/src/Interfaces/ExpressionLanguageRuleFactoryInterface.php
+++ b/packages/EasyDecision/src/Interfaces/ExpressionLanguageRuleFactoryInterface.php
@@ -12,8 +12,9 @@ interface ExpressionLanguageRuleFactoryInterface
      *
      * @param string $expression
      * @param null|int $priority
+     * @param null|string $name
      *
      * @return \EonX\EasyDecision\Rules\ExpressionLanguageRule
      */
-    public function create(string $expression, ?int $priority = null): ExpressionLanguageRule;
+    public function create(string $expression, ?int $priority = null, ?string $name = null): ExpressionLanguageRule;
 }

--- a/packages/EasyDecision/src/Rules/ExpressionLanguageRule.php
+++ b/packages/EasyDecision/src/Rules/ExpressionLanguageRule.php
@@ -20,6 +20,11 @@ final class ExpressionLanguageRule implements RuleInterface, ContextAwareInterfa
     private $expression;
 
     /**
+     * @var null|string
+     */
+    private $name;
+
+    /**
      * @var int
      */
     private $priority;
@@ -29,11 +34,13 @@ final class ExpressionLanguageRule implements RuleInterface, ContextAwareInterfa
      *
      * @param string $expression
      * @param null|int $priority
+     * @param null|string $name
      */
-    public function __construct(string $expression, ?int $priority = null)
+    public function __construct(string $expression, ?int $priority = null, ?string $name = null)
     {
         $this->expression = $expression;
         $this->priority = $priority ?? 0;
+        $this->name = $name;
     }
 
     /**
@@ -79,6 +86,6 @@ final class ExpressionLanguageRule implements RuleInterface, ContextAwareInterfa
      */
     public function toString(): string
     {
-        return $this->expression;
+        return $this->name ?? $this->expression;
     }
 }

--- a/packages/EasyDecision/src/Rules/ExpressionLanguageRuleFactory.php
+++ b/packages/EasyDecision/src/Rules/ExpressionLanguageRuleFactory.php
@@ -12,11 +12,12 @@ final class ExpressionLanguageRuleFactory implements ExpressionLanguageRuleFacto
      *
      * @param string $expression
      * @param null|int $priority
+     * @param null|string $name
      *
      * @return \EonX\EasyDecision\Rules\ExpressionLanguageRule
      */
-    public function create(string $expression, ?int $priority = null): ExpressionLanguageRule
+    public function create(string $expression, ?int $priority = null, ?string $name = null): ExpressionLanguageRule
     {
-        return new ExpressionLanguageRule($expression, $priority);
+        return new ExpressionLanguageRule($expression, $priority, $name);
     }
 }

--- a/packages/EasyDecision/tests/AbstractTestCase.php
+++ b/packages/EasyDecision/tests/AbstractTestCase.php
@@ -62,12 +62,16 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $expression
      * @param null|int $priority
+     * @param null|string $name
      *
      * @return \EonX\EasyDecision\Interfaces\RuleInterface
      */
-    protected function createLanguageRule(string $expression, ?int $priority = null): RuleInterface
-    {
-        return $this->getLanguageRuleFactory()->create($expression, $priority);
+    protected function createLanguageRule(
+        string $expression,
+        ?int $priority = null,
+        ?string $name = null
+    ): RuleInterface {
+        return $this->getLanguageRuleFactory()->create($expression, $priority, $name);
     }
 
     /**

--- a/packages/EasyDecision/tests/Decisions/DecisionWithExpressionLanguageTest.php
+++ b/packages/EasyDecision/tests/Decisions/DecisionWithExpressionLanguageTest.php
@@ -40,7 +40,7 @@ final class DecisionWithExpressionLanguageTest extends AbstractTestCase
     public function testSameDecisionWithDifferentInputs(): void
     {
         $rules = [
-            $this->createLanguageRule('add(10)'),
+            $this->createLanguageRule('add(10)', null, 'Add Ten'),
             $this->createLanguageRule('if(name in ["Brad", "Matt"]).then(add(10))'),
             $this->createLanguageRule('if(equal(name, "Matt")).then(add(1000))'),
             $this->createLanguageRule('cap(value, 200)'),
@@ -64,7 +64,7 @@ final class DecisionWithExpressionLanguageTest extends AbstractTestCase
                 'original' => ['value' => 0, 'name' => 'Nathan', 'extra_param1' => 1],
                 'expected' => 11,
                 'outputs' => [
-                    'add(10)' => 10,
+                    'Add Ten' => 10,
                     'if(name in ["Brad", "Matt"]).then(add(10))' => 10,
                     'if(equal(name, "Matt")).then(add(1000))' => 10,
                     'cap(value, 200)' => 10,
@@ -76,7 +76,7 @@ final class DecisionWithExpressionLanguageTest extends AbstractTestCase
                 'original' => ['value' => 0, 'name' => 'Brad', 'extra_param1' => 1],
                 'expected' => 21,
                 'outputs' => [
-                    'add(10)' => 10,
+                    'Add Ten' => 10,
                     'if(name in ["Brad", "Matt"]).then(add(10))' => 20,
                     'if(equal(name, "Matt")).then(add(1000))' => 20,
                     'cap(value, 200)' => 20,
@@ -88,7 +88,7 @@ final class DecisionWithExpressionLanguageTest extends AbstractTestCase
                 'original' => ['value' => 0, 'name' => 'Matt', 'extra_param1' => 1],
                 'expected' => 201,
                 'outputs' => [
-                    'add(10)' => 10,
+                    'Add Ten' => 10,
                     'if(name in ["Brad", "Matt"]).then(add(10))' => 20,
                     'if(equal(name, "Matt")).then(add(1000))' => 1020,
                     'cap(value, 200)' => 200,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
