### PR TITLE
[EasyCore] Add JsonbType and Contains function support for PostgreSQL

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,7 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace PHPSTORM_META;
-
-// $container->get(Type::class) → instance of "Type"
-override(\Psr\Container\ContainerInterface::get(0), type(0));

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPSTORM_META;
+
+// $container->get(Type::class) → instance of "Type"
+override(\Psr\Container\ContainerInterface::get(0), type(0));

--- a/packages/EasyCore/src/Doctrine/DBAL/Types/DateTimeMicrosecondsType.php
+++ b/packages/EasyCore/src/Doctrine/DBAL/Types/DateTimeMicrosecondsType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EonX\EasyCore\Doctrine\Type;
+namespace EonX\EasyCore\Doctrine\DBAL\Types;
 
 use DateTime;
 use DateTimeInterface;
@@ -16,12 +16,7 @@ final class DateTimeMicrosecondsType extends DateTimeType
     /**
      * @var string
      */
-    public const TYPE_NAME = 'datetime';
-
-    /**
-     * @var string
-     */
-    public const FORMAT_PHP_DATETIME = 'Y-m-d H:i:s.u';
+    public const FORMAT_DB_DATETIME = 'DATETIME(6)';
 
     /**
      * @var string
@@ -36,7 +31,12 @@ final class DateTimeMicrosecondsType extends DateTimeType
     /**
      * @var string
      */
-    public const FORMAT_DB_DATETIME = 'DATETIME(6)';
+    public const FORMAT_PHP_DATETIME = 'Y-m-d H:i:s.u';
+
+    /**
+     * @var string
+     */
+    public const TYPE_NAME = 'datetime';
 
     /**
      * @param mixed $value

--- a/packages/EasyCore/src/Doctrine/DBAL/Types/JsonbType.php
+++ b/packages/EasyCore/src/Doctrine/DBAL/Types/JsonbType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyCore\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
+
+final class JsonbType extends JsonType
+{
+    /**
+     * @var string
+     */
+    public const TYPE_NAME = 'jsonb';
+
+    public function getName(): string
+    {
+        return static::TYPE_NAME;
+    }
+
+    /**
+     * @param mixed[] $fieldDeclaration
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getDoctrineTypeMapping(static::TYPE_NAME);
+    }
+}

--- a/packages/EasyCore/src/Doctrine/ORM/Query/AST/Functions/Contains.php
+++ b/packages/EasyCore/src/Doctrine/ORM/Query/AST/Functions/Contains.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyCore\Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+final class Contains extends FunctionNode
+{
+    /**
+     * @var \Doctrine\ORM\Query\AST\InputParameter
+     */
+    private $inputParameter;
+
+    /**
+     * @var \Doctrine\ORM\Query\AST\Node
+     */
+    private $node;
+
+    /**
+     * @throws \Doctrine\ORM\Query\AST\ASTException
+     */
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        return \sprintf(
+            '(%s @> %s)',
+            $this->node->dispatch($sqlWalker),
+            $sqlWalker->walkInputParameter($this->inputParameter)
+        );
+    }
+
+    /**
+     * @throws \Doctrine\ORM\Query\QueryException
+     */
+    public function parse(Parser $parser): void
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->node = $parser->StringPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->inputParameter = $parser->InputParameter();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}

