### PR TITLE
[EasyStandard] Fix ExplicitBoolCompareRector

### DIFF
--- a/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
+++ b/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
@@ -100,7 +100,7 @@ PHP
             /** @var \PhpParser\Node\Expr\BinaryOp\Identical $identicalExpr */
             $identicalExpr = $expr;
 
-            if (isset($identicalExpr->left) === false || isset($identicalExpr->right) === false) {
+            if (isset($identicalExpr->left, $identicalExpr->right) === false) {
                 return $expr;
             }
 

--- a/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
+++ b/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
@@ -96,13 +96,10 @@ PHP
      */
     private function getNewConditionNode(bool $isNegated, Expr $expr): Expr
     {
-        if ($isNegated === false) {
-            /** @var \PhpParser\Node\Expr\BinaryOp\Identical $identicalExpr */
-            $identicalExpr = $expr;
+        /** @var \PhpParser\Node\Expr\BinaryOp\Identical $identicalExpr */
+        $identicalExpr = $expr;
 
-            if (isset($identicalExpr->left, $identicalExpr->right) === false) {
-                return $expr;
-            }
+        if ($isNegated === false && isset($identicalExpr->left, $identicalExpr->right)) {
 
             $left = $identicalExpr->left;
             /** @var \PhpParser\Node\Expr\ConstFetch $right */

--- a/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
+++ b/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
@@ -100,7 +100,6 @@ PHP
         $identicalExpr = $expr;
 
         if ($isNegated === false && isset($identicalExpr->left, $identicalExpr->right)) {
-
             $left = $identicalExpr->left;
             /** @var \PhpParser\Node\Expr\ConstFetch $right */
             $right = $identicalExpr->right;

--- a/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
+++ b/packages/EasyStandard/src/Rector/ExplicitBoolCompareRector.php
@@ -100,6 +100,10 @@ PHP
             /** @var \PhpParser\Node\Expr\BinaryOp\Identical $identicalExpr */
             $identicalExpr = $expr;
 
+            if (isset($identicalExpr->left) === false || isset($identicalExpr->right) === false) {
+                return $expr;
+            }
+
             $left = $identicalExpr->left;
             /** @var \PhpParser\Node\Expr\ConstFetch $right */
             $right = $identicalExpr->right;

--- a/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/FuncCallWithShortTrueComparison.php.inc
+++ b/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/FuncCallWithShortTrueComparison.php.inc
@@ -1,0 +1,12 @@
+<?php
+if (\in_array('value', [])) {
+    echo 'in array';
+}
+?>
+
+-----
+<?php
+if (\in_array('value', [])) {
+    echo 'in array';
+}
+?>

--- a/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/FuncCallWithShortTrueComparison.php.inc
+++ b/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/FuncCallWithShortTrueComparison.php.inc
@@ -3,10 +3,3 @@ if (\in_array('value', [])) {
     echo 'in array';
 }
 ?>
-
------
-<?php
-if (\in_array('value', [])) {
-    echo 'in array';
-}
-?>

--- a/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/MethodCallWithShortTrueComparison.php.inc
+++ b/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/MethodCallWithShortTrueComparison.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Tests\Rector\ExplicitBoolCompareRector\Fixture;
+
+class MethodCallWithShortTrueComparison
+{
+    public function isValid(): bool
+    {
+        return true;
+    }
+
+    public function testProcess(): void
+    {
+        if ($this->isValid()) {
+            echo 'valid';
+        }
+    }
+}
+
+?>
+
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Tests\Rector\ExplicitBoolCompareRector\Fixture;
+
+class MethodCallWithShortTrueComparison
+{
+    public function isValid(): bool
+    {
+        return true;
+    }
+
+    public function testProcess(): void
+    {
+        if ($this->isValid()) {
+            echo 'valid';
+        }
+    }
+}
+
+?>

--- a/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/MethodCallWithShortTrueComparison.php.inc
+++ b/packages/EasyStandard/tests/Rector/ExplicitBoolCompareRector/Fixture/MethodCallWithShortTrueComparison.php.inc
@@ -20,27 +20,3 @@ class MethodCallWithShortTrueComparison
 }
 
 ?>
-
------
-<?php
-
-declare(strict_types=1);
-
-namespace EonX\EasyStandard\Tests\Rector\ExplicitBoolCompareRector\Fixture;
-
-class MethodCallWithShortTrueComparison
-{
-    public function isValid(): bool
-    {
-        return true;
-    }
-
-    public function testProcess(): void
-    {
-        if ($this->isValid()) {
-            echo 'valid';
-        }
-    }
-}
-
-?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->

Fixed ExplicitBoolCompareRector notices on short true comparisons.