### PR TITLE
[EasyAsync] Move Laravel queue listeners from easy-core to easy-async

### DIFF
--- a/packages/EasyAsync/src/Bridge/Laravel/Queue/QueueWorkerStoppingListener.php
+++ b/packages/EasyAsync/src/Bridge/Laravel/Queue/QueueWorkerStoppingListener.php
@@ -2,22 +2,18 @@
 
 declare(strict_types=1);
 
-namespace EonX\EasyCore\Bridge\Laravel\Listeners;
+namespace EonX\EasyAsync\Bridge\Laravel\Queue;
 
 use Illuminate\Queue\Events\WorkerStopping;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-/**
- * @deprecated since 3.3.12, will be removed in 4.0.
- * Use EonX\EasyAsync\Bridge\Laravel\Queue\QueueWorkerStoppingListener instead.
- */
 final class QueueWorkerStoppingListener
 {
     /**
-     * @var mixed[]
+     * @var string[]
      */
-    private static $reasons = [
+    private const REASONS = [
         12 => 'Memory exceeded',
     ];
 
@@ -33,7 +29,7 @@ final class QueueWorkerStoppingListener
 
     public function handle(WorkerStopping $event): void
     {
-        $reason = static::$reasons[$event->status] ?? null;
+        $reason = self::REASONS[$event->status] ?? null;
 
         $this->logger->warning(\sprintf(
             'Worker stopping with status "%s"%s',

--- a/packages/EasyCore/src/Bridge/Laravel/Listeners/DoctrineClearEmBeforeJobListener.php
+++ b/packages/EasyCore/src/Bridge/Laravel/Listeners/DoctrineClearEmBeforeJobListener.php
@@ -9,6 +9,10 @@ use Illuminate\Queue\Events\JobProcessing;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
+/**
+ * @deprecated since 3.3.12, will be removed in 4.0.
+ * Use EonX\EasyAsync\Bridge\Laravel\Queue\DoctrineManagersClearListener instead.
+ */
 final class DoctrineClearEmBeforeJobListener
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Fixes #712 
