### PR TITLE
[EasyDoctrine] Sort an array (decoded JSON data) by keys in the JsonbType DBAL type.

### DIFF
--- a/packages/EasyDoctrine/composer.json
+++ b/packages/EasyDoctrine/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2 || ^8.0",
+        "ext-json": "*",
         "eonx-com/easy-event-dispatcher": "^3.5",
         "nesbot/carbon": "^1.39 || ^2.22"
     },

--- a/packages/EasyDoctrine/src/DBAL/Types/JsonbType.php
+++ b/packages/EasyDoctrine/src/DBAL/Types/JsonbType.php
@@ -5,27 +5,93 @@ declare(strict_types=1);
 namespace EonX\EasyDoctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\JsonType;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use JsonException;
 
-final class JsonbType extends JsonType
+final class JsonbType extends Type
 {
     /**
      * @var string
      */
-    public const TYPE_NAME = 'JSONB';
+    public const JSONB = 'JSONB';
 
-    public function getName(): string
+    /**
+     * @param mixed $value
+     *
+     * @throws \Doctrine\DBAL\Types\ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
-        return static::TYPE_NAME;
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return \json_encode($value, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw ConversionException::conversionFailedSerialization(
+                $value,
+                $this->getName(),
+                $exception->getMessage()
+            );
+        }
     }
 
     /**
-     * @param mixed[] $fieldDeclaration
+     * @param mixed $value
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @return mixed[]|null
+     *
+     * @throws \Doctrine\DBAL\Types\ConversionException
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
     {
-        return $platform->getDoctrineTypeMapping(static::TYPE_NAME);
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (\is_resource($value)) {
+            $value = \stream_get_contents($value);
+        }
+
+        try {
+            return $this->sortByKey(\json_decode($value, true, 512, \JSON_THROW_ON_ERROR));
+        } catch (JsonException $exception) {
+            throw ConversionException::conversionFailed($value, $this->getName(), $exception);
+        }
+    }
+
+    public function getName(): string
+    {
+        return self::JSONB;
+    }
+
+    /**
+     * @param mixed[] $column
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getDoctrineTypeMapping(self::JSONB);
+    }
+
+    /**
+     * @param mixed[] $array
+     *
+     * @return mixed[]
+     */
+    private function sortByKey(array $array): array
+    {
+        \ksort($array);
+
+        foreach ($array as $key => $value) {
+            if (\is_array($value)) {
+                $array[$key] = $this->sortByKey($value);
+            }
+        }
+
+        return $array;
     }
 }

--- a/packages/EasyDoctrine/src/DBAL/Types/JsonbType.php
+++ b/packages/EasyDoctrine/src/DBAL/Types/JsonbType.php
@@ -41,11 +41,11 @@ final class JsonbType extends Type
     /**
      * @param mixed $value
      *
-     * @return mixed[]|null
+     * @return mixed
      *
      * @throws \Doctrine\DBAL\Types\ConversionException
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if ($value === null || $value === '') {
             return null;

--- a/packages/EasyDoctrine/src/DBAL/Types/JsonbType.php
+++ b/packages/EasyDoctrine/src/DBAL/Types/JsonbType.php
@@ -56,7 +56,9 @@ final class JsonbType extends Type
         }
 
         try {
-            return $this->sortByKey(\json_decode($value, true, 512, \JSON_THROW_ON_ERROR));
+            $decodedValue = \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
+
+            return \is_array($decodedValue) ? $this->sortByKey($decodedValue) : $decodedValue;
         } catch (JsonException $exception) {
             throw ConversionException::conversionFailed($value, $this->getName(), $exception);
         }

--- a/packages/EasyDoctrine/tests/DBAL/Types/JsonbTypeTest.php
+++ b/packages/EasyDoctrine/tests/DBAL/Types/JsonbTypeTest.php
@@ -25,6 +25,22 @@ final class JsonbTypeTest extends AbstractTestCase
         return \array_merge(
             $this->provideConvertToPhpValues(),
             [
+                'multidimensional array phpValue' => [
+                    'phpValue' => [
+                        'key3' => '15',
+                        'key1' => 'value1',
+                        'key4' => 15,
+                        'key2' => false,
+                        'key6' => [
+                            'sub-key-2' => 'bar',
+                            'sub-key-3' => 42,
+                            'sub-key-1' => 'foo',
+                        ],
+                        'key5' => [112, 242, 309, 310],
+                    ],
+                    'postgresValue' => '{"key3":"15","key1":"value1","key4":15,"key2":false,' .
+                        '"key6":{"sub-key-2":"bar","sub-key-3":42,"sub-key-1":"foo"},"key5":[112,242,309,310]}',
+                ],
                 'object phpValue' => [
                     'phpValue' => (object)[
                         'property' => 'value',

--- a/packages/EasyDoctrine/tests/DBAL/Types/JsonbTypeTest.php
+++ b/packages/EasyDoctrine/tests/DBAL/Types/JsonbTypeTest.php
@@ -74,8 +74,14 @@ final class JsonbTypeTest extends AbstractTestCase
                     'key3' => '15',
                     'key4' => 15,
                     'key5' => [112, 242, 309, 310],
+                    'key6' => [
+                        'sub-key-1' => 'foo',
+                        'sub-key-2' => 'bar',
+                        'sub-key-3' => 42,
+                    ],
                 ],
-                'postgresValue' => '{"key1":"value1","key2":false,"key3":"15","key4":15,"key5":[112,242,309,310]}',
+                'postgresValue' => '{"key3":"15","key1":"value1","key4":15,"key2":false,' .
+                    '"key6":{"sub-key-2":"bar","sub-key-3":42,"sub-key-1":"foo"},"key5":[112,242,309,310]}',
             ],
         ];
     }
@@ -91,7 +97,7 @@ final class JsonbTypeTest extends AbstractTestCase
     public function testConvertToDatabaseValueSucceeds($phpValue, ?string $postgresValue = null): void
     {
         /** @var \EonX\EasyDoctrine\DBAL\Types\JsonbType $type */
