### PR TITLE
[EasyCore] Make sure DeferredEntityEventDispatcher dispatches one event per entity

### DIFF
--- a/packages/EasyCore/src/Doctrine/Dispatchers/DeferredEntityEventDispatcher.php
+++ b/packages/EasyCore/src/Doctrine/Dispatchers/DeferredEntityEventDispatcher.php
@@ -102,13 +102,23 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
             return;
         }
 
-        \array_walk_recursive($entityInsertions, function (object $entity): void {
-            $this->eventDispatcher->dispatch(new EntityCreatedEvent($entity));
-        });
+        $processedEntities = [];
+        foreach ($entityInsertions as $entities) {
+            foreach ($entities as $oid => $entity) {
+                $processedEntities[$oid] = $entity;
+                $this->eventDispatcher->dispatch(new EntityCreatedEvent($entity));
+            }
+        }
 
-        \array_walk_recursive($entityUpdates, function (object $entity): void {
-            $this->eventDispatcher->dispatch(new EntityUpdatedEvent($entity));
-        });
+        foreach ($entityUpdates as $entities) {
+            foreach ($entities as $oid => $entity) {
+                if (\array_key_exists($oid, $processedEntities)) {
+                    continue;
+                }
+                $processedEntities[$oid] = $entity;
+                $this->eventDispatcher->dispatch(new EntityUpdatedEvent($entity));
+            }
+        }
     }
 
     public function enable(): void

--- a/packages/EasyCore/src/Doctrine/Dispatchers/DeferredEntityEventDispatcher.php
+++ b/packages/EasyCore/src/Doctrine/Dispatchers/DeferredEntityEventDispatcher.php
@@ -112,7 +112,7 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
 
         foreach ($entityUpdates as $entities) {
             foreach ($entities as $oid => $entity) {
-                if (\array_key_exists($oid, $processedEntities)) {
+                if (isset($processedEntities[$oid])) {
                     continue;
                 }
                 $processedEntities[$oid] = $entity;

--- a/packages/EasyCore/tests/Doctrine/Dispatchers/DeferredEntityEventDispatcherTest.php
+++ b/packages/EasyCore/tests/Doctrine/Dispatchers/DeferredEntityEventDispatcherTest.php
@@ -278,8 +278,6 @@ final class DeferredEntityEventDispatcherTest extends AbstractTestCase
         $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
         $eventDispatcher->dispatch($entityCreatedEvent)
             ->willReturnArgument(0);
-        $eventDispatcher->dispatch($entityUpdatedEvent)
-            ->willReturnArgument(0);
         /** @var \Psr\EventDispatcher\EventDispatcherInterface $eventDispatcherReveal */
         $eventDispatcherReveal = $eventDispatcher->reveal();
         $deferredEntityEventDispatcher = new DeferredEntityEventDispatcher($eventDispatcherReveal);


### PR DESCRIPTION
In the easy-core package we have the `\EonX\EasyCore\Doctrine\Dispatchers\DeferredEntityEventDispatcher` event dispatcher that allows us to dispatch the `\EonX\EasyCore\Doctrine\Events\EntityCreatedEvent` and `\EonX\EasyCore\Doctrine\Events\EntityUpdatedEvent` events when an entity really saved in a database. But we have found a problem with this dispatcher.

Let’s imagine the following flow:
* Begin a transaction.
* Create an entity and flush it.
* Update the entity and flush.
* Update the entity again and flush.
* Commit the transaction.

When the transaction will be committed our dispatcher will dispatch 3 events: one `EntityCreatedEvent` and two `EntityUpdatedEvent`. It’s wrong because in terms of the database we have created the entity and that's all. The same for the regular updates. If we update and flush some entity many times inside a transaction then we should dispatch only one `EntityUpdatedEvent` event after the transaction will be committed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes