### PR TITLE
[EasySchedule] Use eonx-com/easy-lock instead of easy-core

### DIFF
--- a/packages/EasySchedule/composer.json
+++ b/packages/EasySchedule/composer.json
@@ -8,7 +8,7 @@
         "nesbot/carbon": "^2.22",
         "dragonmantank/cron-expression": "^2.3",
         "symfony/console": "^4.2 || ^5.0",
-        "eonx-com/easy-core": "^2.4.45"
+        "eonx-com/easy-lock": "^2.4.45"
     },
     "require-dev": {
         "symfony/symfony": "^4.2 || ^5.0"

--- a/packages/EasySchedule/src/Interfaces/ScheduleRunnerInterface.php
+++ b/packages/EasySchedule/src/Interfaces/ScheduleRunnerInterface.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace EonX\EasySchedule\Interfaces;
 
-use EonX\EasyCore\Lock\LockServiceInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 interface ScheduleRunnerInterface
 {
     public function run(ScheduleInterface $schedule, OutputInterface $output): void;
-
-    public function setLockService(LockServiceInterface $lockService): self;
 }

--- a/packages/EasySchedule/src/ScheduleRunner.php
+++ b/packages/EasySchedule/src/ScheduleRunner.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasySchedule;
 
-use EonX\EasyCore\Lock\LockServiceInterface;
+use EonX\EasyLock\Interfaces\LockServiceInterface;
 use EonX\EasySchedule\Interfaces\ScheduleInterface;
 use EonX\EasySchedule\Interfaces\ScheduleRunnerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ScheduleRunner implements ScheduleRunnerInterface
 {
     /**
-     * @var \EonX\EasyCore\Lock\LockServiceInterface
+     * @var \EonX\EasyLock\Interfaces\LockServiceInterface
      */
     private $lockService;
 
@@ -56,12 +56,5 @@ final class ScheduleRunner implements ScheduleRunnerInterface
         if ($this->ran === false) {
             $output->writeln('<info>No scheduled commands are ready to run.</info>');
         }
-    }
-
-    public function setLockService(LockServiceInterface $lockService): ScheduleRunnerInterface
-    {
-        $this->lockService = $lockService;
-
-        return $this;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
