### PR TITLE
feature/PLU-4035-disable-datetime-comments-generation-in-migrations

### DIFF
--- a/packages/EasyDoctrine/src/DBAL/Types/DateTimeImmutableMicrosecondsType.php
+++ b/packages/EasyDoctrine/src/DBAL/Types/DateTimeImmutableMicrosecondsType.php
@@ -101,4 +101,9 @@ final class DateTimeImmutableMicrosecondsType extends DateTimeImmutableType
 
         return self::FORMAT_DB_DATETIME;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
* disable doctrine comments generation for "datetime" type in migrations

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->


As we use "datetime" name for DateTimeImmutable type for doctrine. It will be better to disable comments generations for datetime type.