--- a/packages/EasyCore/tests/Doctrine/DBAL/Types/JsonbTypeTest.php
+++ b/packages/EasyCore/tests/Doctrine/DBAL/Types/JsonbTypeTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyCore\Tests\Doctrine\DBAL\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use EonX\EasyCore\Doctrine\DBAL\Types\JsonbType;
+use EonX\EasyCore\Tests\AbstractTestCase;
+
+/**
+ * @covers \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType
+ */
+final class JsonbTypeTest extends AbstractTestCase
+{
+    /**
+     * @return mixed[]
+     *
+     * @see testConvertToDatabaseValueSucceeds
+     * @see testConvertToPhpValueSucceeds
+     */
+    public function provideConvertToDatabaseValues(): array
+    {
+        return [
+            'null phpValue' => [
+                'phpValue' => null,
+                'postgresValue' => null,
+            ],
+            'empty phpValue' => [
+                'phpValue' => [],
+                'postgresValue' => '[]',
+            ],
+            'integer phpValue' => [
+                'phpValue' => 13,
+                'postgresValue' => '13',
+            ],
+            'float phpValue' => [
+                'phpValue' => 13.93,
+                'postgresValue' => '13.93',
+            ],
+            'string phpValue' => [
+                'phpValue' => 'a string value',
+                'postgresValue' => '"a string value"',
+            ],
+            'array og integers phpValue' => [
+                'phpValue' => [681, 1185, 1878, 1989],
+                'postgresValue' => '[681,1185,1878,1989]',
+            ],
+            'multidimensional array phpValue' => [
+                'phpValue' => [
+                    'key1' => 'value1',
+                    'key2' => false,
+                    'key3' => '15',
+                    'key4' => 15,
+                    'key5' => [112, 242, 309, 310],
+                ],
+                'postgresValue' => '{"key1":"value1","key2":false,"key3":"15","key4":15,"key5":[112,242,309,310]}',
+            ],
+        ];
+    }
+
+    /**
+     * @param array|float|int|string|null $phpValue
+     *
+     * @throws \Doctrine\DBAL\Types\ConversionException
+     * @throws \Doctrine\DBAL\DBALException
+     *
+     * @dataProvider provideConvertToDatabaseValues
+     */
+    public function testConvertToDatabaseValueSucceeds($phpValue, ?string $postgresValue): void
+    {
+        /** @var \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType $type */
+        $type = Type::getType(JsonbType::TYPE_NAME);
+        /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+        $platform = $this->mock(AbstractPlatform::class);
+
+        $result = $type->convertToDatabaseValue($phpValue, $platform);
+
+        self::assertSame($postgresValue, $result);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Types\ConversionException
+     */
+    public function testConvertToDatabaseValueThrowsConversionException(): void
+    {
+        /** @var \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType $type */
+        $type = Type::getType(JsonbType::TYPE_NAME);
+        /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+        $platform = $this->mock(AbstractPlatform::class);
+        $value = \urldecode('some bad utf string %C4');
+        $this->expectException(ConversionException::class);
+        $this->expectExceptionMessage("Could not convert PHP type 'string' to 'json', as an " .
+            "'Malformed UTF-8 characters, possibly incorrectly encoded' error was triggered by the serialization"
+        );
+
+        $type->convertToDatabaseValue($value, $platform);
+    }
+
+    /**
+     * @param array|float|int|string|null $phpValue
+     *
+     * @throws \Doctrine\DBAL\Types\ConversionException
+     * @throws \Doctrine\DBAL\DBALException
+     *
+     * @dataProvider provideConvertToDatabaseValues
+     */
+    public function testConvertToPhpValueSucceeds($phpValue, ?string $postgresValue): void
+    {
+        /** @var \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType $type */
+        $type = Type::getType(JsonbType::TYPE_NAME);
+        /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+        $platform = $this->mock(AbstractPlatform::class);
+
+        $result = $type->convertToPHPValue($postgresValue, $platform);
+
+        self::assertSame($phpValue, $result);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Types\ConversionException
+     */
+    public function testConvertToPhpValueThrowsConversionException(): void
+    {
+        /** @var \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType $type */
+        $type = Type::getType(JsonbType::TYPE_NAME);
+        /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+        $platform = $this->mock(AbstractPlatform::class);
+        $value = 'ineligible-value';
+        $this->expectException(ConversionException::class);
+        $this->expectExceptionMessage('Could not convert database value "ineligible-value" ' .
+            'to Doctrine Type jsonb');
+
+        $type->convertToPHPValue($value, $platform);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function testGetNameSucceeds(): void
+    {
+        /** @var \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType $type */
+        $type = Type::getType(JsonbType::TYPE_NAME);
+        $name = $type->getName();
+
+        self::assertSame(JsonbType::TYPE_NAME, $name);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function testGetSQLDeclaration(): void
+    {
+        /** @var \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType $type */
+        $type = Type::getType(JsonbType::TYPE_NAME);
+        $platform = $this->prophesize(AbstractPlatform::class);
+
+        $platform->getDoctrineTypeMapping($type::TYPE_NAME)
+            ->shouldBeCalled()
+            ->withArguments([$type::TYPE_NAME])
+            ->willReturn($type::TYPE_NAME);
+
+        self::assertSame(
+            $type::TYPE_NAME,
+            $type->getSQLDeclaration([], $platform->reveal())
+        );
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (Type::hasType(JsonbType::TYPE_NAME) === false) {
+            Type::addType(JsonbType::TYPE_NAME, JsonbType::class);
+        }
+    }
+}

--- a/packages/EasyCore/tests/Doctrine/DBAL/Types/JsonbTypeTest.php
+++ b/packages/EasyCore/tests/Doctrine/DBAL/Types/JsonbTypeTest.php
@@ -152,6 +152,7 @@ final class JsonbTypeTest extends AbstractTestCase
         $value = 'ineligible-value';
         $this->expectException(ConversionException::class);
         $this->expectExceptionMessage('Could not convert database value "ineligible-value" to Doctrine Type jsonb');
+        
         $type->convertToPHPValue($value, $platform);
     }
 
@@ -162,6 +163,7 @@ final class JsonbTypeTest extends AbstractTestCase
     {
         /** @var \EonX\EasyCore\Doctrine\DBAL\Types\JsonbType $type */
         $type = Type::getType(JsonbType::TYPE_NAME);
+
         $name = $type->getName();
 
         self::assertSame(JsonbType::TYPE_NAME, $name);

--- a/packages/EasyCore/tests/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
+++ b/packages/EasyCore/tests/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
@@ -56,7 +56,7 @@ final class ContainsTest extends AbstractTestCase
 
         $result = $contains->getSql($sqlWalker);
 
-        self::assertSame("(${parameter} @> ${parameterValue})", $result);
+        self::assertSame(\sprintf('(%s @> %s)', $parameter, $parameterValue), $result);
     }
 
     /**

--- a/packages/EasyCore/tests/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
+++ b/packages/EasyCore/tests/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
@@ -28,7 +28,8 @@ final class ContainsTest extends AbstractTestCase
         $contains = new Contains($parameter);
         $inputParameter = new InputParameter($parameterValue);
         /** @var \Doctrine\ORM\Query\SqlWalker $sqlWalker */
-        $sqlWalker = $this->mock(SqlWalker::class,
+        $sqlWalker = $this->mock(
+            SqlWalker::class,
             static function (MockInterface $mock) use ($contains, $parameter, $inputParameter, $parameterValue): void {
                 $mock
                     ->shouldReceive('walkFunction')
@@ -41,7 +42,8 @@ final class ContainsTest extends AbstractTestCase
                     ->once()
                     ->with($inputParameter)
                     ->andReturn($parameterValue);
-            });
+            }
+        );
         $this->mock(Node::class, static function (MockInterface $mock) use ($sqlWalker, $parameter): void {
             $mock
                 ->shouldReceive('dispatch')
@@ -54,7 +56,7 @@ final class ContainsTest extends AbstractTestCase
 
         $result = $contains->getSql($sqlWalker);
 
-        self::assertSame("($parameter @> $parameterValue)", $result);
+        self::assertSame("(${parameter} @> ${parameterValue})", $result);
     }
 
     /**
@@ -71,10 +73,11 @@ final class ContainsTest extends AbstractTestCase
         $this->expectNotToPerformAssertions();
     }
 
-    private function mockParser($contains, $inputParameter): Parser
+    private function mockParser(Contains $contains, InputParameter $inputParameter): Parser
     {
         /** @var \Doctrine\ORM\Query\Parser $parser */
-        $parser = $this->mock(Parser::class,
+        $parser = $this->mock(
+            Parser::class,
             static function (MockInterface $mock) use ($contains, $inputParameter): void {
                 $mock
                     ->shouldReceive('match')
@@ -107,7 +110,8 @@ final class ContainsTest extends AbstractTestCase
                     ->shouldReceive('match')
                     ->once()
                     ->with(Lexer::T_CLOSE_PARENTHESIS);
-            });
+            }
+        );
 
         return $parser;
     }

--- a/packages/EasyCore/tests/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
+++ b/packages/EasyCore/tests/Doctrine/ORM/Query/AST/Functions/ContainsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyCore\Tests\Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\AST\InputParameter;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use EonX\EasyCore\Doctrine\ORM\Query\AST\Functions\Contains;
+use EonX\EasyCore\Tests\AbstractTestCase;
+use Mockery\MockInterface;
+
+/**
+ * @covers \EonX\EasyCore\Doctrine\ORM\Query\AST\Functions\Contains
+ */
+final class ContainsTest extends AbstractTestCase
+{
+    /**
+     * @throws \Doctrine\ORM\Query\QueryException
+     */
+    public function testGetSqlSucceeds(): void
+    {
+        $parameter = 'test';
+        $parameterValue = 'test-value';
+        $contains = new Contains($parameter);
+        $inputParameter = new InputParameter($parameterValue);
+        /** @var \Doctrine\ORM\Query\SqlWalker $sqlWalker */
+        $sqlWalker = $this->mock(SqlWalker::class,
+            static function (MockInterface $mock) use ($contains, $parameter, $inputParameter, $parameterValue): void {
+                $mock
+                    ->shouldReceive('walkFunction')
+                    ->once()
+                    ->with($contains)
+                    ->andReturn($parameter);
+
+                $mock
+                    ->shouldReceive('walkInputParameter')
+                    ->once()
+                    ->with($inputParameter)
+                    ->andReturn($parameterValue);
+            });
+        $this->mock(Node::class, static function (MockInterface $mock) use ($sqlWalker, $parameter): void {
+            $mock
+                ->shouldReceive('dispatch')
+                ->once()
+                ->with($sqlWalker)
+                ->andReturn($parameter);
+        });
+        $parser = $this->mockParser($contains, $inputParameter);
+        $contains->parse($parser);
+
+        $result = $contains->getSql($sqlWalker);
+
+        self::assertSame("($parameter @> $parameterValue)", $result);
+    }
+
+    /**
+     * @throws \Doctrine\ORM\Query\QueryException
+     */
+    public function testParseSucceeds(): void
+    {
+        $contains = new Contains('test');
+        $inputParameter = new InputParameter('test');
+        $parser = $this->mockParser($contains, $inputParameter);
+
+        $contains->parse($parser);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    private function mockParser($contains, $inputParameter): Parser
+    {
+        /** @var \Doctrine\ORM\Query\Parser $parser */
+        $parser = $this->mock(Parser::class,
+            static function (MockInterface $mock) use ($contains, $inputParameter): void {
+                $mock
+                    ->shouldReceive('match')
+                    ->once()
+                    ->with(Lexer::T_IDENTIFIER);
+
+                $mock
+                    ->shouldReceive('match')
+                    ->once()
+                    ->with(Lexer::T_OPEN_PARENTHESIS);
+
+                $mock
+                    ->shouldReceive('StringPrimary')
+                    ->once()
+                    ->withNoArgs()
+                    ->andReturn($contains);
+
+                $mock
+                    ->shouldReceive('match')
+                    ->once()
+                    ->with(Lexer::T_COMMA);
+
+                $mock
+                    ->shouldReceive('InputParameter')
+                    ->once()
+                    ->withNoArgs()
+                    ->andReturn($inputParameter);
+
+                $mock
+                    ->shouldReceive('match')
+                    ->once()
+                    ->with(Lexer::T_CLOSE_PARENTHESIS);
+            });
+
+        return $parser;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | ...   <!-- #-prefixed issue number(s), if any -->

- Add Jsonb type for Doctrine DBAL and CONTAINS function for ORM.

BC related to changed namespace for DBAL Types.