### PR TITLE
[EasySecurity] Rename `sub_code` to `subCode` in the authentication failure response

### DIFF
--- a/packages/EasySecurity/src/Bridge/Symfony/Factories/AuthenticationFailureResponseFactory.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Factories/AuthenticationFailureResponseFactory.php
@@ -36,7 +36,7 @@ final class AuthenticationFailureResponseFactory implements AuthenticationFailur
         $data = [
             'message' => 'Unauthorized',
             'code' => JsonResponse::HTTP_UNAUTHORIZED,
-            'sub_code' => 0,
+            'subCode' => 0,
         ];
 
         return new JsonResponse($data, JsonResponse::HTTP_UNAUTHORIZED);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #831
