### PR TITLE
[EasyAsync] ManagersSanityChecker - fetchAllAssociative instead of executeStatement

### DIFF
--- a/packages/EasyAsync/src/Doctrine/ManagersSanityChecker.php
+++ b/packages/EasyAsync/src/Doctrine/ManagersSanityChecker.php
@@ -67,7 +67,7 @@ final class ManagersSanityChecker
         // Check connection ok
         try {
             $conn = $entityManager->getConnection();
-            $conn->executeStatement($conn->getDatabasePlatform()->getDummySelectSQL());
+            $conn->fetchAllAssociative($conn->getDatabasePlatform()->getDummySelectSQL());
         } catch (\Throwable $throwable) {
             throw new DoctrineConnectionNotOkException(
                 \sprintf('Connection for manager "%s" not ok: %s', $name, $throwable->getMessage()),

--- a/packages/EasyAsync/tests/Doctrine/ManagersSanityCheckerTest.php
+++ b/packages/EasyAsync/tests/Doctrine/ManagersSanityCheckerTest.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace EonX\EasyAsync\Tests\Doctrine;
 
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\Persistence\Mapping\Driver\PHPDriver;
 use EonX\EasyAsync\Doctrine\Exceptions\DoctrineConnectionNotOkException;
 use EonX\EasyAsync\Doctrine\Exceptions\DoctrineManagerClosedException;
 use EonX\EasyAsync\Doctrine\ManagersSanityChecker;
-use EonX\EasyAsync\Tests\AbstractTestCase;
+use EonX\EasyAsync\Tests\AbstractStoreTestCase;
 use EonX\EasyAsync\Tests\Doctrine\Stubs\EntityManagerForSanityStub;
 use EonX\EasyAsync\Tests\Doctrine\Stubs\ManagerRegistryStub;
 
-final class ManagersSanityCheckerTest extends AbstractTestCase
+final class ManagersSanityCheckerTest extends AbstractStoreTestCase
 {
     public function testEntityManagerClosed(): void
     {
@@ -33,5 +36,24 @@ final class ManagersSanityCheckerTest extends AbstractTestCase
         ]);
 
         (new ManagersSanityChecker($registry))->checkSanity();
+    }
+
+    public function testWithRealDoctrineConnection(): void
+    {
+        $config = new Configuration();
+        $config->setMetadataDriverImpl(new PHPDriver(__DIR__));
+        $config->setProxyDir(__DIR__);
+        $config->setProxyNamespace('proxies');
+
+        $conn = $this->getDoctrineDbalConnection();
+        $entityManager = EntityManager::create($conn, $config);
+
+        $registry = new ManagerRegistryStub([
+            'default' => $entityManager,
+        ]);
+
+        (new ManagersSanityChecker($registry))->checkSanity();
+
+        self::assertTrue(true);
     }
 }

--- a/packages/EasyAsync/tests/Doctrine/Stubs/ManagerRegistryStub.php
+++ b/packages/EasyAsync/tests/Doctrine/Stubs/ManagerRegistryStub.php
@@ -86,7 +86,14 @@ final class ManagerRegistryStub implements ManagerRegistry
      */
     public function getManagerNames(): array
     {
-        return \array_keys($this->managers);
+        $return = [];
+
+        // To reproduce doctrine behavior
+        foreach ($this->managers as $name => $manager) {
+            $return[$name] = \get_class($manager);
+        }
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yno <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #554    <!-- #-prefixed issue number(s), if any -->
