### PR TITLE
hotfix/Update-ArrangeActAssertSniff-to-support-multilevel-closures

### DIFF
--- a/packages/EasyStandard/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
+++ b/packages/EasyStandard/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
@@ -56,24 +56,24 @@ final class ArrangeActAssertSniff implements Sniff
         $currentTokenPosition = $openTokenPosition;
         $previousLine = $tokens[$openTokenPosition]['line'];
         $emptyLines = 0;
-        $insideClosure = false;
+        $closureLevel = 0;
 
         while ($currentTokenPosition < $closeTokenPosition) {
             // Find next token skipping whitespaces
             $nextTokenPosition = TokenHelper::findNextExcluding($phpcsFile, [T_WHITESPACE], $currentTokenPosition + 1);
             if ($tokens[$currentTokenPosition]['type'] === 'T_CLOSURE') {
-                $insideClosure = true;
+                $closureLevel++;
             }
 
             $currentLine = $tokens[$nextTokenPosition]['line'];
-            if ($currentLine - $previousLine > 1 && $insideClosure === false) {
+            if ($currentLine - $previousLine > 1 && $closureLevel === 0) {
                 $emptyLines++;
             }
 
             $previousLine = $currentLine;
             $currentTokenPosition = $nextTokenPosition;
             if ($tokens[$currentTokenPosition]['type'] === 'T_CLOSE_CURLY_BRACKET') {
-                $insideClosure = false;
+                $closureLevel--;
             }
         }
 

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/ArrangeActAssertSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/ArrangeActAssertSniffTest.php
@@ -16,6 +16,15 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 final class ArrangeActAssertSniffTest extends AbstractCheckerTestCase
 {
     /**
+     * Test anonymous class succeeds.
+     */
+    public function testAnonymousClassSucceeds(): void
+    {
+        $fileInfo = new SmartFileInfo(__DIR__ . '/Fixture/Correct/anonymousClass.php.inc');
+        $this->doTestCorrectFileInfo($fileInfo);
+    }
+
+    /**
      * Tests class with no test namespace succeeds.
      */
     public function testClassWithNoTestNamespaceSucceeds(): void
@@ -75,6 +84,15 @@ final class ArrangeActAssertSniffTest extends AbstractCheckerTestCase
     public function testMethodWithInnerCurlyBracketsSucceeds(): void
     {
         $fileInfo = new SmartFileInfo(__DIR__ . '/Fixture/Correct/innerCurlyBrackets.php.inc');
+        $this->doTestCorrectFileInfo($fileInfo);
+    }
+
+    /**
+     * Test multilevel closure succeeds.
+     */
+    public function testMultiLevelClosureSucceeds(): void
+    {
+        $fileInfo = new SmartFileInfo(__DIR__ . '/Fixture/Correct/multiLevelClosure.php.inc');
         $this->doTestCorrectFileInfo($fileInfo);
     }
 

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/anonymousClass.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/anonymousClass.php.inc
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Quality\Ecs\ArrangeActAssertSniff\Correct;
+
+final class TestClass
+{
+    public function testSomething()
+    {
+        $object = new class() {
+            public function getResult(): int
+            {
+                $value = 1;
+
+                return $value + 0;
+            }
+        };
+
+        $result = $object->getResult();
+
+        self::assertSame(1, $result);
+    }
+}

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/multiLevelClosure.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/multiLevelClosure.php.inc
@@ -9,7 +9,7 @@ final class TestClass
     {
         $value1 = 2;
         $value2 = 2;
-        $expectedClosure = \array_map(static function ($value) use ($value1, $value2) {
+        $expectedClosure = \array_map(static function () use ($value1, $value2) {
             $result = static function () use ($value1, $value2): int {
                 $result = $value1 + $value2;
 

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/multiLevelClosure.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/ArrangeActAssertSniff/Fixture/Correct/multiLevelClosure.php.inc
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Quality\Ecs\ArrangeActAssertSniff\Correct;
+
+final class TestClass
+{
+    public function testSomething()
+    {
+        $value1 = 2;
+        $value2 = 2;
+        $expectedClosure = \array_map(static function ($value) use ($value1, $value2) {
+            $result = static function () use ($value1, $value2): int {
+                $result = $value1 + $value2;
+
+                return $result + 0;
+            };
+
+            return $result();
+        }, []);
+
+        $actualResult = 2 + 2;
+
+        self::assertSame($expectedClosure(), $actualResult);
+    }
+}


### PR DESCRIPTION
- Update ArrangeActAssertSniff to support multilevel closures

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
