### PR TITLE
[EasyCore] hotfix/easy-core-decimal-validator

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/Validator/Constraints/DecimalValidator.php
+++ b/packages/EasyCore/src/Bridge/Symfony/Validator/Constraints/DecimalValidator.php
@@ -26,7 +26,9 @@ final class DecimalValidator extends ConstraintValidator
             throw new UnexpectedValueException($value, 'scalar');
         }
 
-        $value = (string) $value;
+        $value = \is_float($value)
+            ? \rtrim(\number_format($value, $constraint->maxPrecision + 1, '.', ''), '.0')
+            : (string) $value;
 
         $pattern = \sprintf('/^\d+(\.\d{%d,%d})?$/', $constraint->minPrecision, $constraint->maxPrecision);
 

--- a/packages/EasyCore/tests/Bridge/Symfony/Validator/Constraints/DecimalValidatorTest.php
+++ b/packages/EasyCore/tests/Bridge/Symfony/Validator/Constraints/DecimalValidatorTest.php
@@ -50,6 +50,7 @@ final class DecimalValidatorTest extends AbstractSymfonyTestCase
             'Valid value #5' => [0.01, 1, 3],
             'Valid value #6' => [1, 1, 3],
             'Valid value #7' => [0, 1, 3],
+            'Valid value #8' => [0.000001, 1, 6],
             'Empty string' => ['', 1, 3],
             'Null value' => [null, 1, 3],
         ];


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

In the decimalValidator, the value being tested can be converted to an exponential form. And it not will match the regexp pattern.
Eg: "0.000001" to "1.0E-6"

This one should fix that.

