### PR TITLE
[EasyAsync] Persist jobLog when status is in progress

### DIFF
--- a/packages/EasyAsync/src/Bridge/WithProcessJobLogTrait.php
+++ b/packages/EasyAsync/src/Bridge/WithProcessJobLogTrait.php
@@ -100,6 +100,8 @@ trait WithProcessJobLogTrait
         try {
             $this->jobLogUpdater->inProgress($jobLog);
 
+            $this->jobLogPersister->persist($jobLog);
+
             $result = \call_user_func($func);
 
             $this->jobLogUpdater->completed($jobLog);

--- a/packages/EasyAsync/src/Implementations/Doctrine/DBAL/JobLogPersister.php
+++ b/packages/EasyAsync/src/Implementations/Doctrine/DBAL/JobLogPersister.php
@@ -140,13 +140,13 @@ final class JobLogPersister extends AbstractPersister implements JobLogPersister
      */
     private function updateJob(JobLogInterface $jobLog, JobInterface $job): JobInterface
     {
-        $job->setProcessed($job->getProcessed() + 1);
-
         switch ($jobLog->getStatus()) {
             case JobLogInterface::STATUS_FAILED:
+                $job->setProcessed($job->getProcessed() + 1);
                 $job->setFailed($job->getFailed() + 1);
                 break;
             case JobLogInterface::STATUS_COMPLETED:
+                $job->setProcessed($job->getProcessed() + 1);
                 $job->setSucceeded($job->getSucceeded() + 1);
                 break;
         }

--- a/packages/EasyAsync/tests/Implementations/Doctrine/DBAL/JobLogPersisterTest.php
+++ b/packages/EasyAsync/tests/Implementations/Doctrine/DBAL/JobLogPersisterTest.php
@@ -90,6 +90,22 @@ final class JobLogPersisterTest extends AbstractTestCase
                 'finished_at' => $now
             ]
         ];
+
+        $jobLog4 = $this->newJobLog();
+        $jobLog4->setStartedAt($now);
+        $jobLog4->setStatus(JobLogInterface::STATUS_IN_PROGRESS);
+
+        yield 'In Progress No Count Update' => [
+            [$jobLog4],
+            new Job(new Target('id', 'type'), 'test', 1),
+            [
+                'status' => JobInterface::STATUS_IN_PROGRESS,
+                'processed' => 0,
+                'failed' => 0,
+                'succeeded' => 0,
+                'started_at' => $now
+            ]
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Features and deprecations must be submitted against the master branch.
-->
