### PR TITLE
[EasyCore] Added listener for worker restart on EM close

### DIFF
--- a/packages/EasyCore/src/Bridge/Laravel/Listeners/DoctrineRestartQueueOnEmCloseListener.php
+++ b/packages/EasyCore/src/Bridge/Laravel/Listeners/DoctrineRestartQueueOnEmCloseListener.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyCore\Bridge\Laravel\Listeners;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Support\InteractsWithTime;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+final class DoctrineRestartQueueOnEmCloseListener
+{
+    use InteractsWithTime;
+
+    /**
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    private $cache;
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * DoctrineRestartQueueOnEmCloseListener constructor.
+     *
+     * @param \Doctrine\ORM\EntityManagerInterface $entityManager
+     * @param \Illuminate\Contracts\Cache\Repository $cache
+     * @param \Psr\Log\LoggerInterface|null $logger
+     */
+    public function __construct(EntityManagerInterface $entityManager, Cache $cache, ?LoggerInterface $logger = null)
+    {
+        $this->entityManager = $entityManager;
+        $this->cache = $cache;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Handles JobExceptionOccurred event.
+     *
+     * @param \Illuminate\Queue\Events\JobExceptionOccurred $event
+     */
+    public function handle(JobExceptionOccurred $event): void
+    {
+        if ($this->entityManager->isOpen() === false) {
+            $this->cache->forever('illuminate:queue:restart', $this->currentTime());
+
+            $this->logger->info('Restarting queue because em is closed.', [
+                'connection' => $event->connectionName,
+                'job_id' => $event->job->getJobId(),
+                'job_name' => $event->job->getName(),
+            ]);
+        }
+    }
+}

--- a/packages/EasyCore/src/Bridge/Laravel/Providers/EasyCoreServiceProvider.php
+++ b/packages/EasyCore/src/Bridge/Laravel/Providers/EasyCoreServiceProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace EonX\EasyCore\Bridge\Laravel\Providers;
 
 use EonX\EasyCore\Bridge\Laravel\Listeners\DoctrineClearEmBeforeJobListener;
+use EonX\EasyCore\Bridge\Laravel\Listeners\DoctrineRestartQueueOnEmCloseListener;
 use EonX\EasyCore\Bridge\Laravel\Listeners\QueueWorkerStoppingListener;
+use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\ServiceProvider;
@@ -20,6 +22,7 @@ final class EasyCoreServiceProvider extends ServiceProvider
 
         $this->clearDoctrineEmBeforeJob();
         $this->logQueueWorkerStopping();
+        $this->restartQueue();
     }
 
     public function register(): void
@@ -43,5 +46,19 @@ final class EasyCoreServiceProvider extends ServiceProvider
         }
 
         $this->app->get('events')->listen(WorkerStopping::class, QueueWorkerStoppingListener::class);
+    }
+
+    /**
+     * Restarts Queue.
+     *
+     * @return void
+     */
+    private function restartQueue(): void
+    {
+        if ((bool)\config('easy-core.restart_queue_on_doctrine_em_close', true) === false) {
+            return;
+        }
+
+        $this->app->get('events')->listen(JobExceptionOccurred::class, DoctrineRestartQueueOnEmCloseListener::class);
     }
 }

--- a/packages/EasyCore/src/Bridge/Laravel/Providers/EasyCoreServiceProvider.php
+++ b/packages/EasyCore/src/Bridge/Laravel/Providers/EasyCoreServiceProvider.php
@@ -22,7 +22,7 @@ final class EasyCoreServiceProvider extends ServiceProvider
 
         $this->clearDoctrineEmBeforeJob();
         $this->logQueueWorkerStopping();
-        $this->restartQueue();
+        $this->restartQueueOnEmClose();
     }
 
     public function register(): void
@@ -48,12 +48,7 @@ final class EasyCoreServiceProvider extends ServiceProvider
         $this->app->get('events')->listen(WorkerStopping::class, QueueWorkerStoppingListener::class);
     }
 
