### PR TITLE
[EasyActivity] Codestyle fix

### DIFF
--- a/packages/EasyActivity/src/ActivitySubject.php
+++ b/packages/EasyActivity/src/ActivitySubject.php
@@ -34,16 +34,16 @@ final class ActivitySubject implements ActivitySubjectInterface
     private $type;
 
     /**
-     * @param list<string>|array<string, list<string>> $allowedProperties
      * @param list<string> $disallowedProperties
      * @param array<string, list<string>> $nestedObjectAllowedProperties
+     * @param list<string>|array<string, list<string>>|null $allowedProperties
      */
     public function __construct(
         string $id,
         string $type,
-        ?array $allowedProperties,
         array $disallowedProperties,
-        array $nestedObjectAllowedProperties
+        array $nestedObjectAllowedProperties,
+        ?array $allowedProperties = null
     ) {
         $this->id = $id;
         $this->type = $type;

--- a/packages/EasyActivity/src/Resolvers/DefaultActivitySubjectResolver.php
+++ b/packages/EasyActivity/src/Resolvers/DefaultActivitySubjectResolver.php
@@ -49,9 +49,9 @@ final class DefaultActivitySubjectResolver implements ActivitySubjectResolverInt
         return new ActivitySubject(
             (string)$object->getId(),
             $subjectConfig['type'] ?? $subjectClass,
-            $allowedProperties,
             $subjectConfig['disallowed_properties'] ?? [],
-            $subjectConfig['nested_object_allowed_properties'] ?? []
+            $subjectConfig['nested_object_allowed_properties'] ?? [],
+            $allowedProperties
         );
     }
 }

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
@@ -51,7 +51,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
                 'name' => $authorName,
                 'position' => $authorPosition,
             ],
-            'subject' => new ActivitySubject((string)$entityId, Author::class, [], $disallowedProperties, []),
+            'subject' => new ActivitySubject((string)$entityId, Author::class, $disallowedProperties, [], []),
             'disallowedProperties' => null,
             'expectedResult' => '{"name":"John Doe","position":1}',
         ];
@@ -65,7 +65,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
                 'name' => $authorName,
                 'position' => $authorPosition,
             ],
-            'subject' => new ActivitySubject((string)$entityId, Author::class, [], $disallowedProperties, []),
+            'subject' => new ActivitySubject((string)$entityId, Author::class, $disallowedProperties, [], []),
             'disallowedProperties' => null,
             'expectedResult' => null,
         ];
@@ -107,7 +107,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
                 'name' => $authorName,
                 'position' => $authorPosition,
             ],
-            'subject' => new ActivitySubject((string)$entityId, Author::class, null, [], []),
+            'subject' => new ActivitySubject((string)$entityId, Author::class, [], [], null),
             'disallowedProperties' => null,
             'expectedResult' => null,
         ];
@@ -121,7 +121,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
                 'name' => $authorName,
                 'position' => $authorPosition,
             ],
-            'subject' => new ActivitySubject((string)$entityId, Author::class, $allowedProperties, [], []),
+            'subject' => new ActivitySubject((string)$entityId, Author::class, [], [], $allowedProperties),
             'disallowedProperties' => null,
             'expectedResult' => '{"id":1,"name":"John Doe"}',
         ];
@@ -138,7 +138,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
                 'createdAt' => new \DateTimeImmutable(),
                 'id' => $entityId,
             ],
-            'subject' => new ActivitySubject((string)$entityId, Article::class, $allowedProperties, [], []),
+            'subject' => new ActivitySubject((string)$entityId, Article::class, [], [], $allowedProperties),
             'disallowedProperties' => null,
             'expectedResult' => '{"author":{"id":1,"name":"John Doe"},"content":"text"}',
         ];
@@ -161,9 +161,9 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
             'subject' => new ActivitySubject(
                 (string)$entityId,
                 Article::class,
-                $allowedProperties,
                 [],
-                $nestedObjectAllowedProperties
+                $nestedObjectAllowedProperties,
+                $allowedProperties
             ),
             'disallowedProperties' => null,
             'expectedResult' => '{"author":{"name":"John Doe"},"content":"text"}',


### PR DESCRIPTION
As we have a convention to use default `null` value for optional arguments and place them at the end of the arguments list it was decided to change the signature of the `ActivitySubject` constructor

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
