### PR TITLE
[EasyWebhook] Explicitly use http 1.1 in default http client

### DIFF
--- a/packages/EasyWebhook/src/HttpClientFactory.php
+++ b/packages/EasyWebhook/src/HttpClientFactory.php
@@ -12,6 +12,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 {
     public function create(): HttpClientInterface
     {
-        return HttpClient::create();
+        return HttpClient::create([
+            'http_version' => '1.1',
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
