### PR TITLE
[EasyWebhook] Change priority of EventsMiddleware

### DIFF
--- a/packages/EasyWebhook/src/Bridge/Laravel/EasyWebhookServiceProvider.php
+++ b/packages/EasyWebhook/src/Bridge/Laravel/EasyWebhookServiceProvider.php
@@ -111,22 +111,22 @@ final class EasyWebhookServiceProvider extends ServiceProvider
                     MiddlewareInterface::PRIORITY_CORE_BEFORE - 5
                 );
             },
+            EventsMiddleware::class => static function (Container $app): EventsMiddleware {
+                return new EventsMiddleware(
+                    $app->make(EventDispatcherInterface::class),
+                    MiddlewareInterface::PRIORITY_CORE_BEFORE - 4
+                );
+            },
             StatusAndAttemptMiddleware::class => static function (): StatusAndAttemptMiddleware {
-                return new StatusAndAttemptMiddleware(MiddlewareInterface::PRIORITY_CORE_BEFORE - 4);
+                return new StatusAndAttemptMiddleware(MiddlewareInterface::PRIORITY_CORE_BEFORE - 3);
             },
             HandleExceptionsMiddleware::class => static function (): HandleExceptionsMiddleware {
-                return new HandleExceptionsMiddleware(MiddlewareInterface::PRIORITY_CORE_BEFORE - 3);
+                return new HandleExceptionsMiddleware(MiddlewareInterface::PRIORITY_CORE_BEFORE - 2);
             },
             ResetStoreMiddleware::class => static function (Container $app): ResetStoreMiddleware {
                 return new ResetStoreMiddleware(
                     $app->make(StoreInterface::class),
                     $app->make(ResultStoreInterface::class),
-                    MiddlewareInterface::PRIORITY_CORE_BEFORE - 2
-                );
-            },
-            EventsMiddleware::class => static function (Container $app): EventsMiddleware {
-                return new EventsMiddleware(
-                    $app->make(EventDispatcherInterface::class),
                     MiddlewareInterface::PRIORITY_CORE_BEFORE - 1
                 );
             },

--- a/packages/EasyWebhook/src/Bridge/Symfony/Resources/config/core_middleware.php
+++ b/packages/EasyWebhook/src/Bridge/Symfony/Resources/config/core_middleware.php
@@ -35,19 +35,19 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 5);
 
     $services
-        ->set(StatusAndAttemptMiddleware::class)
+        ->set(EventsMiddleware::class)
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 4);
 
     $services
-        ->set(HandleExceptionsMiddleware::class)
+        ->set(StatusAndAttemptMiddleware::class)
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 3);
 
     $services
-        ->set(ResetStoreMiddleware::class)
+        ->set(HandleExceptionsMiddleware::class)
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 2);
 
     $services
-        ->set(EventsMiddleware::class)
+        ->set(ResetStoreMiddleware::class)
         ->arg('$priority', MiddlewareInterface::PRIORITY_CORE_BEFORE - 1);
 
     $services


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Doing functional testing I noticed that events never fire. I think the problem is in the status updating process. In the current implementation, EventsMiddleware checks status before StatusAndAttemptMiddleware has done its work. So I offer to change this priority.

