### PR TITLE
[EasyStandard] Implement LinebreakAfterEqualsSignSniff

### DIFF
--- a/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
+++ b/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
@@ -45,11 +45,7 @@ final class LinebreakAfterEqualsSignSniff implements Sniff
         $phpcsFile->fixer->replaceToken($equalsSignPointer + 1, ' ');
         $phpcsFile->fixer->replaceToken($equalsSignPointer + 2, '');
 
-        $endOfExpressionPointer = TokenHelper::findNext(
-            $phpcsFile,
-            \T_SEMICOLON,
-            $equalsSignPointer
-        );
+        $endOfExpressionPointer = TokenHelper::findNext($phpcsFile, \T_SEMICOLON, $equalsSignPointer);
 
         $whitespaces = TokenHelper::findNextAll(
             $phpcsFile,
@@ -69,11 +65,7 @@ final class LinebreakAfterEqualsSignSniff implements Sniff
             if ($tokens[$whitespace]['length'] > 1 && ctype_space($whitespaceContent)) {
                 $phpcsFile->fixer->replaceToken(
                     $whitespace,
-                    \str_pad(
-                        $firstLineIdentationContent,
-                        $firstLineIdentationLength + self::IDENTATION_LENGTH,
-                        ' '
-                    )
+                    \str_pad($firstLineIdentationContent, $firstLineIdentationLength + self::IDENTATION_LENGTH, ' ')
                 );
             }
         }

--- a/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
+++ b/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace EonX\EasyStandard\Sniffs\ControlStructures;

--- a/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
+++ b/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
@@ -6,15 +6,9 @@ namespace EonX\EasyStandard\Sniffs\ControlStructures;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use SlevomatCodingStandard\Helpers\TokenHelper;
 
 final class LinebreakAfterEqualsSignSniff implements Sniff
 {
-    /**
-     * @var int
-     */
-    private const IDENTATION_LENGTH = 4;
-
     /**
      * @var string
      */
@@ -33,45 +27,11 @@ final class LinebreakAfterEqualsSignSniff implements Sniff
             return;
         }
 
-        $fix = $phpcsFile->addFixableError(
+        $phpcsFile->addErrorOnLine(
             'The line can\'t be broken just after the equals sign.',
             $tokens[$equalsSignPointer]['line'],
             self::LINEBREAK_AFTER_EQUALS_SIGN
         );
-
-        if ($fix === false) {
-            return;
-        }
-
-        $phpcsFile->fixer->replaceToken($equalsSignPointer + 1, ' ');
-        $phpcsFile->fixer->replaceToken($equalsSignPointer + 2, '');
-
-        $endOfExpressionPointer = TokenHelper::findNext($phpcsFile, \T_SEMICOLON, $equalsSignPointer);
-
-        $whitespaces = TokenHelper::findNextAll(
-            $phpcsFile,
-            \T_WHITESPACE,
-            $equalsSignPointer,
-            $endOfExpressionPointer
-        );
-
-        $firstLineIdentationPointer = TokenHelper::findFirstTokenOnLine($phpcsFile, $equalsSignPointer);
-        $firstLineIdentationContent = $tokens[$firstLineIdentationPointer]['type'] === 'T_WHITESPACE' ?
-            $tokens[$firstLineIdentationPointer]['content'] :
-            '';
-        $firstLineIdentationLength = \strlen($firstLineIdentationContent);
-
-        foreach ($whitespaces as $whitespace) {
-            $whitespaceContent = $tokens[$whitespace]['content'];
-            if ($tokens[$whitespace]['length'] > 1 && ctype_space($whitespaceContent)) {
-                $phpcsFile->fixer->replaceToken(
-                    $whitespace,
-                    \str_pad($firstLineIdentationContent, $firstLineIdentationLength + self::IDENTATION_LENGTH, ' ')
-                );
-            }
-        }
-
-        $phpcsFile->fixer->endChangeset();
     }
 
     /**

--- a/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
+++ b/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
@@ -28,7 +28,7 @@ final class LinebreakAfterEqualsSignSniff implements Sniff
         }
 
         $phpcsFile->addErrorOnLine(
-            'The line can\'t be broken just after the equals sign.',
+            'The line must not be broken right after the equals sign.',
             $tokens[$equalsSignPointer]['line'],
             self::LINEBREAK_AFTER_EQUALS_SIGN
         );

--- a/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
+++ b/packages/EasyStandard/src/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+final class LinebreakAfterEqualsSignSniff implements Sniff
+{
+    /**
+     * @var int
+     */
+    private const IDENTATION_LENGTH = 4;
+
+    /**
+     * @var string
+     */
+    private const LINEBREAK_AFTER_EQUALS_SIGN = 'LinebreakAfterEqualsSign';
+
+    /**
+     * @param int $equalsSignPointer
+     */
+    public function process(File $phpcsFile, $equalsSignPointer): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $afterEqualsSignToken = $tokens[$equalsSignPointer + 1];
+
+        if ($afterEqualsSignToken['content'] !== "\n") {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'The line can\'t be broken just after the equals sign.',
+            $tokens[$equalsSignPointer]['line'],
+            self::LINEBREAK_AFTER_EQUALS_SIGN
+        );
+
+        if ($fix === false) {
+            return;
+        }
+
+        $phpcsFile->fixer->replaceToken($equalsSignPointer + 1, ' ');
+        $phpcsFile->fixer->replaceToken($equalsSignPointer + 2, '');
+
+        $endOfExpressionPointer = TokenHelper::findNext(
+            $phpcsFile,
+            \T_SEMICOLON,
+            $equalsSignPointer
+        );
+
+        $whitespaces = TokenHelper::findNextAll(
+            $phpcsFile,
+            \T_WHITESPACE,
+            $equalsSignPointer,
+            $endOfExpressionPointer
+        );
+
+        $firstLineIdentationPointer = TokenHelper::findFirstTokenOnLine($phpcsFile, $equalsSignPointer);
+        $firstLineIdentationContent = $tokens[$firstLineIdentationPointer]['type'] === 'T_WHITESPACE' ?
+            $tokens[$firstLineIdentationPointer]['content'] :
+            '';
+        $firstLineIdentationLength = \strlen($firstLineIdentationContent);
+
+        foreach ($whitespaces as $whitespace) {
+            $whitespaceContent = $tokens[$whitespace]['content'];
+            if ($tokens[$whitespace]['length'] > 1 && ctype_space($whitespaceContent)) {
+                $phpcsFile->fixer->replaceToken(
+                    $whitespace,
+                    \str_pad(
+                        $firstLineIdentationContent,
+                        $firstLineIdentationLength + self::IDENTATION_LENGTH,
+                        ' '
+                    )
+                );
+            }
+        }
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function register(): array
+    {
+        return [\T_EQUAL];
+    }
+}

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+$someClass =
+    new class() {
+
+    };
+?>
+-----
+<?php
+
+$someClass = new class() {
+
+    };
+?>

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc
@@ -4,11 +4,9 @@ $someClass =
     new class() {
 
     };
