### PR TITLE
[EasyCore] Allow square brackets in VirtualSearchFilter

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Filter/VirtualSearchFilter.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Filter/VirtualSearchFilter.php
@@ -15,8 +15,8 @@ use Doctrine\ORM\QueryBuilder;
  * ApiFilter(
  *     VirtualSearchFilter::class,
  *     properties={
- *         "number_partial": {"number": "ipartial"}, --> Virtual search property to number partial
- *         "number_exact": {"number": "exact"}, --> Virtual search property to number exact
+ *         "number[partial]": {"number": "ipartial"}, --> Virtual search property to number partial
+ *         "number[exact]": {"number": "exact"}, --> Virtual search property to number exact
  *         "email": "ipartial" --> Normal search property definition
  *     }
  * )
@@ -117,6 +117,12 @@ final class VirtualSearchFilter extends SearchFilter
         // Keep virtual properties on private property because parent uses `$properties`
         if ($this->virtualProperties === null) {
             $this->virtualProperties = $this->properties ?? [];
+        }
+
+        // Allow square brackets in filter property
+        if (\is_array($value)) {
+            $property .= '[' . \array_keys($value)[0] . ']';
+            $value = \array_values($value)[0];
         }
 
         $props = $this->virtualProperties[$property] ?? null;


### PR DESCRIPTION
If we allow square brackets in filter property it will look great in docs and will be consistent with DateFilter.

<img src="https://user-images.githubusercontent.com/6824784/135093141-47741df1-0563-4196-b3ed-d3da162de272.png" width="44%"> <img src="https://user-images.githubusercontent.com/6824784/135093143-3925dff7-ac6e-4000-af24-172caaedf905.png" width="44%">


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
