### PR TITLE
[EasyUtils] Add sugar comparing methods to Math

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
+        "ext-bcmath": "*",
         "ext-simplexml": "*",
         "doctrine/orm": "^2.6",
         "nesbot/carbon": "^1.39 || ^2.22",

--- a/packages/EasyUtils/src/Interfaces/MathComparisonInterface.php
+++ b/packages/EasyUtils/src/Interfaces/MathComparisonInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyUtils\Interfaces;
+
+interface MathComparisonInterface
+{
+    public function equalTo(string $rightOperand): bool;
+
+    public function greaterOrEqualTo(string $rightOperand): bool;
+
+    public function greaterThan(string $rightOperand): bool;
+
+    public function lessOrEqualTo(string $rightOperand): bool;
+
+    public function lessThan(string $rightOperand): bool;
+
+    public function setLeftOperand(string $leftOperand): self;
+}

--- a/packages/EasyUtils/src/Interfaces/MathComparisonInterface.php
+++ b/packages/EasyUtils/src/Interfaces/MathComparisonInterface.php
@@ -15,6 +15,4 @@ interface MathComparisonInterface
     public function lessOrEqualTo(string $rightOperand): bool;
 
     public function lessThan(string $rightOperand): bool;
-
-    public function setLeftOperand(string $leftOperand): self;
 }

--- a/packages/EasyUtils/src/Interfaces/MathInterface.php
+++ b/packages/EasyUtils/src/Interfaces/MathInterface.php
@@ -37,19 +37,9 @@ interface MathInterface
 
     public function comp(string $leftOperand, string $rightOperand): int;
 
