### PR TITLE
[EasySsm][EasyTest] Make console commands lazy.

### DIFF
--- a/packages/EasySsm/src/Console/Commands/ApplyCommand.php
+++ b/packages/EasySsm/src/Console/Commands/ApplyCommand.php
@@ -10,9 +10,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class ApplyCommand extends AbstractCommand
 {
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'apply';
+
     protected function configure(): void
     {
-        $this->setName('apply');
         $this->setDescription('Apply diff to remote SSM parameters');
     }
 

--- a/packages/EasySsm/src/Console/Commands/DiffCommand.php
+++ b/packages/EasySsm/src/Console/Commands/DiffCommand.php
@@ -10,9 +10,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class DiffCommand extends AbstractCommand
 {
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'diff';
+
     protected function configure(): void
     {
-        $this->setName('diff');
         $this->setDescription('Display diff between remote and local SSM parameters');
     }
 

--- a/packages/EasySsm/src/Console/Commands/DumpEnvCommand.php
+++ b/packages/EasySsm/src/Console/Commands/DumpEnvCommand.php
@@ -11,6 +11,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class DumpEnvCommand extends AbstractCommand
 {
     /**
+     * @var string
+     */
+    protected static $defaultName = 'dump-env';
+
+    /**
      * @var string[]
      */
     private static $excludes = [
@@ -34,7 +39,6 @@ final class DumpEnvCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setName('dump-env')
             ->setDescription('Dump env vars in a PHP file to improve loading time.')
             ->addOption(
                 'filename',

--- a/packages/EasySsm/src/Console/Commands/ExportEnvsCommand.php
+++ b/packages/EasySsm/src/Console/Commands/ExportEnvsCommand.php
@@ -12,6 +12,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ExportEnvsCommand extends AbstractCommand
 {
     /**
+     * @var string
+     */
+    protected static $defaultName = 'export-envs';
+
+    /**
      * @var \EonX\EasySsm\Services\Dotenv\SsmDotenvInterface
      */
     private $ssmDotenv;
@@ -27,7 +32,6 @@ final class ExportEnvsCommand extends AbstractCommand
     protected function configure(): void
     {
         $this
-            ->setName('export-envs')
             ->setDescription('Export SSM parameters to env variables')
             ->addOption(
                 'strict',

--- a/packages/EasySsm/src/Console/Commands/InitCommand.php
+++ b/packages/EasySsm/src/Console/Commands/InitCommand.php
@@ -10,9 +10,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class InitCommand extends AbstractCommand
 {
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'init';
+
     protected function configure(): void
     {
-        $this->setName('init');
         $this->setDescription('Initial pull content of SSM and create YAML file');
     }
 

--- a/packages/EasySsm/src/Console/Commands/LocalApplyCommand.php
+++ b/packages/EasySsm/src/Console/Commands/LocalApplyCommand.php
@@ -10,9 +10,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class LocalApplyCommand extends AbstractCommand
 {
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'local-apply';
+
     protected function configure(): void
     {
-        $this->setName('local-apply');
         $this->setDescription('Display local diff between old and local SSM parameters');
     }
 

--- a/packages/EasySsm/src/Console/Commands/LocalDiffCommand.php
+++ b/packages/EasySsm/src/Console/Commands/LocalDiffCommand.php
@@ -10,9 +10,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class LocalDiffCommand extends AbstractCommand
 {
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'local-diff';
+
     protected function configure(): void
     {
-        $this->setName('local-diff');
         $this->setDescription('Display local diff between old and local SSM parameters');
     }
 

--- a/packages/EasySsm/src/Console/Commands/PullCommand.php
+++ b/packages/EasySsm/src/Console/Commands/PullCommand.php
@@ -10,9 +10,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class PullCommand extends AbstractCommand
 {
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'pull';
+
     protected function configure(): void
     {
-        $this->setName('pull');
         $this->setDescription('Pull content of SSM and create YAML file');
     }
 

--- a/packages/EasyTest/src/Console/Commands/CheckCoverageCommand.php
+++ b/packages/EasyTest/src/Console/Commands/CheckCoverageCommand.php
@@ -16,6 +16,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class CheckCoverageCommand extends Command
 {
     /**
+     * @var string
+     */
+    protected static $defaultName = 'check-coverage';
+
+    /**
      * @var \EonX\EasyTest\Interfaces\CoverageLoaderInterface
      */
     private $coverageLoader;
@@ -36,7 +41,6 @@ final class CheckCoverageCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('check-coverage')
             ->setDescription('Run given test script and check output coverage against coverage option')
             ->addArgument('file', InputArgument::REQUIRED, 'File containing the coverage output')
             ->addOption('coverage', 'c', InputOption::VALUE_REQUIRED, 'Coverage limit to check against');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -  <!-- #-prefixed issue number(s), if any -->

This PR is about of a little optimisation to avoid initialisation of all command services on each executing `bin/console` command.
Since Symfony 3.4 console commands can be lazy thanks to [a static name property](https://github.com/symfony/symfony/pull/23887).
This change does not break BC because the BC layer is already [in the base command's constructor](https://github.com/symfony/symfony/pull/23887/files#diff-8e80595663798837db1b033187835535R75).