### PR TITLE
[EasyBugsnag] Use cache channel for bugsnag session cache

### DIFF
--- a/packages/EasyBugsnag/src/Bridge/Symfony/Resources/config/sessions.php
+++ b/packages/EasyBugsnag/src/Bridge/Symfony/Resources/config/sessions.php
@@ -21,7 +21,8 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(BridgeConstantsInterface::SERVICE_SESSION_TRACKING_CACHE, PhpFilesAdapter::class)
         ->arg('$namespace', '%' . BridgeConstantsInterface::PARAM_SESSION_TRACKING_CACHE_NAMESPACE . '%')
-        ->arg('$directory', '%' . BridgeConstantsInterface::PARAM_SESSION_TRACKING_CACHE_DIRECTORY . '%');
+        ->arg('$directory', '%' . BridgeConstantsInterface::PARAM_SESSION_TRACKING_CACHE_DIRECTORY . '%')
+        ->tag('monolog.logger', ['channel' => 'cache']);
 
     $services
         ->set(SessionTracker::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #624 
