### PR TITLE
[EasyStandard] Improve ArrangeActAssertSniff to ignore empty lines inside closures

### DIFF
--- a/packages/EasyStandard/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
+++ b/packages/EasyStandard/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
@@ -56,16 +56,25 @@ final class ArrangeActAssertSniff implements Sniff
         $currentTokenPosition = $openTokenPosition;
         $previousLine = $tokens[$openTokenPosition]['line'];
         $emptyLines = 0;
+        $insideClosure = false;
 
         while ($currentTokenPosition < $closeTokenPosition) {
             // Find next token skipping whitespaces
             $nextTokenPosition = TokenHelper::findNextExcluding($phpcsFile, [T_WHITESPACE], $currentTokenPosition + 1);
+            if ($tokens[$currentTokenPosition]['type'] === 'T_CLOSURE') {
+                $insideClosure = true;
+            }
+
             $currentLine = $tokens[$nextTokenPosition]['line'];
-            if ($currentLine - $previousLine > 1) {
+            if ($currentLine - $previousLine > 1 && $insideClosure === false) {
                 $emptyLines++;
             }
+
             $previousLine = $currentLine;
             $currentTokenPosition = $nextTokenPosition;
+            if ($tokens[$currentTokenPosition]['type'] === 'T_CLOSE_CURLY_BRACKET') {
+                $insideClosure = false;
+            }
         }
 
         if (\in_array($emptyLines, self::ALLOWED_SPACES_COUNT, true) === false) {

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/ArrangeActAssertSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/ArrangeActAssertSniffTest.php
@@ -61,6 +61,15 @@ final class ArrangeActAssertSniffTest extends AbstractCheckerTestCase
     }
 
     /**
+     * Tests method with empty lines in Closure succeeds.
+     */
+    public function testMethodWithEmptyLinesInClosureSucceeds(): void
+    {
+        $fileInfo = new SmartFileInfo(__DIR__ . '/Fixture/Correct/EmptyLinesInClosure.php.inc');
+        $this->doTestCorrectFileInfo($fileInfo);
+    }
+
+    /**
      * Tests method with inner curly brackets succeeds.
      */
     public function testMethodWithInnerCurlyBracketsSucceeds(): void

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/EmptyLinesInClosure.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/EmptyLinesInClosure.php.inc
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Quality\Ecs\ArrangeActAssertSniff\Correct;
+
+final class TestClass
+{
+    public function testSomething()
+    {
+        $value1 = 2;
+        $value2 = 2;
+        $expectedClosure = static function () use ($value1, $value2): int {
+            $result = $value1 + $value2;
+
+            return $result;
+        };
+
+        $actualResult = 2 + 2;
+
+        self::assertSame($expectedClosure(), $actualResult);
+    }
+}

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/EmptyLinesInClosure.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/EmptyLinesInClosure.php.inc
@@ -12,7 +12,7 @@ final class TestClass
         $expectedClosure = static function () use ($value1, $value2): int {
             $result = $value1 + $value2;
 
-            return $result;
+            return $result + 0;
         };
 
         $actualResult = 2 + 2;

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/innerCurlyBrackets.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/innerCurlyBrackets.php.inc
@@ -18,6 +18,11 @@ final class TestClass
                     ->withNoArgs()
                     ->once()
                     ->andReturn([]);
+
+                $mock->shouldReceive('anotherMethod')
+                    ->withNoArgs()
+                    ->once()
+                    ->andReturn([]);
             }
         );
         $array = $ruleRepository->someMethod();


### PR DESCRIPTION
- Improve ArrangeActAssertSniff to ignore empty line in closure

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
