### PR TITLE
[EasyBatch] Fix error handling on EasyBatchExceptionInterface to include previous exception

### DIFF
--- a/packages/EasyBatch/src/Bridge/Symfony/Messenger/ProcessBatchItemMiddleware.php
+++ b/packages/EasyBatch/src/Bridge/Symfony/Messenger/ProcessBatchItemMiddleware.php
@@ -102,7 +102,11 @@ final class ProcessBatchItemMiddleware implements MiddlewareInterface
         } catch (\Throwable $throwable) {
             // Do not retry if exception from package
             if ($throwable instanceof EasyBatchExceptionInterface) {
-                throw new UnrecoverableMessageHandlingException($throwable->getMessage());
+                throw new UnrecoverableMessageHandlingException(
+                    $throwable->getMessage(),
+                    $throwable->getCode(),
+                    $throwable
+                );
             }
 
             if (($throwable instanceof HandlerFailedException)


### PR DESCRIPTION
- Update ProcessBatchItemMiddleware to fix handling EasyBatchExceptionInterface and include previous exception in new "wrapping" exception

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
