### PR TITLE
Fixed several deprecations

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Command/ApiResourceAndSimpleDataPersisterMaker.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Command/ApiResourceAndSimpleDataPersisterMaker.php
@@ -18,6 +18,11 @@ use Symfony\Component\Console\Input\InputOption;
 
 final class ApiResourceAndSimpleDataPersisterMaker extends AbstractMaker
 {
+    public static function getCommandDescription(): string
+    {
+        return 'Create ApiResource + its SimpleDataPersister';
+    }
+
     public static function getCommandName(): string
     {
         return 'make:simple_api_resource';
@@ -26,7 +31,7 @@ final class ApiResourceAndSimpleDataPersisterMaker extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
-            ->setDescription('Create ApiResource + its SimpleDataPersister')
+            ->setDescription(self::getCommandDescription())
             ->addArgument(
                 'name',
                 InputArgument::REQUIRED,

--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Command/ApiResourceAndSimpleDataPersisterMaker.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Command/ApiResourceAndSimpleDataPersisterMaker.php
@@ -31,7 +31,6 @@ final class ApiResourceAndSimpleDataPersisterMaker extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
-            ->setDescription(self::getCommandDescription())
             ->addArgument(
                 'name',
                 InputArgument::REQUIRED,

--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Listeners/ResolveRequestAttributesListener.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Listeners/ResolveRequestAttributesListener.php
@@ -28,7 +28,8 @@ final class ResolveRequestAttributesListener implements EventListenerInterface
     public function __construct(RequestStack $requestStack, ?ArgumentResolverInterface $argumentResolver = null)
     {
         $this->argumentResolver = $argumentResolver ?? new ArgumentResolver();
-        $this->request = $requestStack->getMasterRequest();
+        $getMainRequestMethod = \method_exists($requestStack, 'getMainRequest') ? 'getMainRequest' : 'getMasterRequest';
+        $this->request = $requestStack->{$getMainRequestMethod}();
     }
 
     public function __invoke(DataPersisterResolvedEvent $event): void

--- a/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
+++ b/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
@@ -37,10 +37,7 @@ final class EntityManagerDecorator extends DoctrineEntityManagerDecorator
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function clear($objectName = null)
+    public function clear($objectName = null): void
     {
         parent::clear($objectName);
         $this->deferredEntityEventDispatcher->clear();

--- a/packages/EasyRequestId/src/Bridge/Symfony/Listeners/RequestListener.php
+++ b/packages/EasyRequestId/src/Bridge/Symfony/Listeners/RequestListener.php
@@ -24,7 +24,9 @@ final class RequestListener
 
     public function __invoke(RequestEvent $event): void
     {
-        if ($event->isMasterRequest()) {
+        $isMainRequestMethod = \method_exists($event, 'isMainRequest') ? 'isMainRequest' : 'isMasterRequest';
+
+        if ($event->{$isMainRequestMethod}()) {
             $this->setResolver($event->getRequest(), $this->requestIdService);
         }
     }

--- a/packages/EasySecurity/src/Bridge/Symfony/Security/ContextAuthenticator.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Security/ContextAuthenticator.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace EonX\EasySecurity\Bridge\Symfony\Security;
 
 use EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationFailureResponseFactoryInterface;
-use EonX\EasySecurity\Interfaces\DeferredSecurityContextProviderInterface;
 use EonX\EasySecurity\Interfaces\SecurityContextInterface;
+use EonX\EasySecurity\Interfaces\SecurityContextResolverInterface;
 use EonX\EasySecurity\Interfaces\UserInterface as EonxUserInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,15 +24,15 @@ final class ContextAuthenticator extends AbstractGuardAuthenticator
     private $responseFactory;
 
     /**
-     * @var \EonX\EasySecurity\Interfaces\DeferredSecurityContextProviderInterface
+     * @var \EonX\EasySecurity\Interfaces\SecurityContextResolverInterface
      */
-    private $securityContextProvider;
+    private $securityContextResolver;
 
     public function __construct(
-        DeferredSecurityContextProviderInterface $securityContextProvider,
+        SecurityContextResolverInterface $securityContextResolver,
         AuthenticationFailureResponseFactoryInterface $respFactory
     ) {
-        $this->securityContextProvider = $securityContextProvider;
+        $this->securityContextResolver = $securityContextResolver;
         $this->responseFactory = $respFactory;
     }
 
@@ -46,7 +46,7 @@ final class ContextAuthenticator extends AbstractGuardAuthenticator
 
     public function getCredentials(Request $request): SecurityContextInterface
     {
-        return $this->securityContextProvider->getSecurityContext();
+        return $this->securityContextResolver->resolveContext();
     }
 
     /**


### PR DESCRIPTION
Fixed several deprecations:

- [EasyCore] Added the `getCommandDescription` method to the `ApiResourceAndSimpleDataPersisterMaker` console command.
- [EasyCore] Started to use the `getMainRequest` method of the `RequestStack` class if possible.
- [EasyDoctrine] Improved type hinting in the `EntityManagerDecorator` class.
- [EasyRequestId] Started to use the `getMainRequest` method of the `RequestEvent` class if possible.
- [EasySecurity] Stopped using the `DeferredSecurityContextProviderInterface` deprecated class.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
