### PR TITLE
[EasyApiToken] Fix ChainDecoder to use CollectorHelper::filterByClassArray

### DIFF
--- a/packages/EasyApiToken/src/Decoders/ChainDecoder.php
+++ b/packages/EasyApiToken/src/Decoders/ChainDecoder.php
@@ -21,7 +21,7 @@ final class ChainDecoder extends AbstractApiTokenDecoder
      */
     public function __construct(array $decoders, ?string $name = null)
     {
-        $this->decoders = CollectorHelper::filterByClass($decoders, ApiTokenDecoderInterface::class);
+        $this->decoders = CollectorHelper::filterByClassAsArray($decoders, ApiTokenDecoderInterface::class);
 
         parent::__construct($name ?? self::NAME_CHAIN);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #547    <!-- #-prefixed issue number(s), if any -->