-    public function compareThat(string $leftOperand): self;
+    public function compareThat(string $leftOperand): MathComparisonInterface;
 
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string;
-
-    public function equalTo(string $rightOperand): bool;
-
-    public function greaterOrEqualTo(string $rightOperand): bool;
-
-    public function greaterThan(string $rightOperand): bool;
-
-    public function lessOrEqualTo(string $rightOperand): bool;
-
-    public function lessThan(string $rightOperand): bool;
 
     public function multiply(
         string $multiplicand,

--- a/packages/EasyUtils/src/Interfaces/MathInterface.php
+++ b/packages/EasyUtils/src/Interfaces/MathInterface.php
@@ -35,6 +35,9 @@ interface MathInterface
 
     public function add(string $augend, string $addend, ?int $precision = null, ?int $mode = null): string;
 
+    /**
+     * @deprecated must be deleted on next major update, use compareThat() method instead
+     */
     public function comp(string $leftOperand, string $rightOperand): int;
 
     public function compareThat(string $leftOperand): MathComparisonInterface;

--- a/packages/EasyUtils/src/Interfaces/MathInterface.php
+++ b/packages/EasyUtils/src/Interfaces/MathInterface.php
@@ -37,7 +37,19 @@ interface MathInterface
 
     public function comp(string $leftOperand, string $rightOperand): int;
 
+    public function compareThat(string $leftOperand): self;
+
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string;
+
+    public function equalTo(string $rightOperand): bool;
+
+    public function greaterOrEqualTo(string $rightOperand): bool;
+
+    public function greaterThan(string $rightOperand): bool;
+
+    public function lessOrEqualTo(string $rightOperand): bool;
+
+    public function lessThan(string $rightOperand): bool;
 
     public function multiply(
         string $multiplicand,

--- a/packages/EasyUtils/src/Interfaces/MathInterface.php
+++ b/packages/EasyUtils/src/Interfaces/MathInterface.php
@@ -35,9 +35,6 @@ interface MathInterface
 
     public function add(string $augend, string $addend, ?int $precision = null, ?int $mode = null): string;
 
-    /**
-     * @deprecated must be deleted on next major update, use compareThat() method instead
-     */
     public function comp(string $leftOperand, string $rightOperand): int;
 
     public function compareThat(string $leftOperand): MathComparisonInterface;

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -73,7 +73,7 @@ final class Math implements MathInterface
 
     public function compareThat(string $leftOperand): MathComparisonInterface
     {
-        return (new MathComparison($this->scale))->setLeftOperand($leftOperand);
+        return (new MathComparison($leftOperand, $this->scale));
     }
 
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -51,7 +51,9 @@ final class Math implements MathInterface
 
     public function abs(string $value, ?int $precision = null, ?int $mode = null): string
     {
-        return $this->compareThat($value)->lessThan('0')
+        return $this
+            ->compareThat($value)
+            ->lessThan('0')
             ? $this->multiply($value, '-1', $precision, $mode)
             : $this->round($value, $precision, $mode);
     }
@@ -71,7 +73,7 @@ final class Math implements MathInterface
 
     public function compareThat(string $leftOperand): MathComparisonInterface
     {
-        return (new MathComparison())->setLeftOperand($leftOperand);
+        return (new MathComparison($this->scale))->setLeftOperand($leftOperand);
     }
 
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EonX\EasyUtils;
 
 use EonX\EasyUtils\Exceptions\InvalidDivisionByZeroException;
+use EonX\EasyUtils\Interfaces\MathComparisonInterface;
 use EonX\EasyUtils\Interfaces\MathInterface;
 
 final class Math implements MathInterface
@@ -13,11 +14,6 @@ final class Math implements MathInterface
      * @var string
      */
     private $decimalSeparator;
-
-    /**
-     * @var string
-     */
-    private $leftOperand;
 
     /**
      * @var int
@@ -55,7 +51,7 @@ final class Math implements MathInterface
 
     public function abs(string $value, ?int $precision = null, ?int $mode = null): string
     {
-        return $this->comp($value, '0') === -1
+        return $this->compareThat($value)->lessThan('0')
             ? $this->multiply($value, '-1', $precision, $mode)
             : $this->round($value, $precision, $mode);
     }
@@ -66,20 +62,16 @@ final class Math implements MathInterface
     }
 
     /**
-     * @deprecated will become private after next major update, use compareThat() methods instead
+     * @deprecated musst be deleted on next major update, use compareThat() method instead
      */
     public function comp(string $leftOperand, string $rightOperand): int
     {
         return \bccomp($leftOperand, $rightOperand, $this->scale);
     }
 
-    public function compareThat(string $leftOperand): MathInterface
+    public function compareThat(string $leftOperand): MathComparisonInterface
     {
-        $self = new self();
-
-        $self->leftOperand = $leftOperand;
-
-        return $self;
+        return (new MathComparison())->setLeftOperand($leftOperand);
     }
 
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string
@@ -91,31 +83,6 @@ final class Math implements MathInterface
         }
 
         return $this->round($value, $precision, $mode);
-    }
-
-    public function equalTo(string $rightOperand): bool
-    {
-        return $this->comp($this->leftOperand, $rightOperand) === 0;
-    }
-
-    public function greaterOrEqualTo(string $rightOperand): bool
-    {
-        return $this->comp($this->leftOperand, $rightOperand) !== -1;
-    }
-
-    public function greaterThan(string $rightOperand): bool
-    {
-        return $this->comp($this->leftOperand, $rightOperand) === 1;
-    }
-
-    public function lessOrEqualTo(string $rightOperand): bool
-    {
-        return $this->comp($this->leftOperand, $rightOperand) !== 1;
-    }
-
-    public function lessThan(string $rightOperand): bool
-    {
-        return $this->comp($this->leftOperand, $rightOperand) === -1;
     }
 
     public function multiply(

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -73,7 +73,7 @@ final class Math implements MathInterface
 
     public function compareThat(string $leftOperand): MathComparisonInterface
     {
-        return (new MathComparison($leftOperand, $this->scale));
+        return new MathComparison($leftOperand, $this->scale);
     }
 
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -15,6 +15,11 @@ final class Math implements MathInterface
     private $decimalSeparator;
 
     /**
+     * @var string
+     */
+    private $leftOperand;
+
+    /**
      * @var int
      */
     private $roundMode;
@@ -60,9 +65,21 @@ final class Math implements MathInterface
         return $this->round(\bcadd($augend, $addend, $this->scale), $precision, $mode);
     }
 
