### PR TITLE
[EasyDoctrine] Added types to `TimestampableTrait`

### DIFF
--- a/packages/EasyDoctrine/src/Interfaces/TimestampableInterface.php
+++ b/packages/EasyDoctrine/src/Interfaces/TimestampableInterface.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Interfaces;
 
-use DateTimeImmutable;
+use Carbon\CarbonImmutable;
 
 interface TimestampableInterface
 {
-    public function getCreatedAt(): DateTimeImmutable;
+    public function getCreatedAt(): CarbonImmutable;
 
-    public function getUpdatedAt(): DateTimeImmutable;
+    public function getUpdatedAt(): CarbonImmutable;
 
     public function updateTimestamps(): void;
 }

--- a/packages/EasyDoctrine/src/Subscribers/TimestampableEventSubscriber.php
+++ b/packages/EasyDoctrine/src/Subscribers/TimestampableEventSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Subscribers;
 
-use DateTimeInterface;
+use Carbon\CarbonImmutable;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
@@ -48,8 +48,8 @@ final class TimestampableEventSubscriber implements EventSubscriber
             if ($classMetadata->hasField($field) === false) {
                 $classMetadata->mapField([
                     'fieldName' => $field,
-                    'nullable' => true,
-                    'type' => DateTimeInterface::class,
+                    'nullable' => false,
+                    'type' => CarbonImmutable::class,
                 ]);
             }
         }

--- a/packages/EasyDoctrine/src/Traits/TimestampableTrait.php
+++ b/packages/EasyDoctrine/src/Traits/TimestampableTrait.php
@@ -5,26 +5,19 @@ declare(strict_types=1);
 namespace EonX\EasyDoctrine\Traits;
 
 use Carbon\CarbonImmutable;
-use DateTimeImmutable;
 
-trait TimestampableImmutableTrait
+trait TimestampableTrait
 {
-    /**
-     * @var \DateTimeImmutable
-     */
-    protected $createdAt;
+    protected CarbonImmutable $createdAt;
 
-    /**
-     * @var \DateTimeImmutable
-     */
-    protected $updatedAt;
+    protected CarbonImmutable $updatedAt;
 
-    public function getCreatedAt(): DateTimeImmutable
+    public function getCreatedAt(): CarbonImmutable
     {
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): DateTimeImmutable
+    public function getUpdatedAt(): CarbonImmutable
     {
         return $this->updatedAt;
     }
@@ -33,7 +26,7 @@ trait TimestampableImmutableTrait
     {
         $dateTime = CarbonImmutable::now();
 
-        if ($this->createdAt === null) {
+        if (isset($this->createdAt) === false) {
             $this->createdAt = $dateTime;
         }
 

--- a/packages/EasyDoctrine/tests/Subscribers/TimestampableEventSubscriberTest.php
+++ b/packages/EasyDoctrine/tests/Subscribers/TimestampableEventSubscriberTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Tests\Subscribers;
 
+use Carbon\CarbonImmutable;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -12,7 +13,7 @@ use EonX\EasyDoctrine\Subscribers\TimestampableEventSubscriber;
 use EonX\EasyDoctrine\Tests\AbstractTestCase;
 use EonX\EasyDoctrine\Tests\Fixtures\Product;
 use EonX\EasyDoctrine\Tests\Stubs\EntityManagerStub;
-use EonX\EasyDoctrine\Traits\TimestampableImmutableTrait;
+use EonX\EasyDoctrine\Traits\TimestampableTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -56,7 +57,7 @@ final class TimestampableEventSubscriberTest extends AbstractTestCase
     public function testLoadClassMetadataDoesNothingWhenEntityIsMappedSuperClass(): void
     {
         $entity = new class() implements TimestampableInterface {
-            use TimestampableImmutableTrait;
+            use TimestampableTrait;
         };
         $classMetadata = new ClassMetadata(Product::class);
         $classMetadata->reflClass = new ReflectionClass($entity);
@@ -101,7 +102,7 @@ final class TimestampableEventSubscriberTest extends AbstractTestCase
     public function testLoadClassMetadataSucceeds(): void
     {
         $entity = new class() implements TimestampableInterface {
-            use TimestampableImmutableTrait;
+            use TimestampableTrait;
         };
         $classMetadata = new ClassMetadata(Product::class);
         $classMetadata->reflClass = new ReflectionClass($entity);
@@ -115,7 +116,7 @@ final class TimestampableEventSubscriberTest extends AbstractTestCase
 
         self::assertCount(1, $classMetadata->getLifecycleCallbacks(Events::prePersist));
         self::assertCount(1, $classMetadata->getLifecycleCallbacks(Events::preUpdate));
-        self::assertSame('DateTimeInterface', $classMetadata->getFieldMapping('createdAt')['type']);
-        self::assertSame('DateTimeInterface', $classMetadata->getFieldMapping('updatedAt')['type']);
+        self::assertSame(CarbonImmutable::class, $classMetadata->getFieldMapping('createdAt')['type']);
+        self::assertSame(CarbonImmutable::class, $classMetadata->getFieldMapping('updatedAt')['type']);
     }
 }

--- a/packages/EasyDoctrine/tests/Traits/TimestampableTraitTest.php
+++ b/packages/EasyDoctrine/tests/Traits/TimestampableTraitTest.php
@@ -6,19 +6,19 @@ namespace EonX\EasyDoctrine\Tests\Traits;
 
 use Carbon\CarbonImmutable;
 use EonX\EasyDoctrine\Tests\AbstractTestCase;
-use EonX\EasyDoctrine\Traits\TimestampableImmutableTrait;
+use EonX\EasyDoctrine\Traits\TimestampableTrait;
 
 /**
- * @covers \EonX\EasyDoctrine\Traits\TimestampableImmutableTrait
+ * @covers \EonX\EasyDoctrine\Traits\TimestampableTrait
  */
-final class TimestampableImmutableTraitTest extends AbstractTestCase
+final class TimestampableTraitTest extends AbstractTestCase
 {
     public function testGetCreatedAtSucceeds(): void
     {
         $now = CarbonImmutable::now();
         CarbonImmutable::setTestNow($now);
         $object = new class() {
-            use TimestampableImmutableTrait;
+            use TimestampableTrait;
         };
         $object->updateTimestamps();
 
@@ -32,7 +32,7 @@ final class TimestampableImmutableTraitTest extends AbstractTestCase
         $now = CarbonImmutable::now();
         CarbonImmutable::setTestNow($now);
         $object = new class() {
-            use TimestampableImmutableTrait;
+            use TimestampableTrait;
         };
         $object->updateTimestamps();
 
@@ -45,7 +45,7 @@ final class TimestampableImmutableTraitTest extends AbstractTestCase
     {
         CarbonImmutable::setTestNow('2021-11-24');
         $object = new class() {
-            use TimestampableImmutableTrait;
+            use TimestampableTrait;
         };
 
         $object->updateTimestamps();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Backward compatibility changes:
- Renamed the `TimestampableImmutableTrait` trait to `TimestampableTrait`.
