### PR TITLE
[EasyPaginator] Fix getTotalItems for Doctrine paginator when no fromAlias

### DIFF
--- a/packages/EasyPagination/src/Traits/DoctrinePaginatorTrait.php
+++ b/packages/EasyPagination/src/Traits/DoctrinePaginatorTrait.php
@@ -49,7 +49,8 @@ trait DoctrinePaginatorTrait
 
         $fromAlias = $this->getFromAlias(true);
         $countAlias = \sprintf('_count_%s', $fromAlias);
-        $sql = \sprintf('COUNT(DISTINCT %s) as %s', $fromAlias, $countAlias);
+        $countSelect = $fromAlias !== '1' ? \sprintf('DISTINCT %s', $fromAlias) : $fromAlias;
+        $sql = \sprintf('COUNT(%s) as %s', $countSelect, $countAlias);
 
         $queryBuilder = $this->createQueryBuilder()
             ->select($sql);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
