### PR TITLE
[EasyWebhook] Add missing SendAfterMiddleware to config in bridges

### DIFF
--- a/packages/EasyWebhook/src/Bridge/Laravel/EasyWebhookServiceProvider.php
+++ b/packages/EasyWebhook/src/Bridge/Laravel/EasyWebhookServiceProvider.php
@@ -31,6 +31,7 @@ use EonX\EasyWebhook\Middleware\LockMiddleware;
 use EonX\EasyWebhook\Middleware\MethodMiddleware;
 use EonX\EasyWebhook\Middleware\RerunMiddleware;
 use EonX\EasyWebhook\Middleware\ResetStoreMiddleware;
+use EonX\EasyWebhook\Middleware\SendAfterMiddleware;
 use EonX\EasyWebhook\Middleware\SendWebhookMiddleware;
 use EonX\EasyWebhook\Middleware\SignatureHeaderMiddleware;
 use EonX\EasyWebhook\Middleware\StatusAndAttemptMiddleware;
@@ -88,6 +89,13 @@ final class EasyWebhookServiceProvider extends ServiceProvider
         $this->app->singleton(LockMiddleware::class, function (): LockMiddleware {
             return new LockMiddleware(
                 $this->app->make(LockServiceInterface::class),
+                MiddlewareInterface::PRIORITY_CORE_BEFORE - 2
+            );
+        });
+
+        $this->app->singleton(SendAfterMiddleware::class, function (): SendAfterMiddleware {
+            return new SendAfterMiddleware(
+                $this->app->make(StoreInterface::class),
                 MiddlewareInterface::PRIORITY_CORE_BEFORE - 1
             );
         });

--- a/packages/EasyWebhook/src/Bridge/Symfony/Resources/config/core_middleware.php
+++ b/packages/EasyWebhook/src/Bridge/Symfony/Resources/config/core_middleware.php
@@ -12,6 +12,7 @@ use EonX\EasyWebhook\Middleware\LockMiddleware;
 use EonX\EasyWebhook\Middleware\MethodMiddleware;
 use EonX\EasyWebhook\Middleware\RerunMiddleware;
 use EonX\EasyWebhook\Middleware\ResetStoreMiddleware;
+use EonX\EasyWebhook\Middleware\SendAfterMiddleware;
 use EonX\EasyWebhook\Middleware\SendWebhookMiddleware;
 use EonX\EasyWebhook\Middleware\StatusAndAttemptMiddleware;
 use EonX\EasyWebhook\Middleware\StoreMiddleware;
@@ -25,6 +26,10 @@ return static function (ContainerConfigurator $container): void {
     // BEFORE MIDDLEWARE
     $services
         ->set(LockMiddleware::class)
+        ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 2);
+
+    $services
+        ->set(SendAfterMiddleware::class)
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 1);
 
     $services


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