+if ('sooooooooooooooooooooooome-veeeeeeeeeeeeeeeeeeeery-loooooooooooooooooooooooooon-striiiiiiiiiiiiiiiiiiiiiiiing' ===
+ 'some') {
+    die();
+}
 ?>
------
-<?php
 
-$someClass = new class() {
-
-    };
-?>

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
@@ -16,7 +16,9 @@ final class LinebreakAfterEqualsSignSniffTest extends AbstractCheckerTestCase
      */
     public function providerTestSniff(): iterable
     {
-        yield ['filePath' => '/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc'];
+        yield [
+            'filePath' => '/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc',
+        ];
     }
 
     /**

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyStandard\Tests\Sniffs\ControlStructures\LinebreakAfterEqualsSignSniff;
+
+use EonX\EasyStandard\Sniffs\ControlStructures\LinebreakAfterEqualsSignSniff;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class LinebreakAfterEqualsSignSniffTest extends AbstractCheckerTestCase
+{
+    /**
+     * @return mixed[]
+     *
+     * @see testSniff
+     */
+    public function providerTestSniff(): iterable
+    {
+        yield ['filePath' => '/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc'];
+    }
+
+    /**
+     * @param string $filePath
+     *
+     * @throws \Symplify\SmartFileSystem\Exception\FileNotFoundException
+     *
+     * @dataProvider providerTestSniff
+     */
+    public function testSniff(string $filePath): void
+    {
+        $smartFileInfo = new SmartFileInfo(__DIR__ . $filePath);
+        $this->doTestFileInfo($smartFileInfo);
+    }
+
+    protected function getCheckerClass(): string
+    {
+        return LinebreakAfterEqualsSignSniff::class;
+    }
+}

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace EonX\EasyStandard\Tests\Sniffs\ControlStructures\LinebreakAfterEqualsSignSniff;
@@ -7,6 +8,11 @@ use EonX\EasyStandard\Sniffs\ControlStructures\LinebreakAfterEqualsSignSniff;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
+/**
+ * @covers \EonX\EasyStandard\Sniffs\ControlStructures\LinebreakAfterEqualsSignSniff
+ *
+ * @internal
+ */
 final class LinebreakAfterEqualsSignSniffTest extends AbstractCheckerTestCase
 {
     /**

--- a/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
+++ b/packages/EasyStandard/tests/Sniffs/ControlStructures/LinebreakAfterEqualsSignSniff/LinebreakAfterEqualsSignSniffTest.php
@@ -24,6 +24,7 @@ final class LinebreakAfterEqualsSignSniffTest extends AbstractCheckerTestCase
     {
         yield [
             'filePath' => '/Fixture/LinebreakAfterEqualsSignSniffTest.php.inc',
+            'expectedErrorCount' => 1,
         ];
     }
 
@@ -34,10 +35,10 @@ final class LinebreakAfterEqualsSignSniffTest extends AbstractCheckerTestCase
      *
      * @dataProvider providerTestSniff
      */
-    public function testSniff(string $filePath): void
+    public function testSniff(string $filePath, int $expectedErrorCount): void
     {
         $smartFileInfo = new SmartFileInfo(__DIR__ . $filePath);
-        $this->doTestFileInfo($smartFileInfo);
+        $this->doTestFileInfoWithErrorCountOf($smartFileInfo, $expectedErrorCount);
     }
 
     protected function getCheckerClass(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->

- Add LinebreakAfterEqualsSignSniff.
