### PR TITLE
[EasySecurity] Allow custom authentication exceptions

### DIFF
--- a/packages/EasySecurity/src/Bridge/Symfony/Interfaces/AuthenticationExceptionInterface.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Interfaces/AuthenticationExceptionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasySecurity\Bridge\Symfony\Interfaces;
+
+interface AuthenticationExceptionInterface
+{
+}

--- a/packages/EasySecurity/src/Bridge/Symfony/Security/SecurityContextAuthenticator.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Security/SecurityContextAuthenticator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasySecurity\Bridge\Symfony\Security;
 
+use EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationExceptionInterface;
 use EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationFailureResponseFactoryInterface;
 use EonX\EasySecurity\Interfaces\SecurityContextResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,6 +45,9 @@ final class SecurityContextAuthenticator extends AbstractAuthenticator implement
                 ->resolveContext()
                 ->getUserOrFail();
         } catch (\Throwable $throwable) {
+            if ($throwable instanceof AuthenticationExceptionInterface) {
+                throw $throwable;
+            }
             throw new AuthenticationException($throwable->getMessage());
         }
 

--- a/packages/EasySecurity/tests/Bridge/Symfony/Security/SecurityContextAuthenticatorTest.php
+++ b/packages/EasySecurity/tests/Bridge/Symfony/Security/SecurityContextAuthenticatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasySecurity\Tests\Bridge\Symfony\Security;
+
+use EonX\EasySecurity\Bridge\Symfony\Factories\AuthenticationFailureResponseFactory;
+use EonX\EasySecurity\Bridge\Symfony\Security\SecurityContextAuthenticator;
+use EonX\EasySecurity\Interfaces\SecurityContextResolverInterface;
+use EonX\EasySecurity\Tests\AbstractTestCase;
+use EonX\EasySecurity\Tests\Bridge\Symfony\Stubs\CustomAuthenticationException;
+use LogicException;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Throwable;
+
+final class SecurityContextAuthenticatorTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider provideExceptions
+     *
+     * @psalm-param class-string<\Throwable> $expectedExceptionClass
+     */
+    public function testAuthenticateThrowsCorrectException(
+        Throwable $thrownException,
+        string $expectedExceptionClass,
+    ): void {
+        $this->expectException($expectedExceptionClass);
+
+        $securityContextResolver = $this->prophesize(SecurityContextResolverInterface::class);
+        $securityContextResolver->resolveContext()
+            ->willThrow($thrownException);
+        /** @var SecurityContextResolverInterface $securityContextResolverReveal */
+        $securityContextResolverReveal = $securityContextResolver->reveal();
+        $authenticator = new SecurityContextAuthenticator(
+            $securityContextResolverReveal,
+            new AuthenticationFailureResponseFactory()
+        );
+
+        $authenticator->authenticate(new Request());
+    }
+
+    /**
+     * @return iterable<mixed>
+     *
+     * @see testAuthenticateThrowsCorrectException
+     */
+    protected function provideExceptions(): iterable
+    {
+        yield 'Library exception 1' => [
+            'thrownException' => new RuntimeException(),
+            'expectedExceptionClass' => AuthenticationException::class,
+        ];
+
+        yield 'Library exception 2' => [
+            'thrownException' => new LogicException(),
+            'expectedExceptionClass' => AuthenticationException::class,
+        ];
+
+        yield 'Custom exception' => [
+            'thrownException' => new CustomAuthenticationException(),
+            'expectedExceptionClass' => CustomAuthenticationException::class,
+        ];
+    }
+}

--- a/packages/EasySecurity/tests/Bridge/Symfony/Stubs/CustomAuthenticationException.php
+++ b/packages/EasySecurity/tests/Bridge/Symfony/Stubs/CustomAuthenticationException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasySecurity\Tests\Bridge\Symfony\Stubs;
+
+use EonX\EasySecurity\Bridge\Symfony\Interfaces\AuthenticationExceptionInterface;
+use Exception;
+
+final class CustomAuthenticationException extends Exception implements AuthenticationExceptionInterface
+{
+    // The body is not required
+}


### PR DESCRIPTION
Currently, all exceptions in the `SecurityContextConfigurator` are caught and there is no way to define a specific error code for the client. The client always gets:
```
{"message":"Unauthorized","code":401,"subCode":0}
```

This PR adds support for exceptions with a specific error code.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes