### PR TITLE
[EasyLogging] Add aliases after all bundles loaded

### DIFF
--- a/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/Compiler/ReplaceChannelsDefinitionPass.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/Compiler/ReplaceChannelsDefinitionPass.php
@@ -26,6 +26,11 @@ final class ReplaceChannelsDefinitionPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container): void
     {
+        $container->addAliases([
+            'logger' => 'easy_logging.logger',
+            LoggerInterface::class => 'logger'
+        ]);
+
         $defaultChannel = $container->getParameter(BridgeConstantsInterface::PARAM_DEFAULT_CHANNEL);
 
         foreach ($container->findTaggedServiceIds(self::MONOLOG_LOGGER_TAG) as $tags) {

--- a/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/Compiler/ReplaceChannelsDefinitionPass.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/DependencyInjection/Compiler/ReplaceChannelsDefinitionPass.php
@@ -28,7 +28,7 @@ final class ReplaceChannelsDefinitionPass implements CompilerPassInterface
     {
         $container->addAliases([
             'logger' => 'easy_logging.logger',
-            LoggerInterface::class => 'logger'
+            LoggerInterface::class => 'logger',
         ]);
 
         $defaultChannel = $container->getParameter(BridgeConstantsInterface::PARAM_DEFAULT_CHANNEL);

--- a/packages/EasyLogging/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/Resources/config/services.php
@@ -7,7 +7,6 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use EonX\EasyLogging\Bridge\BridgeConstantsInterface;
 use EonX\EasyLogging\Interfaces\LoggerFactoryInterface;
 use EonX\EasyLogging\LoggerFactory;
-use Psr\Log\LoggerInterface;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -30,7 +29,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('easy_logging.logger', '%' . BridgeConstantsInterface::PARAM_LOGGER_CLASS . '%')
         ->factory([service(LoggerFactoryInterface::class), 'create'])
         ->args(['%' . BridgeConstantsInterface::PARAM_DEFAULT_CHANNEL . '%']);
-
-    $services->alias('logger', 'easy_logging.logger');
-    $services->alias(LoggerInterface::class, 'logger');
 };

--- a/packages/EasyUtils/src/Math.php
+++ b/packages/EasyUtils/src/Math.php
@@ -66,10 +66,10 @@ final class Math implements MathInterface
 
     public function divide(string $dividend, string $divisor, ?int $precision = null, ?int $mode = null): string
     {
-        $value = \bcdiv($dividend, $divisor, $this->scale);
-
-        if ($value === null) {
-            throw new InvalidDivisionByZeroException('Division by 0 is invalid');
+        try {
+            $value = \bcdiv($dividend, $divisor, $this->scale);
+        } catch (\DivisionByZeroError $exception) {
+            throw new InvalidDivisionByZeroException('Division by 0 is invalid', 0, $exception);
         }
 
         return $this->round($value, $precision, $mode);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,9 +5,6 @@ services:
     - class: EonX\EasyMonorepo\PHPStan\SymfonyMessengerEnvelopeLastReturnType
       tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
-    - class: Symplify\PHPStanRules\ObjectCalisthenics\Rules\NoElseAndElseIfRule
-      tags: [phpstan.rules.rule]
-
 parameters:
     parallel:
             maximumNumberOfProcesses: 2


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

If `MonologBundle` is registered after `EasyLoggingBundle` it replaces our aliases.

In this PR we add aliases in the compiler pass - at this step, all bundles are already loaded.