### PR TITLE
hotfix/easy-async-issue-with-default-all-managers-logic

### DIFF
--- a/packages/EasyAsync/src/Doctrine/ManagersClearer.php
+++ b/packages/EasyAsync/src/Doctrine/ManagersClearer.php
@@ -27,7 +27,7 @@ final class ManagersClearer
     public function clear(?array $managers = null): void
     {
         // If no managers given, default to all
-        $managers = $managers ?? $this->registry->getManagerNames();
+        $managers = $managers ?? \array_keys($this->registry->getManagerNames());
 
         foreach ($managers as $managerName) {
             $this->registry->getManager($managerName)

--- a/packages/EasyAsync/src/Doctrine/ManagersSanityChecker.php
+++ b/packages/EasyAsync/src/Doctrine/ManagersSanityChecker.php
@@ -38,7 +38,7 @@ final class ManagersSanityChecker
     public function checkSanity(?array $managers = null): void
     {
         // If no managers given, default to all
-        $managers = $managers ?? $this->registry->getManagerNames();
+        $managers = $managers ?? \array_keys($this->registry->getManagerNames());
 
         foreach ($managers as $managerName) {
             $manager = $this->registry->getManager($managerName);


### PR DESCRIPTION
- Updated ManagersSanityChecker and ManagersClearer to return keys returned from getManagerNames.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #548   <!-- #-prefixed issue number(s), if any -->
