### PR TITLE
[EasyActivity] [EasyDoctrine] Change flex recipes to make it easier to install EasyActivity

### DIFF
--- a/packages/EasyActivity/composer.json
+++ b/packages/EasyActivity/composer.json
@@ -28,6 +28,11 @@
             "EonX\\EasyActivity\\Tests\\": "tests"
         }
     },
+    "suggest": {
+        "symfony/serializer": "To serialize subject's data",
+        "symfony/messenger": "To save log entities asynchronously",
+        "eonx-com/easy-doctrine": "To create Log entries from to doctrine events"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/symfony-recipes/eonx-com/easy-activity/3.4/config/packages/easy_activity.yaml
+++ b/symfony-recipes/eonx-com/easy-activity/3.4/config/packages/easy_activity.yaml
@@ -1,7 +1,8 @@
 easy_activity:
+    table_name: activity_logs
+
     disallowed_properties:
         - updatedAt
-        - createdAt
 
     subjects:
 #        App\Entity\SomeEntity:
@@ -10,4 +11,7 @@ easy_activity:
 #                - description
 #            disallowed_properties:
 #                - author
-#            type: SomeEntity
+#            nested_object_allowed_properties:
+#                App\Entity\SomeAnotherEntity:
+#                    - processingDate
+#

--- a/symfony-recipes/eonx-com/easy-activity/3.4/manifest.json
+++ b/symfony-recipes/eonx-com/easy-activity/3.4/manifest.json
@@ -1,6 +1,5 @@
 {
     "bundles": {
-        "EonX\\EasyDoctrine\\Bridge\\Symfony\\EasyDoctrineSymfonyBundle": ["all"],
         "EonX\\EasyActivity\\Bridge\\Symfony\\EasyActivitySymfonyBundle": ["all"]
     },
     "copy-from-recipe": {

--- a/symfony-recipes/eonx-com/easy-doctrine/3.4/config/packages/easy_doctrine.yaml
+++ b/symfony-recipes/eonx-com/easy-doctrine/3.4/config/packages/easy_doctrine.yaml
@@ -1,0 +1,21 @@
+easy_doctrine:
+    deferred_dispatcher_entities: []
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: false
+
+    EonX\EasyDoctrine\ORM\Decorators\EntityManagerDecorator:
+        arguments:
+            $wrapped: '@.inner'
+        decorates: doctrine.orm.default_entity_manager
+
+    EonX\EasyDoctrine\Subscribers\EntityEventSubscriber:
+        arguments:
+            $entities: '%easy_doctrine.deferred_dispatcher_entities%'
+        tags:
+            -
+                name: doctrine.event_subscriber
+                connection: default
+

--- a/symfony-recipes/eonx-com/easy-doctrine/3.4/manifest.json
+++ b/symfony-recipes/eonx-com/easy-doctrine/3.4/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "EonX\\EasyDoctrine\\Bridge\\Symfony\\EasyDoctrineSymfonyBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
The `eonx-com/easy-activity` package doesn't depend on `eonx-com/easy-doctrine`. But the flex recipe adds `EonX\EasyDoctrine\Bridge\Symfony\EasyDoctrineSymfonyBundle` to the `bundles.php`. 
It leads to an error in `composer require eonx-com/easy-activity`.

Also, I've added a few changes to make it easier to install EasyActivity:
1. Added a `suggest` section to the `composer.json`
2. Added a flex recipe for `eonx-com/easy-doctrine`


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
