### PR TITLE
[EasyCore] DeferredEntityEventDispatcher service

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyCore/src/Bridge/Symfony/Resources/config/services.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use EonX\EasyCore\Bridge\Symfony\Env\ForBuildEnvVarProcessor;
 use EonX\EasyCore\Bridge\Symfony\Messenger\StopWorkerOnEmClosedEventListener;
+use EonX\EasyCore\Doctrine\Dispatchers\DeferredEntityEventDispatcher;
+use EonX\EasyCore\Doctrine\Dispatchers\DeferredEntityEventDispatcherInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -19,4 +21,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('kernel.event_listener');
 
     $services->set(ForBuildEnvVarProcessor::class);
+
+    $services->set(DeferredEntityEventDispatcherInterface::class, DeferredEntityEventDispatcher::class);
 };

--- a/packages/EasyCore/tests/Doctrine/Subscribers/EntityEventSubscriberTest.php
+++ b/packages/EasyCore/tests/Doctrine/Subscribers/EntityEventSubscriberTest.php
@@ -35,11 +35,14 @@ final class EntityEventSubscriberTest extends AbstractTestCase
     {
         $newEntity = $this->prophesize(stdClass::class)->reveal();
         $existedEntity = $this->prophesize(stdClass::class)->reveal();
+        $notAcceptableEntity = $this->prophesize(stdClass::class)
+            ->willImplement(EntityManagerInterface::class)
+            ->reveal();
         $unitOfWork = $this->prophesize(UnitOfWork::class);
         $unitOfWork->getScheduledEntityInsertions()
-            ->willReturn([$newEntity]);
+            ->willReturn([$newEntity, $notAcceptableEntity]);
         $unitOfWork->getScheduledEntityUpdates()
-            ->willReturn([$existedEntity]);
+            ->willReturn([$existedEntity, $notAcceptableEntity]);
         $connection = $this->prophesize(Connection::class);
         $connection->getTransactionNestingLevel()
             ->willReturn(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | PLU-3387   <!-- #-prefixed issue number(s), if any -->

- Register `DeferredEntityEventDispatcher` service
- return filtering logic to the `\EonX\EasyCore\Doctrine\Subscribers\EntityEventSubscriber`