### PR TITLE
[EasyCore] Mark SetContentLength as deprecated

### DIFF
--- a/packages/EasyCore/src/Http/Middleware/SetContentLength.php
+++ b/packages/EasyCore/src/Http/Middleware/SetContentLength.php
@@ -6,6 +6,9 @@ namespace EonX\EasyCore\Http\Middleware;
 
 use Illuminate\Http\Request;
 
+/**
+ * @deprecated since 2.3.1 and will be removed in 3.0.
+ */
 final class SetContentLength
 {
     public function __construct()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