+    /**
+     * @deprecated will become private after next major update, use compareThat() methods instead
+     */
     public function comp(string $leftOperand, string $rightOperand): int
     {
         return \bccomp($leftOperand, $rightOperand, $this->scale);
+    }
+
+    public function compareThat(string $leftOperand): self
+    {
+        $self = new self();
+
+        $self->leftOperand = $leftOperand;
+
+        return $self;
     }
 
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string
@@ -74,6 +91,31 @@ final class Math implements MathInterface
         }
 
         return $this->round($value, $precision, $mode);
+    }
+
+    public function equalTo(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) === 0;
+    }
+
+    public function greaterOrEqualTo(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) !== -1;
+    }
+
+    public function greaterThan(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) === 1;
+    }
+
+    public function lessOrEqualTo(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) !== 1;
+    }
+
+    public function lessThan(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) === -1;
     }
 
     public function multiply(

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -64,7 +64,7 @@ final class Math implements MathInterface
     }
 
     /**
-     * @deprecated musst be deleted on next major update, use compareThat() method instead
+     * @deprecated must be deleted on next major update, use compareThat() method instead
      */
     public function comp(string $leftOperand, string $rightOperand): int
     {

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -51,9 +51,7 @@ final class Math implements MathInterface
 
     public function abs(string $value, ?int $precision = null, ?int $mode = null): string
     {
-        return $this
-            ->compareThat($value)
-            ->lessThan('0')
+        return $this->comp($value, '0') === -1
             ? $this->multiply($value, '-1', $precision, $mode)
             : $this->round($value, $precision, $mode);
     }
@@ -63,9 +61,6 @@ final class Math implements MathInterface
         return $this->round(\bcadd($augend, $addend, $this->scale), $precision, $mode);
     }
 
-    /**
-     * @deprecated must be deleted on next major update, use compareThat() method instead
-     */
     public function comp(string $leftOperand, string $rightOperand): int
     {
         return \bccomp($leftOperand, $rightOperand, $this->scale);

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -73,7 +73,7 @@ final class Math implements MathInterface
         return \bccomp($leftOperand, $rightOperand, $this->scale);
     }
 
