### PR TITLE
[EasyLogging] Allow to specify stream handler level in config

### DIFF
--- a/packages/EasyLogging/src/Bridge/BridgeConstantsInterface.php
+++ b/packages/EasyLogging/src/Bridge/BridgeConstantsInterface.php
@@ -14,6 +14,11 @@ interface BridgeConstantsInterface
     /**
      * @var string
      */
+    public const PARAM_STREAM_HANDLER_LEVEL = 'easy_logging.stream_handler_level';
+
+    /**
+     * @var string
+     */
     public const PARAM_LOGGER_CLASS = 'easy_logging.logger_class';
 
     /**

--- a/packages/EasyLogging/src/Bridge/Laravel/EasyLoggingServiceProvider.php
+++ b/packages/EasyLogging/src/Bridge/Laravel/EasyLoggingServiceProvider.php
@@ -47,7 +47,13 @@ final class EasyLoggingServiceProvider extends ServiceProvider
 
         // Default stream handler
         if (\config('easy-logging.stream_handler', true)) {
-            $this->app->singleton(StreamHandlerConfigProvider::class);
+            $this->app->singleton(StreamHandlerConfigProvider::class, function (): StreamHandlerConfigProvider {
+                $level = \config('easy-logging.stream_handler_level')
+                    ? (int)\config('easy-logging.stream_handler_level')
+                    : null;
+
+                return new StreamHandlerConfigProvider(null, $level);
+            });
             $this->app->tag(
                 StreamHandlerConfigProvider::class,
                 [BridgeConstantsInterface::TAG_HANDLER_CONFIG_PROVIDER]

--- a/packages/EasyLogging/src/Bridge/Laravel/config/easy-logging.php
+++ b/packages/EasyLogging/src/Bridge/Laravel/config/easy-logging.php
@@ -14,4 +14,9 @@ return [
      * Enable/Disable the default stream handler.
      */
     'stream_handler' => true,
+
+    /**
+     * The log level to set on the default stream handler, defaults to DEBUG.
+     */
+    'stream_handler_level' => null,
 ];

--- a/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -16,8 +16,9 @@ final class Configuration implements ConfigurationInterface
 
         $treeBuilder->getRootNode()
             ->children()
-            ->scalarNode('default_channel')->defaultValue(LoggerFactoryInterface::DEFAULT_CHANNEL)->end()
-            ->booleanNode('stream_handler')->defaultTrue()->end()
+                ->scalarNode('default_channel')->defaultValue(LoggerFactoryInterface::DEFAULT_CHANNEL)->end()
+                ->booleanNode('stream_handler')->defaultTrue()->end()
+                ->integerNode('stream_handler_level')->defaultNull()->end()
             ->end();
 
         return $treeBuilder;

--- a/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/EasyLoggingExtension.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/EasyLoggingExtension.php
@@ -49,6 +49,8 @@ final class EasyLoggingExtension extends Extension
             \class_exists(SymfonyBridgeLogger::class) ? SymfonyBridgeLogger::class : Logger::class
         );
 
+        $container->setParameter(BridgeConstantsInterface::PARAM_STREAM_HANDLER_LEVEL, $config['stream_handler_level']);
+
         foreach (static::$autoConfigs as $interface => $tag) {
             $container->registerForAutoconfiguration($interface)->addTag($tag);
         }

--- a/packages/EasyLogging/src/Bridge/Symfony/Resources/config/default_stream_handler.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/Resources/config/default_stream_handler.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use EonX\EasyLogging\Bridge\BridgeConstantsInterface;
 use EonX\EasyLogging\Config\StreamHandlerConfigProvider;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -11,5 +12,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autowire()
         ->autoconfigure();
 
-    $services->set(StreamHandlerConfigProvider::class);
+    $services
+        ->set(StreamHandlerConfigProvider::class)
+        ->arg('$level', '%' . BridgeConstantsInterface::PARAM_STREAM_HANDLER_LEVEL . '%');
 };

--- a/packages/EasyLogging/src/Config/StreamHandlerConfigProvider.php
+++ b/packages/EasyLogging/src/Config/StreamHandlerConfigProvider.php
@@ -6,6 +6,7 @@ namespace EonX\EasyLogging\Config;
 
 use EonX\EasyLogging\Interfaces\Config\HandlerConfigProviderInterface;
 use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 
 final class StreamHandlerConfigProvider implements HandlerConfigProviderInterface
 {
@@ -30,17 +31,24 @@ final class StreamHandlerConfigProvider implements HandlerConfigProviderInterfac
     private $stream;
 
     /**
+     * @var int
+     */
+    private $level;
+
+    /**
      * @param null|resource|string $stream
      * @param null|mixed[] $channels
      * @param null|mixed[] $exceptChannels
      */
     public function __construct(
         $stream = null,
+        ?int $level = null,
         ?array $channels = null,
         ?array $exceptChannels = null,
         ?int $priority = null
     ) {
         $this->stream = $stream ?? 'php://stdout';
+        $this->level = $level ?? Logger::DEBUG;
         $this->channels = $channels;
         $this->exceptChannels = $exceptChannels ?? ['event'];
         $this->priority = $priority;
@@ -53,7 +61,7 @@ final class StreamHandlerConfigProvider implements HandlerConfigProviderInterfac
      */
     public function handlers(): iterable
     {
-        $handlerConfig = HandlerConfig::create(new StreamHandler($this->stream));
+        $handlerConfig = HandlerConfig::create(new StreamHandler($this->stream, $this->level));
         $handlerConfig
             ->channels($this->channels)
             ->exceptChannels($this->exceptChannels)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
