### PR TITLE
[EasyDoctrine] Add EntityDeletedEvent

### DIFF
--- a/packages/EasyActivity/src/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriber.php
+++ b/packages/EasyActivity/src/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriber.php
@@ -7,6 +7,7 @@ namespace EonX\EasyActivity\Bridge\EasyDoctrine;
 use EonX\EasyActivity\ActivityLogEntry;
 use EonX\EasyActivity\Interfaces\ActivityLoggerInterface;
 use EonX\EasyDoctrine\Events\EntityCreatedEvent;
+use EonX\EasyDoctrine\Events\EntityDeletedEvent;
 use EonX\EasyDoctrine\Events\EntityUpdatedEvent;
 
 final class EasyDoctrineEntityEventsSubscriber implements EasyDoctrineEntityEventsSubscriberInterface
@@ -31,6 +32,7 @@ final class EasyDoctrineEntityEventsSubscriber implements EasyDoctrineEntityEven
     {
         return [
             EntityCreatedEvent::class => ['onCreate'],
+            EntityDeletedEvent::class => ['onDelete'],
             EntityUpdatedEvent::class => ['onUpdate'],
         ];
     }
@@ -48,6 +50,11 @@ final class EasyDoctrineEntityEventsSubscriber implements EasyDoctrineEntityEven
     public function onCreate(EntityCreatedEvent $event): void
     {
         $this->dispatchLogEntry(ActivityLogEntry::ACTION_CREATE, $event->getEntity(), $event->getChangeSet());
+    }
+
+    public function onDelete(EntityDeletedEvent $event): void
+    {
+        $this->dispatchLogEntry(ActivityLogEntry::ACTION_DELETE, $event->getEntity(), $event->getChangeSet());
     }
 
     public function onUpdate(EntityUpdatedEvent $event): void

--- a/packages/EasyDoctrine/src/Dispatchers/DeferredEntityEventDispatcher.php
+++ b/packages/EasyDoctrine/src/Dispatchers/DeferredEntityEventDispatcher.php
@@ -95,7 +95,8 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
         }
 
         $oid = \spl_object_hash($object);
-        $this->entityDeletions[$oid] = $object;
+        // `clone` is used to preserve the identifier that is removed after deleting entity
+        $this->entityDeletions[$oid] = clone $object;
         $this->entityChangeSets[$transactionNestingLevel][$oid] = $entityChangeSet;
     }
 
@@ -168,7 +169,7 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
      * @param string $oid
      * @param array<string, array{mixed, mixed}> $entityChangeSet
      *