-    public function compareThat(string $leftOperand): self
+    public function compareThat(string $leftOperand): MathInterface
     {
         $self = new self();
 

--- a/packages/EasyUtils/src/MathComparison.php
+++ b/packages/EasyUtils/src/MathComparison.php
@@ -18,8 +18,9 @@ final class MathComparison implements MathComparisonInterface
      */
     private $scale;
 
-    public function __construct(int $scale)
+    public function __construct(string $leftOperand, int $scale)
     {
+        $this->leftOperand = $leftOperand;
         $this->scale = $scale;
     }
 
@@ -46,13 +47,6 @@ final class MathComparison implements MathComparisonInterface
     public function lessThan(string $rightOperand): bool
     {
         return $this->comp($this->leftOperand, $rightOperand) === -1;
-    }
-
-    public function setLeftOperand(string $leftOperand): MathComparisonInterface
-    {
-        $this->leftOperand = $leftOperand;
-
-        return $this;
     }
 
     private function comp(string $leftOperand, string $rightOperand): int

--- a/packages/EasyUtils/src/MathComparison.php
+++ b/packages/EasyUtils/src/MathComparison.php
@@ -13,6 +13,15 @@ final class MathComparison implements MathComparisonInterface
      */
     private $leftOperand;
 
+    /**
+     * @var int
+     */
+    private $scale;
+
+    public function __construct(int $scale) {
+        $this->scale = $scale;
+    }
+
     public function equalTo(string $rightOperand): bool
     {
         return $this->comp($this->leftOperand, $rightOperand) === 0;

--- a/packages/EasyUtils/src/MathComparison.php
+++ b/packages/EasyUtils/src/MathComparison.php
@@ -18,7 +18,8 @@ final class MathComparison implements MathComparisonInterface
      */
     private $scale;
 
-    public function __construct(int $scale) {
+    public function __construct(int $scale)
+    {
         $this->scale = $scale;
     }
 

--- a/packages/EasyUtils/src/MathComparison.php
+++ b/packages/EasyUtils/src/MathComparison.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyUtils;
+
+use EonX\EasyUtils\Interfaces\MathComparisonInterface;
+
+final class MathComparison implements MathComparisonInterface
+{
+    /**
+     * @var string
+     */
+    private $leftOperand;
+
+    public function equalTo(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) === 0;
+    }
+
+    public function greaterOrEqualTo(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) !== -1;
+    }
+
+    public function greaterThan(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) === 1;
+    }
+
+    public function lessOrEqualTo(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) !== 1;
+    }
+
+    public function lessThan(string $rightOperand): bool
+    {
+        return $this->comp($this->leftOperand, $rightOperand) === -1;
+    }
+
+    public function setLeftOperand(string $leftOperand): MathComparisonInterface
+    {
+        $this->leftOperand = $leftOperand;
+
+        return $this;
+    }
+
+    private function comp(string $leftOperand, string $rightOperand): int
+    {
+        return \bccomp($leftOperand, $rightOperand, $this->scale);
+    }
+}

--- a/packages/EasyUtils/tests/AbstractMathTestCase.php
+++ b/packages/EasyUtils/tests/AbstractMathTestCase.php
@@ -121,7 +121,12 @@ abstract class AbstractMathTestCase extends AbstractTestCase
             'compareMethod' => 'lessThan',
             'result' => true,
         ];
-        yield ['leftOperand' => '91', 'rightOperand' => '091', 'compareMethod' => 'equalTo', 'result' => true];
+        yield [
+            'leftOperand' => '91',
+            'rightOperand' => '091',
+            'compareMethod' => 'equalTo',
+            'result' => true,
+        ];
     }
 
     /**
@@ -212,7 +217,9 @@ abstract class AbstractMathTestCase extends AbstractTestCase
     ): void {
         $math = $this->getMath();
 
-        $actual = $math->compareThat($leftOperand)->$compareMethod($rightOperand);
+        $actual = $math
+            ->compareThat($leftOperand)
+            ->{$compareMethod}($rightOperand);
 
         self::assertSame($result, $actual);
     }

--- a/packages/EasyUtils/tests/AbstractMathTestCase.php
+++ b/packages/EasyUtils/tests/AbstractMathTestCase.php
@@ -43,29 +43,85 @@ abstract class AbstractMathTestCase extends AbstractTestCase
     }
 
     /**
-     * @return mixed[]
+     * @return iterable<mixed>
      *
-     * @see testCompSucceeds
+     * @see testCompareSucceeds
      */
