### PR TITLE
[EasyAsync] Add throwable message to debug info when joblog fails

### DIFF
--- a/packages/EasyAsync/src/Interfaces/JobLogInterface.php
+++ b/packages/EasyAsync/src/Interfaces/JobLogInterface.php
@@ -6,16 +6,33 @@ namespace EonX\EasyAsync\Interfaces;
 
 interface JobLogInterface extends EasyAsyncDataInterface
 {
+    /**
+     * @var string
+     */
+    public const MSG_FAILED_BECAUSE_EXCEPTION = 'easy_async.failed.because_exception';
+
+    /**
+     * @var string[]
+     */
     public const STATUSES = [
         self::STATUS_COMPLETED,
         self::STATUS_FAILED,
         self::STATUS_IN_PROGRESS,
     ];
 
+    /**
+     * @var string
+     */
     public const STATUS_COMPLETED = 'completed';
 
+    /**
+     * @var string
+     */
     public const STATUS_FAILED = 'failed';
 
+    /**
+     * @var string
+     */
     public const STATUS_IN_PROGRESS = 'in_progress';
 
     /**

--- a/packages/EasyAsync/src/Updaters/JobLogUpdater.php
+++ b/packages/EasyAsync/src/Updaters/JobLogUpdater.php
@@ -28,9 +28,11 @@ final class JobLogUpdater implements JobLogUpdaterInterface
 
     public function failed(JobLogInterface $jobLog, \Throwable $throwable): void
     {
+        $jobLog->setFailureReason(JobLogInterface::MSG_FAILED_BECAUSE_EXCEPTION);
         $jobLog->setStatus(JobLogInterface::STATUS_FAILED);
         $jobLog->setFinishedAt($this->datetime->now());
         $jobLog->addDebugInfo('exception', [
+            'message' => $throwable->getMessage(),
             'class' => \get_class($throwable),
             'code' => $throwable->getCode(),
             'file' => $throwable->getFile(),

--- a/packages/EasyAsync/tests/Updaters/JobLogUpdaterTest.php
+++ b/packages/EasyAsync/tests/Updaters/JobLogUpdaterTest.php
@@ -28,10 +28,11 @@ final class JobLogUpdaterTest extends AbstractTestCase
     {
         $jobLog = $this->getJobLog();
         $updater = $this->getJobLogUpdater();
-        $throwable = new \Exception();
+        $throwable = new \Exception('test_message');
 
         $debugInfo = [
             'exception' => [
+                'message' => 'test_message',
                 'class' => \get_class($throwable),
                 'code' => $throwable->getCode(),
                 'file' => $throwable->getFile(),
@@ -42,6 +43,7 @@ final class JobLogUpdaterTest extends AbstractTestCase
 
         $updater->failed($jobLog, $throwable);
 
+        self::assertEquals(JobLogInterface::MSG_FAILED_BECAUSE_EXCEPTION, $jobLog->getFailureReason());
         self::assertEquals(JobLogInterface::STATUS_FAILED, $jobLog->getStatus());
         self::assertInstanceOf(\DateTime::class, $jobLog->getFinishedAt());
         self::assertEquals($debugInfo, $jobLog->getDebugInfo());


### PR DESCRIPTION
…mplement generic failure reason

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
