### PR TITLE
[EasyActivity] Fix 'easy_activity.serializer' service registration

### DIFF
--- a/packages/EasyActivity/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Resources/config/services.php
@@ -22,7 +22,6 @@ use EonX\EasyActivity\Interfaces\StoreInterface;
 use EonX\EasyActivity\Logger\AsyncActivityLogger;
 use EonX\EasyActivity\Resolvers\DefaultActivitySubjectResolver;
 use EonX\EasyActivity\Resolvers\DefaultActorResolver;
-use Symfony\Component\Serializer\SerializerInterface;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -48,7 +47,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(ActivityLoggerInterface::class, AsyncActivityLogger::class);
 
     $services
-        ->set(BridgeConstantsInterface::SERVICE_SERIALIZER, SerializerInterface::class);
+        ->alias(BridgeConstantsInterface::SERVICE_SERIALIZER, 'serializer');
 
     $services
         ->set(ActivitySubjectDataSerializerInterface::class, SymfonyActivitySubjectDataSerializer::class)


### PR DESCRIPTION
Now an application must register `easy_activity.serializer` service. Otherwise, the error `Cannot instantiate interface Symfony\Component\Serializer\SerializerInterface` occurs.

The package should provide a default implementation for `easy_activity.serializer`.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
