### PR TITLE
[EasyWebhook] Don't send webhook-id header if default id

### DIFF
--- a/packages/EasyWebhook/src/Interfaces/Stores/StoreInterface.php
+++ b/packages/EasyWebhook/src/Interfaces/Stores/StoreInterface.php
@@ -18,6 +18,11 @@ interface StoreInterface
      */
     public const DEFAULT_TABLE = 'easy_webhooks';
 
+    /**
+     * @var string
+     */
+    public const DEFAULT_WEBHOOK_ID = 'webhook-id';
+
     public function find(string $id): ?WebhookInterface;
 
     public function generateWebhookId(): string;

--- a/packages/EasyWebhook/src/Middleware/IdHeaderMiddleware.php
+++ b/packages/EasyWebhook/src/Middleware/IdHeaderMiddleware.php
@@ -32,7 +32,11 @@ final class IdHeaderMiddleware extends AbstractConfigureOnceMiddleware
     protected function doProcess(WebhookInterface $webhook, StackInterface $stack): WebhookResultInterface
     {
         $webhook->id($webhook->getId() ?? $this->store->generateWebhookId());
-        $webhook->header($this->idHeader, $webhook->getId());
+
+        // Set header only if id isn't the default one
+        if ($webhook->getId() !== StoreInterface::DEFAULT_WEBHOOK_ID) {
+            $webhook->header($this->idHeader, $webhook->getId());
+        }
 
         return $stack
             ->next()

--- a/packages/EasyWebhook/src/Stores/NullStore.php
+++ b/packages/EasyWebhook/src/Stores/NullStore.php
@@ -16,7 +16,7 @@ final class NullStore implements StoreInterface
 
     public function generateWebhookId(): string
     {
-        return 'webhook-id';
+        return self::DEFAULT_WEBHOOK_ID;
     }
 
     public function store(WebhookInterface $webhook): WebhookInterface

--- a/packages/EasyWebhook/tests/Middleware/IdHeaderMiddlewareTest.php
+++ b/packages/EasyWebhook/tests/Middleware/IdHeaderMiddlewareTest.php
@@ -26,7 +26,7 @@ final class IdHeaderMiddlewareTest extends AbstractMiddlewareTestCase
                     ->getHttpClientOptions()['headers'] ?? [];
 
                 self::assertArrayHasKey(WebhookInterface::HEADER_ID, $headers);
-                self::assertEquals('webhook-id', $headers[WebhookInterface::HEADER_ID]);
+                self::assertEquals('not-default-webhook-id', $headers[WebhookInterface::HEADER_ID]);
             },
         ];
 
@@ -68,7 +68,7 @@ final class IdHeaderMiddlewareTest extends AbstractMiddlewareTestCase
         ?StoreInterface $store = null
     ): void {
         // Fix webhook id
-        $store = $store ?? new ArrayStoreStub($this->getRandomGenerator(), 'webhook-id');
+        $store = $store ?? new ArrayStoreStub($this->getRandomGenerator(), 'not-default-webhook-id');
         $middleware = new IdHeaderMiddleware($store, $idHeader);
 
         $test($this->process($middleware, $webhook));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
