### PR TITLE
[EasyStandard] Implement AvoidPrivatePropertiesSniff

### DIFF
--- a/packages/EasyStandard/docs/ecs/sniffs.md
+++ b/packages/EasyStandard/docs/ecs/sniffs.md
@@ -5,7 +5,7 @@ weight: 1001
 #### Classes
 
 ##### [\EonX\EasyStandard\Sniffs\Classes\AvoidPrivatePropertiesSniff][1]
-Class properties must be protected or private.
+Class properties must be protected or public.
 ```php
 // incorrect
 class MyClass

--- a/packages/EasyStandard/docs/ecs/sniffs.md
+++ b/packages/EasyStandard/docs/ecs/sniffs.md
@@ -4,7 +4,28 @@ weight: 1001
 ---eonx_docs---
 #### Classes
 
-##### [\EonX\EasyStandard\Sniffs\Classes\AvoidPublicPropertiesSniff][1]
+##### [\EonX\EasyStandard\Sniffs\Classes\AvoidPrivatePropertiesSniff][1]
+Class properties must be protected or private.
+```php
+// incorrect
+class MyClass
+{
+    private $myProperty1;
+    // or
+    $myProperty2;
+}
+```
+```php
+// correct
+class MyClass
+{
+    public $myProperty1;
+    // or
+    protected $myProperty2;
+}
+```
+
+##### [\EonX\EasyStandard\Sniffs\Classes\AvoidPublicPropertiesSniff][2]
 Class properties must be protected or private.
 ```php
 // incorrect
@@ -25,7 +46,7 @@ class MyClass
 }
 ```
 
-##### [\EonX\EasyStandard\Sniffs\Classes\RequirePublicConstructorSniff][2]
+##### [\EonX\EasyStandard\Sniffs\Classes\RequirePublicConstructorSniff][3]
 Class constructor must be public.
 ```php
 // incorrect
@@ -46,7 +67,7 @@ class MyClass
 }
 ```
 
-##### [\EonX\EasyStandard\Sniffs\Classes\RequireStrictDeclarationSniff][3]
+##### [\EonX\EasyStandard\Sniffs\Classes\RequireStrictDeclarationSniff][4]
 Strict type declaration is required.
 ```php
 // incorrect
@@ -61,7 +82,7 @@ declare(strict_types=1);
 // any php content
 ```
 
-##### [\EonX\EasyStandard\Sniffs\Classes\StrictDeclarationFormatSniff][4]
+##### [\EonX\EasyStandard\Sniffs\Classes\StrictDeclarationFormatSniff][5]
 Strict type declaration must be on a new line with no leading whitespace.
 ```php
 // incorrect
@@ -85,7 +106,7 @@ declare(strict_types=1);
 
 #### Commenting
 
-##### [\EonX\EasyStandard\Sniffs\Commenting\AnnotationSortingSniff][5]
+##### [\EonX\EasyStandard\Sniffs\Commenting\AnnotationSortingSniff][6]
 Checks that annotations are sorted alphabetically.
 ```php
 // incorrect
@@ -121,7 +142,7 @@ class MyClass
 
 - `alwaysTopAnnotations` - A list of annotations that should always come first in the list, without regard to sorting. Default value: `[]`.
 
-##### [\EonX\EasyStandard\Sniffs\Commenting\FunctionCommentSniff][6]
+##### [\EonX\EasyStandard\Sniffs\Commenting\FunctionCommentSniff][7]
 Checks that function comment blocks follow EonX standards.
 ```php
 // incorrect
@@ -220,7 +241,7 @@ class MyClass
 
 #### Control Structures
 
-##### [\EonX\EasyStandard\Sniffs\ControlStructures\ArrangeActAssertSniff][7]
+##### [\EonX\EasyStandard\Sniffs\ControlStructures\ArrangeActAssertSniff][8]
 Checks that a test method conforms to Arrange, Act and Assert (AAA) pattern. The allowed number of empty lines is between [1, 2].
 ```php
 // incorrect
@@ -321,7 +342,7 @@ final class TestClass
 }
 ```
 
-##### [\EonX\EasyStandard\Sniffs\ControlStructures\NoNotOperatorSniff][8]
+##### [\EonX\EasyStandard\Sniffs\ControlStructures\NoNotOperatorSniff][9]
 A strict comparison operator must be used instead of a NOT operator.
 ```php
 // incorrect
@@ -340,7 +361,7 @@ if ($a === false) {
 
 #### Exceptions
 
-##### [\EonX\EasyStandard\Sniffs\Exceptions\ThrowExceptionMessageSniff][9]
+##### [\EonX\EasyStandard\Sniffs\Exceptions\ThrowExceptionMessageSniff][10]
 Exception message must be either a variable or a translation message, starting with a valid prefix.
 ```php
 // incorrect
@@ -364,7 +385,7 @@ throw new RuntimeException($message);
 
 #### Methods
 
-##### [\EonX\EasyStandard\Sniffs\Methods\TestMethodNameSniff][10]
+##### [\EonX\EasyStandard\Sniffs\Methods\TestMethodNameSniff][11]
 Checks that a method name matches/does not match a specific regex.
 
 **Parameters**
@@ -392,21 +413,22 @@ Default value:
 
 #### Namespaces
 
-##### [\EonX\EasyStandard\Sniffs\Namespaces\Psr4Sniff][11]
+##### [\EonX\EasyStandard\Sniffs\Namespaces\Psr4Sniff][12]
 Checks that a namespace name matches PSR-4 project structure.
 
 **Parameters**
 
 - `composerJsonPath` - A relative path to the project file `composer.json`. Default value: `composer.json`.
 
