### PR TITLE
[EasyWebhook] Disable async properly if Messenger not installed

### DIFF
--- a/packages/EasyWebhook/src/Bridge/Symfony/DependencyInjection/EasyWebhookExtension.php
+++ b/packages/EasyWebhook/src/Bridge/Symfony/DependencyInjection/EasyWebhookExtension.php
@@ -70,11 +70,11 @@ final class EasyWebhookExtension extends Extension
 
     private function async(): void
     {
-        $enabled = $config['async']['enabled'] ?? true;
+        $enabled = \class_exists(MessengerPass::class) && ($config['async']['enabled'] ?? true);
 
         $this->container->setParameter(BridgeConstantsInterface::PARAM_ASYNC, $enabled);
 
-        if ($enabled && \class_exists(MessengerPass::class)) {
+        if ($enabled) {
             $this->container->setParameter(BridgeConstantsInterface::PARAM_BUS, $this->config['async']['bus']);
             $this->loader->load('async.php');
         }

--- a/packages/EasyWebhook/src/Middleware/AsyncMiddleware.php
+++ b/packages/EasyWebhook/src/Middleware/AsyncMiddleware.php
@@ -45,6 +45,9 @@ final class AsyncMiddleware extends AbstractMiddleware
     public function process(WebhookInterface $webhook, StackInterface $stack): WebhookResultInterface
     {
         if ($this->enabled === false || $webhook->isSendNow()) {
+            // If async disabled, make sure webhook is sendNow
+            $webhook->sendNow(true);
+
             return $stack
                 ->next()
                 ->process($webhook, $stack);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
