### PR TITLE
[EasyWebhook] Make sure failing webhook response is not set on result

### DIFF
--- a/packages/EasyWebhook/src/Middleware/SendWebhookMiddleware.php
+++ b/packages/EasyWebhook/src/Middleware/SendWebhookMiddleware.php
@@ -35,7 +35,6 @@ final class SendWebhookMiddleware extends AbstractMiddleware
             throw new InvalidWebhookUrlException('Webhook URL required');
         }
 
-        $response = null;
         $throwable = null;
 
         try {
@@ -43,6 +42,9 @@ final class SendWebhookMiddleware extends AbstractMiddleware
             // Trigger exception on bad response
             $response->getContent();
         } catch (\Throwable $throwable) {
+            // Set response to null here to make sure not to carry over the faulty response
+            $response = null;
+
             if ($throwable instanceof HttpExceptionInterface) {
                 $response = $throwable->getResponse();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Fixes #853 