### PR TITLE
[EasyLock] Add monolog.logger tag to lock service for symfony for dedicated channel

### DIFF
--- a/packages/EasyLock/src/Bridge/BridgeConstantsInterface.php
+++ b/packages/EasyLock/src/Bridge/BridgeConstantsInterface.php
@@ -9,6 +9,11 @@ interface BridgeConstantsInterface
     /**
      * @var string
      */
+    public const LOG_CHANNEL = 'lock';
+
+    /**
+     * @var string
+     */
     public const PARAM_CONNECTION = 'easy_lock.param.connection';
 
     /**

--- a/packages/EasyLock/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyLock/src/Bridge/Symfony/Resources/config/services.php
@@ -14,5 +14,6 @@ return static function (ContainerConfigurator $container): void {
 
     $services
         ->set(LockServiceInterface::class, LockService::class)
-        ->args([ref(BridgeConstantsInterface::SERVICE_STORE), ref(LoggerInterface::class)]);
+        ->args([ref(BridgeConstantsInterface::SERVICE_STORE), ref(LoggerInterface::class)])
+        ->tag('monolog.logger', ['channel' => BridgeConstantsInterface::LOG_CHANNEL]);
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
