### PR TITLE
[EasySecurity] Make sure configurator listener runs before Symfony listener

### DIFF
--- a/packages/EasySecurity/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Resources/config/services.php
@@ -75,7 +75,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services
         ->set(FromRequestSecurityContextConfiguratorListener::class)
         ->arg('$configurators', tagged_iterator(BridgeConstantsInterface::TAG_CONTEXT_CONFIGURATOR))
-        ->tag('kernel.event_listener');
+        ->tag('kernel.event_listener', ['priority' => 9999]);
 
     // Resolver
     $securityContextResolver = $services->set(SecurityContextResolverInterface::class, SecurityContextResolver::class);

--- a/packages/EasySecurity/src/Bridge/Symfony/Security/ContextAuthenticator.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Security/ContextAuthenticator.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace EonX\EasySecurity\Bridge\Symfony\Security;
 
 use EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationFailureResponseFactoryInterface;
-use EonX\EasySecurity\Bridge\Symfony\Listeners\FromRequestSecurityContextConfiguratorListener;
 use EonX\EasySecurity\Interfaces\DeferredSecurityContextProviderInterface;
 use EonX\EasySecurity\Interfaces\SecurityContextInterface;
 use EonX\EasySecurity\Interfaces\UserInterface as EonxUserInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -20,11 +18,6 @@ use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 
 final class ContextAuthenticator extends AbstractGuardAuthenticator
 {
-    /**
-     * @var \EonX\EasySecurity\Bridge\Symfony\Listeners\FromRequestSecurityContextConfiguratorListener
-     */
-    private $configuratorListener;
-
     /**
      * @var \EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationFailureResponseFactoryInterface
      */
@@ -37,12 +30,10 @@ final class ContextAuthenticator extends AbstractGuardAuthenticator
 
     public function __construct(
         DeferredSecurityContextProviderInterface $securityContextProvider,
-        AuthenticationFailureResponseFactoryInterface $respFactory,
-        FromRequestSecurityContextConfiguratorListener $configuratorListener
+        AuthenticationFailureResponseFactoryInterface $respFactory
     ) {
         $this->securityContextProvider = $securityContextProvider;
         $this->responseFactory = $respFactory;
-        $this->configuratorListener = $configuratorListener;
     }
 
     /**
@@ -55,10 +46,6 @@ final class ContextAuthenticator extends AbstractGuardAuthenticator
 
     public function getCredentials(Request $request): SecurityContextInterface
     {
-        // Fake event to trigger configurator for given request
-        $event = new RequestEvent(new FakeKernel(), $request, 1);
-        $this->configuratorListener->__invoke($event);
-
         return $this->securityContextProvider->getSecurityContext();
     }
 

--- a/packages/EasySecurity/src/Bridge/Symfony/Security/SecurityContextAuthenticator.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Security/SecurityContextAuthenticator.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace EonX\EasySecurity\Bridge\Symfony\Security;
 
 use EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationFailureResponseFactoryInterface;
-use EonX\EasySecurity\Bridge\Symfony\Listeners\FromRequestSecurityContextConfiguratorListener;
 use EonX\EasySecurity\Interfaces\SecurityContextResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -22,11 +20,6 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 final class SecurityContextAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface
 {
     /**
-     * @var \EonX\EasySecurity\Bridge\Symfony\Listeners\FromRequestSecurityContextConfiguratorListener
-     */
-    private $configuratorListener;
-
-    /**
      * @var \EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationFailureResponseFactoryInterface
      */
     private $responseFactory;
@@ -38,21 +31,15 @@ final class SecurityContextAuthenticator extends AbstractAuthenticator implement
 
     public function __construct(
         SecurityContextResolverInterface $securityContextResolver,
-        AuthenticationFailureResponseFactoryInterface $respFactory,
-        FromRequestSecurityContextConfiguratorListener $configuratorListener
+        AuthenticationFailureResponseFactoryInterface $respFactory
     ) {
         $this->securityContextResolver = $securityContextResolver;
         $this->responseFactory = $respFactory;
-        $this->configuratorListener = $configuratorListener;
     }
 
     public function authenticate(Request $request): PassportInterface
     {
         try {
-            // Fake event to trigger configurator for given request
-            $event = new RequestEvent(new FakeKernel(), $request, 1);
-            $this->configuratorListener->__invoke($event);
-
             $user = $this->securityContextResolver
                 ->resolveContext()
                 ->getUserOrFail();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
