### PR TITLE
[EasyAsync] Fixed the DoctrineManagersSanityCheckListener definition

### DIFF
--- a/packages/EasyAsync/src/Bridge/Laravel/Providers/EasyAsyncServiceProvider.php
+++ b/packages/EasyAsync/src/Bridge/Laravel/Providers/EasyAsyncServiceProvider.php
@@ -171,7 +171,7 @@ final class EasyAsyncServiceProvider extends ServiceProvider
             DoctrineManagersSanityCheckListener::class,
             static function (Container $app): DoctrineManagersSanityCheckListener {
                 return new DoctrineManagersSanityCheckListener(
-                    $app->make('cache'),
+                    $app->make('cache.store'),
                     $app->make(ManagersSanityChecker::class),
                     \config('easy-async.queue.managers_to_check'),
                     $app->make(BridgeConstantsInterface::SERVICE_LOGGER)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...

Fixed the `DoctrineManagersSanityCheckListener` definition in the EasyAsyncServiceProvider.
