### PR TITLE
[EasyDoctrine] DeferredEntityEventDispatcher clear on EntityManager clear

### DIFF
--- a/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
+++ b/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
@@ -37,12 +37,6 @@ final class EntityManagerDecorator extends DoctrineEntityManagerDecorator
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function clear($objectName = null): void
-    {
-        parent::clear($objectName);
-        $this->deferredEntityEventDispatcher->clear();
-    }
-
     public function commit(): void
     {
         parent::commit();


### PR DESCRIPTION
* remove `DeferredEntityEventDispatcher::clear` on `EM::clear`

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

We have an issue with clear `deferredEntityEventDispatcher` on `em::clear`
https://eonx.atlassian.net/browse/PLU-4176

The reason to clear entityEventDispatcher was found here: https://github.com/eonx-com/easy-monorepo/pull/775#discussion_r723091505

From Symfony 4.4 (doctrine-bridge 4.4) EM is clear its state on each message by default. 

https://symfony.com/blog/new-in-symfony-4-4-messenger-middleware-to-clear-doctrine-entity-manager (the first paragraph after the word **update**:)

doctrine-bridge commit: 
https://github.com/symfony/doctrine-bridge/commit/c0cb34eccffb020b274fb2f979bfea3d3d23fc99#diff-4009944d090241c36b19083a3bbded8d06927d1fb9011471e2ef2cad911c742f

And we can remove `entityEventDispatcher::clear` by this PR after minimum version upgrade to Symfony 4.4 in monorepo.
