### PR TITLE
[EasyBatch] Fix issues (injected dispatcher, table field name)

### DIFF
--- a/packages/EasyBatch/src/Bridge/Doctrine/DbalStatementsProvider.php
+++ b/packages/EasyBatch/src/Bridge/Doctrine/DbalStatementsProvider.php
@@ -93,7 +93,7 @@ final class DbalStatementsProvider
         $batchesTable->addColumn('throwable', 'text', [
             'notNull' => false,
         ]);
-        $batchesTable->addColumn('batch_item_id', 'guid', [
+        $batchesTable->addColumn('parent_batch_item_id', 'guid', [
             'notNull' => false,
         ]);
         $batchesTable->addColumn('created_at', 'datetime');

--- a/packages/EasyBatch/src/Bridge/Symfony/Messenger/DispatchBatchMiddleware.php
+++ b/packages/EasyBatch/src/Bridge/Symfony/Messenger/DispatchBatchMiddleware.php
@@ -16,11 +16,11 @@ final class DispatchBatchMiddleware implements MiddlewareInterface
     /**
      * @var \EonX\EasyBatch\Interfaces\BatchDispatcherInterface
      */
-    private $dispatcher;
+    private $batchDispatcher;
 
-    public function __construct(BatchDispatcherInterface $dispatcher)
+    public function __construct(BatchDispatcherInterface $batchDispatcher)
     {
-        $this->dispatcher = $dispatcher;
+        $this->batchDispatcher = $batchDispatcher;
     }
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
@@ -30,7 +30,7 @@ final class DispatchBatchMiddleware implements MiddlewareInterface
             $message = $envelope->getMessage();
 
             if ($message instanceof BatchInterface) {
-                $this->dispatcher->dispatch($message);
+                $this->batchDispatcher->dispatch($message);
 
                 // Do not proceed with normal flow, handled by the batch dispatcher
                 return $envelope;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |    <!-- #-prefixed issue number(s), if any -->

- fix database field name (`batch_item_id` -> `parent_batch_item_id`) in `EonX\EasyBatch\Bridge\Doctrine\DbalStatementsProvider`
- fix injected to `EonX\EasyBatch\Bridge\Symfony\Messenger\DispatchBatchMiddleware` dispatcher by renaming variable `$dispatcher` to `$batchDispatcher` (`$dispatcher` binded to `EasyEventDispatcherInterface`)