-     * @return \EonX\EasyDoctrine\Events\EntityCreatedEvent|\EonX\EasyDoctrine\Events\EntityUpdatedEvent|\EonX\EasyDoctrine\Events\EntityDeletedEvent
+     * @return \EonX\EasyDoctrine\Events\EntityActionEventInterface
      */
     private function createEntityEvent(string $oid, array $entityChangeSet)
     {

--- a/packages/EasyDoctrine/src/Dispatchers/DeferredEntityEventDispatcherInterface.php
+++ b/packages/EasyDoctrine/src/Dispatchers/DeferredEntityEventDispatcherInterface.php
@@ -13,6 +13,13 @@ interface DeferredEntityEventDispatcherInterface
      * @param object $object
      * @param array<string, array{mixed, mixed}> $entityChangeSet
      */
+    public function deferDelete(int $transactionNestingLevel, object $object, array $entityChangeSet): void;
+
+    /**
+     * @param int $transactionNestingLevel
+     * @param object $object
+     * @param array<string, array{mixed, mixed}> $entityChangeSet
+     */
     public function deferInsert(int $transactionNestingLevel, object $object, array $entityChangeSet): void;
 
     /**

--- a/packages/EasyDoctrine/src/Events/EntityActionEventInterface.php
+++ b/packages/EasyDoctrine/src/Events/EntityActionEventInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyDoctrine\Events;
+
+interface EntityActionEventInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getChangeSet(): array;
+
+    public function getEntity(): object;
+}

--- a/packages/EasyDoctrine/src/Events/EntityCreatedEvent.php
+++ b/packages/EasyDoctrine/src/Events/EntityCreatedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Events;
 
-final class EntityCreatedEvent
+final class EntityCreatedEvent implements EntityActionEventInterface
 {
     /**
      * @var array<string, mixed>
@@ -27,7 +27,7 @@ final class EntityCreatedEvent
     }
 
     /**
-     * @return array<string, mixed>
+     * @inheritdoc
      */
     public function getChangeSet(): array
     {

--- a/packages/EasyDoctrine/src/Events/EntityDeletedEvent.php
+++ b/packages/EasyDoctrine/src/Events/EntityDeletedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Events;
 
-final class EntityDeletedEvent
+final class EntityDeletedEvent implements EntityActionEventInterface
 {
     /**
      * @var array<string, mixed>
@@ -27,7 +27,7 @@ final class EntityDeletedEvent
     }
 
     /**
-     * @return array<string, mixed>
+     * @inheritdoc
      */
     public function getChangeSet(): array
     {

--- a/packages/EasyDoctrine/src/Events/EntityDeletedEvent.php
+++ b/packages/EasyDoctrine/src/Events/EntityDeletedEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyDoctrine\Events;
+
+final class EntityDeletedEvent
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private $changeSet;
+
+    /**
+     * @var object
+     */
+    private $entity;
+
+    /**
+     * @param object $entity
+     * @param array<string, mixed> $changeSet
+     */
+    public function __construct(object $entity, array $changeSet)
+    {
+        $this->entity = $entity;
+        $this->changeSet = $changeSet;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getChangeSet(): array
+    {
+        return $this->changeSet;
+    }
+
+    public function getEntity(): object
+    {
+        return $this->entity;
+    }
+}

--- a/packages/EasyDoctrine/src/Events/EntityUpdatedEvent.php
+++ b/packages/EasyDoctrine/src/Events/EntityUpdatedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Events;
 
-final class EntityUpdatedEvent
+final class EntityUpdatedEvent implements EntityActionEventInterface
 {
     /**
      * @var array<string, mixed>
@@ -27,7 +27,7 @@ final class EntityUpdatedEvent
     }
 
     /**
-     * @return array<string, mixed>
+     * @inheritdoc
      */
     public function getChangeSet(): array
     {

--- a/packages/EasyDoctrine/tests/Events/EntityDeletedEventTest.php
+++ b/packages/EasyDoctrine/tests/Events/EntityDeletedEventTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyDoctrine\Tests\Events;
+
+use EonX\EasyDoctrine\Events\EntityDeletedEvent;
+use EonX\EasyDoctrine\Tests\AbstractTestCase;
+use stdClass;
+
+/**
+ * @covers \EonX\EasyDoctrine\Events\EntityDeletedEvent
+ */
+final class EntityDeletedEventTest extends AbstractTestCase
+{
+    public function testGetChangeSetSucceeds(): void
+    {
+        /** @var object $expectedEntity */
+        $expectedEntity = $this->prophesize(stdClass::class)->reveal();
+        $event = new EntityDeletedEvent($expectedEntity, ['changedField' => '1']);
+
+        $changeSet = $event->getChangeSet();
+
+        self::assertSame(['changedField' => '1'], $changeSet);
+    }
+
+    public function testGetEntitySucceeds(): void
+    {
+        /** @var object $expectedEntity */
+        $expectedEntity = $this->prophesize(stdClass::class)->reveal();
+        $event = new EntityDeletedEvent($expectedEntity, ['changedField' => '1']);
+
+        $actualEntity = $event->getEntity();
+
+        self::assertSame($expectedEntity, $actualEntity);
+    }
+}

--- a/packages/EasyDoctrine/tests/Fixtures/Product.php
+++ b/packages/EasyDoctrine/tests/Fixtures/Product.php
@@ -46,6 +46,11 @@ class Product
         return $this->category;
     }
 
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
     public function getName(): string
     {
         return $this->name;

--- a/packages/EasyDoctrine/tests/Subscribers/EntityEventSubscriberTest.php
+++ b/packages/EasyDoctrine/tests/Subscribers/EntityEventSubscriberTest.php
@@ -392,7 +392,17 @@ final class EntityEventSubscriberTest extends AbstractTestCase
             'category_id' => [1, null],
             'category' => [$product->getCategory(), null],
         ]);
-        self::assertSame($actualEvent->getEntity(), $product);
+        /** @var \EonX\EasyDoctrine\Tests\Fixtures\Product $product */
+        $product = $actualEvent->getEntity();
+        self::assertInstanceOf(Product::class, $product);
+        self::assertSame(1, $product->getId());
+        self::assertSame('Keyboard', $product->getName());
+        self::assertSame('1000', $product->getPrice());
+        self::assertNotNull($product->getCategory());
+        /** @var \EonX\EasyDoctrine\Tests\Fixtures\Category $category */
+        $category = $product->getCategory();
+        self::assertSame(1, $category->getId());
+        self::assertSame('Computer', $category->getName());
     }
 
     public function testOneEventIsDispatchedForMultipleUpdatedEntity(): void


### PR DESCRIPTION
We have the `EonX\EasyDoctrine\Events\EntityCreatedEvent` and `EonX\EasyDoctrine\Events\EntityUpdatedEvent` events. Now we also need to know about deleted entities.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