-    public function provideCompData(): array
+    public function provideCompareData(): iterable
     {
-        return [
-            [
-                'leftOperand' => '10000000',
-                'rightOperand' => '10000001',
-                'result' => -1,
-            ],
-            [
-                'leftOperand' => '10000000',
-                'rightOperand' => '10000000',
-                'result' => 0,
-            ],
-            [
-                'leftOperand' => '10000001',
-                'rightOperand' => '10000000',
-                'result' => 1,
-            ],
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000001',
+            'compareMethod' => 'greaterOrEqualTo',
+            'result' => false,
         ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'greaterOrEqualTo',
+            'result' => true,
+        ];
+        yield [
+            'leftOperand' => '10000001',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'greaterOrEqualTo',
+            'result' => true,
+        ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'equalTo',
+            'result' => true,
+        ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000001',
+            'compareMethod' => 'equalTo',
+            'result' => false,
+        ];
+        yield [
+            'leftOperand' => '10000001',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'greaterThan',
+            'result' => true,
+        ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000001',
+            'compareMethod' => 'greaterThan',
+            'result' => false,
+        ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000001',
+            'compareMethod' => 'lessOrEqualTo',
+            'result' => true,
+        ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'lessOrEqualTo',
+            'result' => true,
+        ];
+        yield [
+            'leftOperand' => '10000001',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'lessOrEqualTo',
+            'result' => false,
+        ];
+        yield [
+            'leftOperand' => '10000001',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'lessThan',
+            'result' => false,
+        ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000001',
+            'compareMethod' => 'lessThan',
+            'result' => true,
+        ];
+        yield ['leftOperand' => '91', 'rightOperand' => '091', 'compareMethod' => 'equalTo', 'result' => true];
     }
 
     /**
@@ -146,12 +202,17 @@ abstract class AbstractMathTestCase extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideCompData
+     * @dataProvider provideCompareData
      */
-    public function testCompSucceeds(string $leftOperand, string $rightOperand, int $result): void
-    {
+    public function testCompareSucceeds(
+        string $leftOperand,
+        string $rightOperand,
+        string $compareMethod,
+        bool $result
+    ): void {
         $math = $this->getMath();
-        $actual = $math->comp($leftOperand, $rightOperand);
+
+        $actual = $math->compareThat($leftOperand)->$compareMethod($rightOperand);
 
         self::assertSame($result, $actual);
     }

--- a/packages/EasyUtils/tests/AbstractMathTestCase.php
+++ b/packages/EasyUtils/tests/AbstractMathTestCase.php
@@ -45,9 +45,9 @@ abstract class AbstractMathTestCase extends AbstractTestCase
     /**
      * @return iterable<mixed>
      *
-     * @see testCompareSucceeds
+     * @see testCompareThatSucceeds
      */
-    public function provideCompareData(): iterable
+    public function provideCompareThatData(): iterable
     {
         yield [
             'leftOperand' => '10000000',
@@ -82,8 +82,20 @@ abstract class AbstractMathTestCase extends AbstractTestCase
         yield [
             'leftOperand' => '10000001',
             'rightOperand' => '10000000',
+            'compareMethod' => 'equalTo',
+            'result' => false,
+        ];
+        yield [
+            'leftOperand' => '10000001',
+            'rightOperand' => '10000000',
             'compareMethod' => 'greaterThan',
             'result' => true,
+        ];
+        yield [
+            'leftOperand' => '10000000',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'greaterThan',
+            'result' => false,
         ];
         yield [
             'leftOperand' => '10000000',
@@ -111,6 +123,12 @@ abstract class AbstractMathTestCase extends AbstractTestCase
         ];
         yield [
             'leftOperand' => '10000001',
+            'rightOperand' => '10000000',
+            'compareMethod' => 'lessThan',
+            'result' => false,
+        ];
+        yield [
+            'leftOperand' => '10000000',
             'rightOperand' => '10000000',
             'compareMethod' => 'lessThan',
             'result' => false,
@@ -207,9 +225,9 @@ abstract class AbstractMathTestCase extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideCompareData
+     * @dataProvider provideCompareThatData
      */
-    public function testCompareSucceeds(
+    public function testCompareThatSucceeds(
         string $leftOperand,
         string $rightOperand,
         string $compareMethod,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |    <!-- #-prefixed issue number(s), if any -->

- Add comparing methods to Math to simplify comparisons:
```
$math->compareThat($leftOperand)
    ->equalTo($rightOperand)
    ->greaterOrEqualTo($rightOperand)
    ->greaterThan($rightOperand)
    ->lessOrEqualTo($rightOperand)
    ->lessThan($rightOperand)
```

- ~~`comp()` method marked as `@deprecated` to avoid BC break - it should be deleted then~~
- ~~what do you think about naming of the class, comparisons a bit not a math operations. In EWMP we named this class as `BcMathDecorator`~~