-[1]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/AvoidPublicPropertiesSniff.php
-[2]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/RequirePublicConstructorSniff.php
-[3]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/RequireStrictDeclarationSniff.php
-[4]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/StrictDeclarationFormatSniff.php
-[5]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Commenting/AnnotationSortingSniff.php
-[6]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Commenting/FunctionCommentSniff.php
-[7]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
-[8]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/ControlStructures/NoNotOperatorSniff.php
-[9]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Exceptions/ThrowExceptionMessageSniff.php
-[10]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Methods/TestMethodNameSniff.php
-[11]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Namespaces/Psr4Sniff.php
+[1]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/AvoidPrivatePropertiesSniff.php
+[2]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/AvoidPublicPropertiesSniff.php
+[3]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/RequirePublicConstructorSniff.php
+[4]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/RequireStrictDeclarationSniff.php
+[5]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Classes/StrictDeclarationFormatSniff.php
+[6]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Commenting/AnnotationSortingSniff.php
+[7]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Commenting/FunctionCommentSniff.php
+[8]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/ControlStructures/ArrangeActAssertSniff.php
+[9]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/ControlStructures/NoNotOperatorSniff.php
+[10]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Exceptions/ThrowExceptionMessageSniff.php
+[11]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Methods/TestMethodNameSniff.php
+[12]: https://github.com/eonx-com/easy-monorepo/blob/master/packages/EasyStandard/src/Sniffs/Namespaces/Psr4Sniff.php

--- a/packages/EasyStandard/src/Sniffs/Classes/AvoidPrivatePropertiesSniff.php
+++ b/packages/EasyStandard/src/Sniffs/Classes/AvoidPrivatePropertiesSniff.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+
+final class AvoidPrivatePropertiesSniff extends AbstractVariableSniff
+{
+    /**
+     * @param int $stackPtr
+     */
+    protected function processMemberVar(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        try {
+            $propertyInfo = $phpcsFile->getMemberProperties($stackPtr);
+
+            if (empty($propertyInfo)) {
+                return;
+            }
+        } catch (\Throwable $exception) {
+            return;
+        }
+
+        if (($propertyInfo['scope_specified'] ?? false) === false || empty($propertyInfo['scope'])) {
+            $error = 'Visibility must be declared on property "%s"';
+            $data = [$tokens[$stackPtr]['content']] ?? [];
+
+            $phpcsFile->addError($error, $stackPtr, 'ScopeMissing', $data);
+        }
+
+        if ($propertyInfo['scope'] === 'private') {
+            $error = 'Invalid visibility "private" on property "%s"';
+            $data = [$tokens[$stackPtr]['content']] ?? [];
+
+            $phpcsFile->addError($error, $stackPtr, 'InvalidScope', $data);
+        }
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr): void
+    {
+        // No needed for sniff.
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr): void
+    {
+        // No needed for sniff.
+    }
+}

--- a/packages/EasyStandard/tests/Sniffs/Classes/AvoidPrivatePropertiesSniff/AvoidPrivatePropertiesSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/Classes/AvoidPrivatePropertiesSniff/AvoidPrivatePropertiesSniffTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Tests\Sniffs\Classes\AvoidPrivatePropertiesSniff;
+
+use EonX\EasyStandard\Sniffs\Classes\AvoidPublicPropertiesSniff;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AvoidPrivatePropertiesSniffTest extends AbstractCheckerTestCase
+{
+    /**
+     * @return iterable<array<int, SmartFileInfo|int>>
+     *
+     * @throws \Symplify\SmartFileSystem\Exception\FileNotFoundException
+     */
+    public function providerTestSniff(): iterable
+    {
+        yield [new SmartFileInfo(__DIR__ . '/Fixture/AvoidPrivatePropertiesSniffTest.php.inc'), 1];
+    }
+
+    /**
+     * @dataProvider providerTestSniff()
+     */
+    public function testSniff(SmartFileInfo $smartFileInfo, int $expectedErrorCount): void
+    {
+        $this->doTestFileInfoWithErrorCountOf($smartFileInfo, $expectedErrorCount);
+    }
+
+    protected function getCheckerClass(): string
+    {
+        return AvoidPublicPropertiesSniff::class;
+    }
+}

--- a/packages/EasyStandard/tests/Sniffs/Classes/AvoidPrivatePropertiesSniff/AvoidPrivatePropertiesSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/Classes/AvoidPrivatePropertiesSniff/AvoidPrivatePropertiesSniffTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyStandard\Tests\Sniffs\Classes\AvoidPrivatePropertiesSniff;
 
-use EonX\EasyStandard\Sniffs\Classes\AvoidPublicPropertiesSniff;
+use EonX\EasyStandard\Sniffs\Classes\AvoidPrivatePropertiesSniff;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
@@ -30,6 +30,6 @@ final class AvoidPrivatePropertiesSniffTest extends AbstractCheckerTestCase
 
     protected function getCheckerClass(): string
     {
-        return AvoidPublicPropertiesSniff::class;
+        return AvoidPrivatePropertiesSniff::class;
     }
 }

--- a/packages/EasyStandard/tests/Sniffs/Classes/AvoidPrivatePropertiesSniff/Fixture/AvoidPrivatePropertiesSniffTest.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/Classes/AvoidPrivatePropertiesSniff/Fixture/AvoidPrivatePropertiesSniffTest.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+class MyClassWithPrivateProperty
+{
+    private $myProperty;
+}


### PR DESCRIPTION
Added `AvoidPrivatePropertiesSniff`, a copy of `AvoidPublicPropertiesSniff`. This new sniff will help us to keep only protected properties in entity classes (as we decided to not use private properties there because of inheritance issues).

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
