### PR TITLE
[EasyDecision] Fix filter rules in AddRulesDecisionConfigurator

### DIFF
--- a/packages/EasyDecision/src/Configurators/AddRulesDecisionConfigurator.php
+++ b/packages/EasyDecision/src/Configurators/AddRulesDecisionConfigurator.php
@@ -23,7 +23,7 @@ final class AddRulesDecisionConfigurator extends AbstractConfigurator
     {
         parent::__construct($priority);
 
-        $this->rules = CollectorHelper::filterByClass($rules, RuleInterface::class);
+        $this->rules = CollectorHelper::filterByClassAsArray($rules, RuleInterface::class);
     }
 
     public function configure(DecisionInterface $decision): void


### PR DESCRIPTION
**Context**

When creating multiple decisions using `DecisionFactory`, we're getting `Cannot traverse an already closed generator`

**Solution**

Use `filterByClassAsArray` in `AddRulesDecisionConfigurator` to allow multiple calls in `DecisionFactory::createXXX` to create multiple decisions to make and execute.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
