### PR TITLE
[EasyPagination] Fix request for Laravel in console

### DIFF
--- a/packages/EasyPagination/src/Bridge/Laravel/Providers/AbstractStartSizeEasyPaginationProvider.php
+++ b/packages/EasyPagination/src/Bridge/Laravel/Providers/AbstractStartSizeEasyPaginationProvider.php
@@ -59,20 +59,25 @@ abstract class AbstractStartSizeEasyPaginationProvider extends ServiceProvider
     private function getDataClosure(): Closure
     {
         return function (): StartSizeDataInterface {
-            if ($this->app->runningInConsole() === true) {
-                /**
-                 * When running in console, a request instance is created and bound to `request` alias.
-                 * @see \Laravel\Lumen\Console\Kernel::setRequestForConsole
-                 */
-                $this->app->alias('request', Request::class);
-            }
-
             /** @var \EonX\EasyPsr7Factory\Interfaces\EasyPsr7FactoryInterface $psr7Factory */
             $psr7Factory = $this->app->get(EasyPsr7FactoryInterface::class);
 
             return $this->app->get(StartSizeDataResolverInterface::class)->resolve(
-                $psr7Factory->createRequest($this->app->get(Request::class))
+                $psr7Factory->createRequest($this->getRequest())
             );
         };
+    }
+
+    private function getRequest(): Request
+    {
+        if ($this->app->runningInConsole() === true) {
+            /**
+             * When running in console, a request instance is created and bound to `request` alias.
+             * @see \Laravel\Lumen\Console\Kernel::setRequestForConsole
+             */
+            return $this->app->get('request');
+        }
+
+        return $this->app->get(Request::class);
     }
 }

--- a/packages/EasyPagination/src/Bridge/Laravel/Providers/AbstractStartSizeEasyPaginationProvider.php
+++ b/packages/EasyPagination/src/Bridge/Laravel/Providers/AbstractStartSizeEasyPaginationProvider.php
@@ -59,6 +59,14 @@ abstract class AbstractStartSizeEasyPaginationProvider extends ServiceProvider
     private function getDataClosure(): Closure
     {
         return function (): StartSizeDataInterface {
+            if ($this->app->runningInConsole() === true) {
+                /**
+                 * When running in console, a request instance is created and bound to `request` alias.
+                 * @see \Laravel\Lumen\Console\Kernel::setRequestForConsole
+                 */
+                $this->app->alias('request', Request::class);
+            }
+
             /** @var \EonX\EasyPsr7Factory\Interfaces\EasyPsr7FactoryInterface $psr7Factory */
             $psr7Factory = $this->app->get(EasyPsr7FactoryInterface::class);
 

--- a/packages/EasyPagination/tests/AbstractTestCase.php
+++ b/packages/EasyPagination/tests/AbstractTestCase.php
@@ -98,14 +98,21 @@ abstract class AbstractTestCase extends TestCase
 
     private function createApplication(?bool $pretendInConsole = null): Application
     {
-        if ($pretendInConsole === null | $pretendInConsole === false) {
-            new Application(__DIR__);
-        }
+        return new class(__DIR__, $pretendInConsole) extends Application {
+            /**
+             * @var null|bool
+             */
+            private $runningInConsole;
 
-        return new class(__DIR__) extends Application {
+            public function __construct(?string $basePath = null, ?bool $runningInConsole = null)
+            {
+                parent::__construct($basePath);
+                $this->runningInConsole = $runningInConsole;
+            }
+
             public function runningInConsole()
             {
-                return true;
+                return $this->runningInConsole ?? false;
             }
         };
     }

--- a/packages/EasyPagination/tests/AbstractTestCase.php
+++ b/packages/EasyPagination/tests/AbstractTestCase.php
@@ -54,13 +54,13 @@ abstract class AbstractTestCase extends TestCase
         return (new EasyPsr7Factory())->createRequest(new Request($query ?? [], [], [], [], [], $server));
     }
 
-    protected function getApplication(): Application
+    protected function getApplication(?bool $pretendInConsole = null): Application
     {
         if ($this->app !== null) {
             return $this->app;
         }
 
-        $app = $this->app = new Application(__DIR__);
+        $app = $this->app = $this->createApplication($pretendInConsole);
         $app->register(EasyPsr7FactoryServiceProvider::class);
 
         return $app;
@@ -94,5 +94,19 @@ abstract class AbstractTestCase extends TestCase
         \Mockery::close();
 
         parent::tearDown();
+    }
+
+    private function createApplication(?bool $pretendInConsole = null): Application
+    {
+        if ($pretendInConsole === null | $pretendInConsole === false) {
+            new Application(__DIR__);
+        }
+
+        return new class(__DIR__) extends Application {
+            public function runningInConsole()
+            {
+                return true;
+            }
+        };
     }
 }

--- a/packages/EasyPagination/tests/Bridge/Laravel/ServiceProvidersTest.php
+++ b/packages/EasyPagination/tests/Bridge/Laravel/ServiceProvidersTest.php
@@ -26,9 +26,19 @@ final class ServiceProvidersTest extends AbstractTestCase
 
     public function testRegister(): void
     {
+        $this->registerProviders();
+    }
+
+    public function testRegisterInConsoleApplication(): void
+    {
+        $this->registerProviders(true);
+    }
+
+    private function registerProviders(?bool $pretendInConsole = null): void
+    {
         foreach (static::$providers as $providerClass => $resolverClass) {
             /** @var \Illuminate\Contracts\Foundation\Application $app */
-            $app = $this->getApplication();
+            $app = $this->getApplication($pretendInConsole);
 
             $server = ['HTTP_HOST' => 'eonx.com'];
             $app->instance(Request::class, new Request($query ?? [], [], [], [], [], $server));

--- a/packages/EasyPagination/tests/Bridge/Laravel/ServiceProvidersTest.php
+++ b/packages/EasyPagination/tests/Bridge/Laravel/ServiceProvidersTest.php
@@ -41,7 +41,11 @@ final class ServiceProvidersTest extends AbstractTestCase
             $app = $this->getApplication($pretendInConsole);
 
             $server = ['HTTP_HOST' => 'eonx.com'];
-            $app->instance(Request::class, new Request($query ?? [], [], [], [], [], $server));
+
+            $app->instance(
+                $pretendInConsole === true ? 'request' : Request::class,
+                new Request($query ?? [], [], [], [], [], $server)
+            );
 
             /** @var \Illuminate\Support\ServiceProvider $provider */
             $provider = new $providerClass($app);


### PR DESCRIPTION
 Can't use alias since it resulted to recursive circular call for `app->getAlias(...)` for `request` and `Illuminate\Http\Request` during tests.
 Instead, update the retrieval of request from the application using `request` for console and `Illuminate\Http\Request` if not console.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