-    /**
-     * Restarts Queue.
-     *
-     * @return void
-     */
-    private function restartQueue(): void
+    private function restartQueueOnEmClose(): void
     {
         if ((bool)\config('easy-core.restart_queue_on_doctrine_em_close', true) === false) {
             return;

--- a/packages/EasyCore/src/Bridge/Laravel/config/easy-core.php
+++ b/packages/EasyCore/src/Bridge/Laravel/config/easy-core.php
@@ -12,4 +12,9 @@ return [
      * Add a listener to log when a queue worker stops.
      */
     'log_queue_worker_stop' => \env('EASY_CORE_LOG_QUEUE_WORKER_STOP', true),
+
+    /**
+     * Add a listener to restart queue worker if doctrine entity manager is closed.
+     */
+    'restart_queue_on_doctrine_em_close' => \env('EASY_CORE_RESTART_QUEUE_ON_DOCTRINE_EM_CLOSE', true),
 ];

--- a/packages/EasyCore/tests/Bridge/Laravel/Listeners/DoctrineRestartQueueOnEmCloseListenerTest.php
+++ b/packages/EasyCore/tests/Bridge/Laravel/Listeners/DoctrineRestartQueueOnEmCloseListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyCore\Tests\Bridge\Laravel\Listeners;
+
+use Carbon\Carbon;
+use Doctrine\ORM\EntityManagerInterface;
+use EonX\EasyCore\Bridge\Laravel\Listeners\DoctrineRestartQueueOnEmCloseListener;
+use EonX\EasyCore\Tests\AbstractTestCase;
+use Exception;
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \EonX\EasyCore\Bridge\Laravel\Listeners\DoctrineRestartQueueOnEmCloseListener
+ *
+ * @internal
+ */
+final class DoctrineRestartQueueOnEmCloseListenerTest extends AbstractTestCase
+{
+    /**
+     * Test `handle` succeeds.
+     *
+     * @return void
+     */
+    public function testHandleSucceeds(): void
+    {
+        $jobProphecy = $this->prophesize(Job::class);
+        $jobProphecy->getJobId()->willReturn('job_id');
+        $jobProphecy->getName()->willReturn('job_name');
+        /** @var \Illuminate\Contracts\Queue\Job $job */
+        $job = $jobProphecy->reveal();
+        $event = new JobExceptionOccurred('connectionName', $job, new Exception('some-message'));
+        $emProphecy = $this->prophesize(EntityManagerInterface::class);
+        $emProphecy->isOpen()->willReturn(false);
+        /** @var \Doctrine\ORM\EntityManagerInterface $entityManager */
+        $entityManager = $emProphecy->reveal();
+        Carbon::setTestNow(Carbon::create(2020, 5, 3));
+        $cacheProphecy = $this->prophesize(Repository::class);
+        $cacheProphecy->forever('illuminate:queue:restart', Carbon::now()->getTimestamp())->willReturn(true);
+        /** @var \Illuminate\Cache\Repository $cache */
+        $cache = $cacheProphecy->reveal();
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $logData = [
+            'connection' => $event->connectionName,
+            'job_id' => 'job_id',
+            'job_name' => 'job_name',
+        ];
+        $logMessage = 'Restarting queue because em is closed.';
+        $loggerProphecy->info($logMessage, $logData);
+        /** @var \Psr\Log\LoggerInterface $logger */
+        $logger = $loggerProphecy->reveal();
+        $listener = new DoctrineRestartQueueOnEmCloseListener($entityManager, $cache, $logger);
+
+        $listener->handle($event);
+
+        $emProphecy->isOpen()->shouldHaveBeenCalledOnce();
+        $cacheProphecy->forever('illuminate:queue:restart', Carbon::now()->getTimestamp())->shouldHaveBeenCalledOnce();
+        $loggerProphecy->info($logMessage, $logData)->shouldHaveBeenCalledOnce();
+    }
+}

--- a/packages/EasyCore/tests/Bridge/Laravel/Listeners/DoctrineRestartQueueOnEmCloseListenerTest.php
+++ b/packages/EasyCore/tests/Bridge/Laravel/Listeners/DoctrineRestartQueueOnEmCloseListenerTest.php
@@ -64,11 +64,11 @@ final class DoctrineRestartQueueOnEmCloseListenerTest extends AbstractTestCase
     }
 
     /**
-     * Test `handle` with opened EntityManager succeeds.
+     * Test `handle` with open EntityManager succeeds.
      *
      * @return void
      */
-    public function testHandleWithOpenedEmSucceeds(): void
+    public function testHandleWithOpenEmSucceeds(): void
     {
         /** @var \Illuminate\Contracts\Queue\Job $job */
         $job = $this->prophesize(Job::class)->reveal();
@@ -87,7 +87,6 @@ final class DoctrineRestartQueueOnEmCloseListenerTest extends AbstractTestCase
         $listener->handle(new JobExceptionOccurred('connectionName', $job, new Exception('some-message')));
 
         $emProphecy->isOpen()->shouldHaveBeenCalledOnce();
-
         $cacheProphecy->forever(Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
         /** @var mixed[] $infoData */
         $infoData = Argument::any();


### PR DESCRIPTION
- added listener for worker restarting

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #PTS-962