-        $type = Type::getType(JsonbType::TYPE_NAME);
+        $type = Type::getType(JsonbType::JSONB);
         /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
         $platform = $this->prophesize(AbstractPlatform::class)->reveal();
 
@@ -107,7 +113,7 @@ final class JsonbTypeTest extends AbstractTestCase
     public function testConvertToDatabaseValueThrowsConversionException(): void
     {
         /** @var \EonX\EasyDoctrine\DBAL\Types\JsonbType $type */
-        $type = Type::getType(JsonbType::TYPE_NAME);
+        $type = Type::getType(JsonbType::JSONB);
         /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
         $platform = $this->prophesize(AbstractPlatform::class)->reveal();
         $value = \urldecode('some incorrectly encoded utf string %C4');
@@ -131,7 +137,7 @@ final class JsonbTypeTest extends AbstractTestCase
     public function testConvertToPhpValueSucceeds($phpValue, ?string $postgresValue = null): void
     {
         /** @var \EonX\EasyDoctrine\DBAL\Types\JsonbType $type */
-        $type = Type::getType(JsonbType::TYPE_NAME);
+        $type = Type::getType(JsonbType::JSONB);
         /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
         $platform = $this->prophesize(AbstractPlatform::class)->reveal();
 
@@ -147,7 +153,7 @@ final class JsonbTypeTest extends AbstractTestCase
     public function testConvertToPhpValueThrowsConversionException(): void
     {
         /** @var \EonX\EasyDoctrine\DBAL\Types\JsonbType $type */
-        $type = Type::getType(JsonbType::TYPE_NAME);
+        $type = Type::getType(JsonbType::JSONB);
         /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
         $platform = $this->prophesize(AbstractPlatform::class)->reveal();
         $value = 'ineligible-value';
@@ -163,11 +169,11 @@ final class JsonbTypeTest extends AbstractTestCase
     public function testGetNameSucceeds(): void
     {
         /** @var \EonX\EasyDoctrine\DBAL\Types\JsonbType $type */
-        $type = Type::getType(JsonbType::TYPE_NAME);
+        $type = Type::getType(JsonbType::JSONB);
 
         $name = $type->getName();
 
-        self::assertSame(JsonbType::TYPE_NAME, $name);
+        self::assertSame(JsonbType::JSONB, $name);
     }
 
     /**
@@ -176,15 +182,15 @@ final class JsonbTypeTest extends AbstractTestCase
     public function testGetSQLDeclaration(): void
     {
         /** @var \EonX\EasyDoctrine\DBAL\Types\JsonbType $type */
-        $type = Type::getType(JsonbType::TYPE_NAME);
+        $type = Type::getType(JsonbType::JSONB);
         $platform = $this->prophesize(AbstractPlatform::class);
-        $platform->getDoctrineTypeMapping($type::TYPE_NAME)->willReturn($type::TYPE_NAME);
+        $platform->getDoctrineTypeMapping($type::JSONB)->willReturn($type::JSONB);
 
         /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platformReveal */
         $platformReveal = $platform->reveal();
         $result = $type->getSQLDeclaration([], $platformReveal);
 
-        self::assertSame($type::TYPE_NAME, $result);
+        self::assertSame($type::JSONB, $result);
     }
 
     /**
@@ -194,8 +200,8 @@ final class JsonbTypeTest extends AbstractTestCase
     {
         parent::setUp();
 
-        if (Type::hasType(JsonbType::TYPE_NAME) === false) {
-            Type::addType(JsonbType::TYPE_NAME, JsonbType::class);
+        if (Type::hasType(JsonbType::JSONB) === false) {
+            Type::addType(JsonbType::JSONB, JsonbType::class);
         }
     }
 }

--- a/packages/EasyDoctrine/tests/DBAL/Types/JsonbTypeTest.php
+++ b/packages/EasyDoctrine/tests/DBAL/Types/JsonbTypeTest.php
@@ -135,7 +135,7 @@ final class JsonbTypeTest extends AbstractTestCase
         $value = \urldecode('some incorrectly encoded utf string %C4');
         $this->expectException(ConversionException::class);
         $this->expectExceptionMessage(
-            "Could not convert PHP type 'string' to 'json', as an " .
+            "Could not convert PHP type 'string' to 'JSONB', as an " .
             "'Malformed UTF-8 characters, possibly incorrectly encoded' error was triggered by the serialization"
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

PostgreSQL doesn't guaranty that keys in DB will keep the order as they presented in an array during the saving.
Sometimes it's really true and causes some troubles.
That's why I've decided to sort an array right after fetching it from a database.