### PR TITLE
[EasyCore] Require elasticsearch package for easy-search

### DIFF
--- a/packages/EasyCore/composer.json
+++ b/packages/EasyCore/composer.json
@@ -4,7 +4,8 @@
     "type": "symfony-bundle",
     "license": "MIT",
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "elasticsearch/elasticsearch": "^7.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

- Require elasticsearch package in easy-core search to fix error in SearchService
