### PR TITLE
[EasySecurity/EasyCore] Fixed Registration for argument $targets for PermissionExpressionFunctionProvider and registered ProcessWithLockMiddleware to container 

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/Resources/config/services.yaml
+++ b/packages/EasyCore/src/Bridge/Symfony/Resources/config/services.yaml
@@ -6,3 +6,6 @@ services:
 
     EonX\EasyCore\Lock\LockServiceInterface:
         class: EonX\EasyCore\Lock\LockService
+
+    EonX\EasyCore\Bridge\Symfony\Messenger\ProcessWithLockMiddleware:
+        class: EonX\EasyCore\Bridge\Symfony\Messenger\ProcessWithLockMiddleware

--- a/packages/EasyCore/src/Bridge/Symfony/Resources/config/services.yaml
+++ b/packages/EasyCore/src/Bridge/Symfony/Resources/config/services.yaml
@@ -7,5 +7,4 @@ services:
     EonX\EasyCore\Lock\LockServiceInterface:
         class: EonX\EasyCore\Lock\LockService
 
-    EonX\EasyCore\Bridge\Symfony\Messenger\ProcessWithLockMiddleware:
-        class: EonX\EasyCore\Bridge\Symfony\Messenger\ProcessWithLockMiddleware
+    EonX\EasyCore\Bridge\Symfony\Messenger\ProcessWithLockMiddleware: null

--- a/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterPermissionExpressionFunctionPass.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterPermissionExpressionFunctionPass.php
@@ -23,6 +23,7 @@ final class RegisterPermissionExpressionFunctionPass implements CompilerPassInte
 
         $providerClass = PermissionExpressionFunctionProvider::class;
         $providerDef = new Definition($providerClass);
+        $providerDef->setArgument('$target', $locations);
 
         $container->setDefinition($providerClass, $providerDef);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A

- [EasySecurity] Fixed RegisterPermissionExpressionFunctionPass to set targets for PermissionExpressionFunctionProvider.
- [EasyCore] Updated services.yaml to register ProcessWithLockMiddleware. 
