### PR TITLE
[EasyWebhook] Move SendAfterMiddleware to core after middleware so http client options are populated

### DIFF
--- a/packages/EasyWebhook/docs/middleware.md
+++ b/packages/EasyWebhook/docs/middleware.md
@@ -172,7 +172,6 @@ The following table show the middleware stack in priority order, with summaries 
 | ---------- | --------------------------- | ---------------------- |
 | *Begin initial core middleware* | | |
 | `LockMiddleware` | Lock webhook | Unlock webhook |
-| `SendAfterMiddleware` | If time is before `$sendAfter`, store webhook and return up stack<br/>If time is after `$sendAfter`, continue down stack | |
 | `RerunMiddleware` | If rerun allowed, reset status and current attempt<br/>If not allowed, throw exception | |
 | *End initial core middleware* | | |
 | *Begin custom middleware*<br/>*(processed in priority order)* | | |
@@ -183,6 +182,7 @@ The following table show the middleware stack in priority order, with summaries 
 | Custom middleware | Custom pre-processing | Custom post-processing |
 | *End custom middleware* | | |
 | *Begin final core middleware* | | |
+| `SendAfterMiddleware` | If time is before `$sendAfter`, store webhook and return up stack<br/>If time is after `$sendAfter`, continue down stack | |
 | `ResetStoreMiddleware` | Reset webhook and result stores | |
 | `MethodMiddleware` | Set request method | |
 | `AsyncMiddleware` | If asynchronous, store webhook and return up stack<br/>If synchronous, continue down stack | |

--- a/packages/EasyWebhook/src/Bridge/Laravel/EasyWebhookServiceProvider.php
+++ b/packages/EasyWebhook/src/Bridge/Laravel/EasyWebhookServiceProvider.php
@@ -101,21 +101,21 @@ final class EasyWebhookServiceProvider extends ServiceProvider
                     MiddlewareInterface::PRIORITY_CORE_BEFORE - 2
                 );
             },
-            SendAfterMiddleware::class => static function (Container $app): SendAfterMiddleware {
-                return new SendAfterMiddleware(
-                    $app->make(StoreInterface::class),
-                    MiddlewareInterface::PRIORITY_CORE_BEFORE - 1
-                );
-            },
             RerunMiddleware::class => static function (): RerunMiddleware {
                 return new RerunMiddleware(MiddlewareInterface::PRIORITY_CORE_BEFORE);
             },
             // AFTER MIDDLEWARE
+            SendAfterMiddleware::class => static function (Container $app): SendAfterMiddleware {
+                return new SendAfterMiddleware(
+                    $app->make(StoreInterface::class),
+                    MiddlewareInterface::PRIORITY_CORE_AFTER
+                );
+            },
             ResetStoreMiddleware::class => static function (Container $app): ResetStoreMiddleware {
                 return new ResetStoreMiddleware(
                     $app->make(StoreInterface::class),
                     $app->make(ResultStoreInterface::class),
-                    MiddlewareInterface::PRIORITY_CORE_AFTER
+                    MiddlewareInterface::PRIORITY_CORE_AFTER + 1
                 );
             },
             MethodMiddleware::class => static function (): MethodMiddleware {

--- a/packages/EasyWebhook/src/Bridge/Symfony/Resources/config/core_middleware.php
+++ b/packages/EasyWebhook/src/Bridge/Symfony/Resources/config/core_middleware.php
@@ -31,17 +31,17 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 2);
 
     $services
-        ->set(SendAfterMiddleware::class)
-        ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 1);
-
-    $services
         ->set(RerunMiddleware::class)
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE);
 
     // AFTER MIDDLEWARE
     $services
-        ->set(ResetStoreMiddleware::class)
+        ->set(SendAfterMiddleware::class)
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_AFTER);
+
+    $services
+        ->set(ResetStoreMiddleware::class)
+        ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_AFTER + 1);
 
     $services
         ->set(MethodMiddleware::class)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -112,9 +112,6 @@ parameters:
         - message: '#Method EonX\\EasyPagination\\Tests\\AbstractWithMockTestCase\:\:mock\(\) should return Mockery\\MockInterface but returns Mockery\\LegacyMockInterface#'
           path: packages/EasyPagination/tests/AbstractWithMockTestCase.php
 
-        - message: '#Call to an undefined method Doctrine\\DBAL\\Query\\QueryBuilder\|Doctrine\\ORM\\QueryBuilder\:\:getQuery\(\)#'
-          path: packages/EasyPagination/src/Traits/DoctrinePaginatorTrait.php
-
         - '#Parameter \#1 \$queryBuilder of method EonX\\EasyPagination\\Paginators\\Doctrine(Dbal|Orm)LengthAwarePaginator::doGet(TotalItems|Result)\(\) expects Doctrine\\(ORM|DBAL\\Query)\\QueryBuilder, Doctrine\\DBAL\\Query\\QueryBuilder\|Doctrine\\ORM\\QueryBuilder given.#'
         - '#Method EonX\\EasyPagination\\Paginators\\Doctrine(Dbal|Orm)LengthAwarePaginator::createQueryBuilder\(\) never returns Doctrine\\(ORM|DBAL\\Query)\\QueryBuilder so it can be removed from the return typehint.#'
         - '#Parameter \#2 \$alias of method Doctrine\\ORM\\QueryBuilder\:\:from\(\) expects string, string\|null given#'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
