### PR TITLE
[EasyStandards] Implement sniff to avoid public properties in classes

### DIFF
--- a/packages/EasyStandard/src/Sniffs/Classes/AvoidPublicPropertiesSniff.php
+++ b/packages/EasyStandard/src/Sniffs/Classes/AvoidPublicPropertiesSniff.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+
+final class AvoidPublicPropertiesSniff extends AbstractVariableSniff
+{
+    /**
+     * @param int $stackPtr
+     */
+    protected function processMemberVar(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        try {
+            $propertyInfo = $phpcsFile->getMemberProperties($stackPtr);
+
+            if (empty($propertyInfo)) {
+                return;
+            }
+        } catch (\Throwable $exception) {
+            return;
+        }
+
+        if (($propertyInfo['scope_specified'] ?? false) === false || empty($propertyInfo['scope'])) {
+            $error = 'Visibility must be declared on property "%s"';
+            $data = [$tokens[$stackPtr]['content']] ?? [];
+
+            $phpcsFile->addError($error, $stackPtr, 'ScopeMissing', $data);
+        }
+
+        if ($propertyInfo['scope'] === 'public') {
+            $error = 'Invalid visibility "public" on property "%s"';
+            $data = [$tokens[$stackPtr]['content']] ?? [];
+
+            $phpcsFile->addError($error, $stackPtr, 'InvalidScope', $data);
+        }
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr): void
+    {
+        // No needed for sniff.
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr): void
+    {
+        // No needed for sniff.
+    }
+}

--- a/packages/EasyStandard/tests/Sniffs/Classes/AvoidPublicPropertiesSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/Classes/AvoidPublicPropertiesSniffTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Tests\Sniffs\Classes;
+
+use EonX\EasyStandard\Sniffs\Classes\AvoidPublicPropertiesSniff;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class AvoidPublicPropertiesSniffTest extends AbstractCheckerTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public function providerTestSniff(): iterable
+    {
+        yield [__DIR__ . '/../../fixtures/Sniffs/Classes/AvoidPublicPropertiesSniffTest.php.inc'];
+    }
+
+    /**
+     * @dataProvider providerTestSniff
+     */
+    public function testSniff(string $file): void
+    {
+        $this->doTestWrongFile($file);
+    }
+
+    protected function getCheckerClass(): string
+    {
+        return AvoidPublicPropertiesSniff::class;
+    }
+}

--- a/packages/EasyStandard/tests/fixtures/Sniffs/Classes/AvoidPublicPropertiesSniffTest.php.inc
+++ b/packages/EasyStandard/tests/fixtures/Sniffs/Classes/AvoidPublicPropertiesSniffTest.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+class MyClassWithPublicProperty
+{
+    public $myProperty;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

