### PR TITLE
[EasyActivity] hotfix/easy-activity-circular-reference-handler

### DIFF
--- a/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
@@ -80,8 +80,10 @@ final class SymfonyActivitySubjectDataSerializer implements ActivitySubjectDataS
             return null;
         }
 
-        if(!isset($context['circular_reference_handler'])){
-            $context['circular_reference_handler'] = function($object){return \get_class($object);};
+        if(isset($context['circular_reference_handler']) === false){
+            $context['circular_reference_handler'] = function ($object) {
+                return \get_class($object);
+            };
         }
 
         return $this->serializer->serialize((object)$data, 'json', $context);

--- a/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
@@ -80,7 +80,7 @@ final class SymfonyActivitySubjectDataSerializer implements ActivitySubjectDataS
             return null;
         }
 
-        if(isset($context['circular_reference_handler']) === false){
+        if (isset($context['circular_reference_handler']) === false) {
             $context['circular_reference_handler'] = function ($object) {
                 return \get_class($object);
             };

--- a/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
@@ -80,6 +80,10 @@ final class SymfonyActivitySubjectDataSerializer implements ActivitySubjectDataS
             return null;
         }
 
+        if(!isset($context['circular_reference_handler'])){
+            $context['circular_reference_handler'] = function($object){return \get_class($object);};
+        }
+
         return $this->serializer->serialize((object)$data, 'json', $context);
     }
 }


### PR DESCRIPTION
[EasyActivity] circular_reference_handler added

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

In some easy-activity "subjects" configuration serializer can throw error:
"A circular reference has been detected when serializing the object of class"

It will be useful if circular_reference_handler not configured



