### PR TITLE
[EasyLogging] JsonFormatter which explicitly formats DateTimes

### DIFF
--- a/packages/EasyLogging/src/Formatters/JsonFormatter.php
+++ b/packages/EasyLogging/src/Formatters/JsonFormatter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyLogging\Formatters;
+
+use Monolog\Formatter\JsonFormatter as BaseJsonFormatter;
+
+final class JsonFormatter extends BaseJsonFormatter
+{
+    /**
+     * @param mixed $data
+     * @param null|int $depth
+     *
+     * @return mixed
+     */
+    protected function normalize($data, $depth = null)
+    {
+        return parent::normalize($this->formatDateTimes($data), $depth);
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return mixed
+     */
+    private function formatDateTimes($data)
+    {
+        if (\is_array($data)) {
+            foreach ($data as $key => $value) {
+                $data[$key] = $this->formatDateTimes($value);
+            }
+        }
+
+        if ($data instanceof \DateTimeInterface) {
+            return $data->format('Y-m-d\TH:i:sP');
+        }
+
+        return $data;
+    }
+}

--- a/packages/EasyLogging/src/Formatters/SumoJsonFormatter.php
+++ b/packages/EasyLogging/src/Formatters/SumoJsonFormatter.php
@@ -7,6 +7,9 @@ namespace EonX\EasyLogging\Formatters;
 use DateTime;
 use Monolog\Formatter\JsonFormatter;
 
+/**
+ * @deprecated since 3.10, will be removed in 4.0. Use JsonFormatter instead.
+ */
 final class SumoJsonFormatter extends JsonFormatter
 {
     /**

--- a/packages/EasyLogging/tests/Formatters/JsonFormatterTest.php
+++ b/packages/EasyLogging/tests/Formatters/JsonFormatterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyLogging\Tests\Formatters;
+
+use Carbon\Carbon;
+use EonX\EasyLogging\Formatters\JsonFormatter;
+use EonX\EasyLogging\Tests\AbstractTestCase;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+
+final class JsonFormatterTest extends AbstractTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public function providerTestCreateLogFormat(): iterable
+    {
+        yield 'DateTime format' => [
+            static function (Logger $logger): void {
+                $logger->debug('my-message', [
+                    'carbon' => Carbon::createFromFormat('dmY', '06081993'),
+                ]);
+            },
+            static function (string $logContents): void {
+                self::assertJson($logContents);
+
+                $json = \json_decode($logContents, true);
+
+                self::assertInstanceOf(
+                    Carbon::class,
+                    Carbon::createFromFormat('Y-m-d\TH:i:sP', $json['context']['carbon'])
+                );
+            },
+        ];
+    }
+
+    /**
+     * @dataProvider providerTestCreateLogFormat
+     *
+     * @throws \Exception
+     */
+    public function testCreateLogFormat(callable $log, callable $assert): void
+    {
+        $stream = \fopen('php://memory', 'rw+');
+        $handler = (new StreamHandler($stream))->setFormatter(new JsonFormatter());
+        $logger = new Logger('test', [$handler]);
+
+        $log($logger);
+
+        \rewind($stream);
+        $logContents = (string)\fread($stream, 2048);
+        \fclose($stream);
+
+        $assert($logContents);
+    }
+}

--- a/packages/EasyLogging/tests/Formatters/JsonFormatterTest.php
+++ b/packages/EasyLogging/tests/Formatters/JsonFormatterTest.php
@@ -44,6 +44,11 @@ final class JsonFormatterTest extends AbstractTestCase
     public function testCreateLogFormat(callable $log, callable $assert): void
     {
         $stream = \fopen('php://memory', 'rw+');
+
+        if (\is_resource($stream) === false) {
+            return;
+        }
+
         $handler = (new StreamHandler($stream))->setFormatter(new JsonFormatter());
         $logger = new Logger('test', [$handler]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
