### PR TITLE
[EasyActivity] Use Symfony UuidFactory to generate IDs for ActivityLog

### DIFF
--- a/packages/EasyActivity/src/Bridge/Doctrine/DoctrineDbalStore.php
+++ b/packages/EasyActivity/src/Bridge/Doctrine/DoctrineDbalStore.php
@@ -6,8 +6,8 @@ namespace EonX\EasyActivity\Bridge\Doctrine;
 
 use Doctrine\DBAL\Connection;
 use EonX\EasyActivity\ActivityLogEntry;
+use EonX\EasyActivity\Interfaces\IdFactoryInterface;
 use EonX\EasyActivity\Interfaces\StoreInterface;
-use EonX\EasyRandom\Interfaces\RandomGeneratorInterface;
 
 final class DoctrineDbalStore implements StoreInterface
 {
@@ -17,9 +17,9 @@ final class DoctrineDbalStore implements StoreInterface
     private $connection;
 
     /**
-     * @var \EonX\EasyRandom\Interfaces\RandomGeneratorInterface
+     * @var \EonX\EasyActivity\Interfaces\IdFactoryInterface
      */
-    private $random;
+    private $idFactory;
 
     /**
      * @var string
@@ -27,19 +27,19 @@ final class DoctrineDbalStore implements StoreInterface
     private $table;
 
     public function __construct(
-        RandomGeneratorInterface $random,
+        IdFactoryInterface $idFactory,
         Connection $connection,
         string $table
     ) {
         $this->connection = $connection;
-        $this->random = $random;
+        $this->idFactory = $idFactory;
         $this->table = $table;
     }
 
     public function store(ActivityLogEntry $logEntry): ActivityLogEntry
     {
         $data = [
-            'id' => $this->random->uuidV4(),
+            'id' => $this->idFactory->create(),
             'created_at' => $logEntry->getCreatedAt(),
             'updated_at' => $logEntry->getUpdatedAt(),
             'actor_type' => $logEntry->getActorType(),

--- a/packages/EasyActivity/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Resources/config/services.php
@@ -12,6 +12,7 @@ use EonX\EasyActivity\Bridge\Symfony\Messenger\ActivityLogEntryMessageHandler;
 use EonX\EasyActivity\Bridge\Symfony\Messenger\AsyncDispatcher;
 use EonX\EasyActivity\Bridge\Symfony\Serializers\CircularReferenceHandler;
 use EonX\EasyActivity\Bridge\Symfony\Serializers\SymfonyActivitySubjectDataSerializer;
+use EonX\EasyActivity\Bridge\Symfony\Uid\UuidFactory;
 use EonX\EasyActivity\Interfaces\ActivityLogEntryFactoryInterface;
 use EonX\EasyActivity\Interfaces\ActivityLoggerInterface;
 use EonX\EasyActivity\Interfaces\ActivitySubjectDataResolverInterface;
@@ -19,6 +20,7 @@ use EonX\EasyActivity\Interfaces\ActivitySubjectDataSerializerInterface;
 use EonX\EasyActivity\Interfaces\ActivitySubjectResolverInterface;
 use EonX\EasyActivity\Interfaces\ActorResolverInterface;
 use EonX\EasyActivity\Interfaces\AsyncDispatcherInterface;
+use EonX\EasyActivity\Interfaces\IdFactoryInterface;
 use EonX\EasyActivity\Interfaces\StoreInterface;
 use EonX\EasyActivity\Logger\AsyncActivityLogger;
 use EonX\EasyActivity\Resolvers\DefaultActivitySubjectResolver;
@@ -33,6 +35,9 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(StoreInterface::class, DoctrineDbalStore::class)
         ->arg('$table', '%' . BridgeConstantsInterface::PARAM_TABLE_NAME . '%');
+
+    $services
+        ->set(IdFactoryInterface::class, UuidFactory::class);
 
     $services
         ->set(ActorResolverInterface::class, DefaultActorResolver::class);

--- a/packages/EasyActivity/src/Bridge/Symfony/Uid/UuidFactory.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Uid/UuidFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyActivity\Bridge\Symfony\Uid;
+
+use EonX\EasyActivity\Interfaces\IdFactoryInterface;
+use Symfony\Component\Uid\Factory\UuidFactory as SymfonyUuidFactory;
+
+final class UuidFactory implements IdFactoryInterface
+{
+    public function __construct(private SymfonyUuidFactory $uuidFactory)
+    {
+        // The body is not required
+    }
+
+    public function create(): int|string
+    {
+        return (string)$this->uuidFactory->create();
+    }
+}

--- a/packages/EasyActivity/src/Interfaces/IdFactoryInterface.php
+++ b/packages/EasyActivity/src/Interfaces/IdFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyActivity\Interfaces;
+
+interface IdFactoryInterface
+{
+    public function create(): int|string;
+}

--- a/packages/EasyActivity/tests/Bridge/Symfony/Stubs/KernelStub.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Stubs/KernelStub.php
@@ -20,8 +20,6 @@ use EonX\EasyDoctrine\Interfaces\EntityEventSubscriberInterface;
 use EonX\EasyDoctrine\Subscribers\EntityEventSubscriber;
 use EonX\EasyDoctrine\Utils\ObjectCopier;
 use EonX\EasyEventDispatcher\Bridge\Symfony\EventDispatcher;
-use EonX\EasyRandom\Interfaces\RandomGeneratorInterface;
-use EonX\EasyRandom\RandomGenerator;
 use EonX\EasyWebhook\Tests\Bridge\Symfony\Stubs\MessageBusStub;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -38,8 +36,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface as SymfonyNormal
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
-
-use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use Symfony\Component\Uid\Factory\UuidFactory;
 
 final class KernelStub extends Kernel implements CompilerPassInterface
 {
@@ -74,7 +71,7 @@ final class KernelStub extends Kernel implements CompilerPassInterface
                 ->setFactory([ObjectCopierFactory::class, 'create']),
         ]);
         $container->setDefinition(DeferredEntityEventDispatcherInterface::class, $deferredEntityDefinition);
-        $container->setDefinition(RandomGeneratorInterface::class, new Definition(RandomGenerator::class));
+        $container->setDefinition(UuidFactory::class, new Definition(UuidFactory::class));
         $container->setDefinition(LoggerInterface::class, new Definition(NullLogger::class));
         $container->setDefinition(MessageBusInterface::class, new Definition(MessageBusStub::class));
         $container->setDefinition(

--- a/packages/EasyActivity/tests/Stubs/EntityManagerStub.php
+++ b/packages/EasyActivity/tests/Stubs/EntityManagerStub.php
@@ -17,6 +17,7 @@ use EonX\EasyActivity\Bridge\EasyDoctrine\EasyDoctrineEntityEventsSubscriber;
 use EonX\EasyActivity\Bridge\Symfony\Messenger\ActivityLogEntryMessage;
 use EonX\EasyActivity\Bridge\Symfony\Messenger\ActivityLogEntryMessageHandler;
 use EonX\EasyActivity\Bridge\Symfony\Messenger\AsyncDispatcher;
+use EonX\EasyActivity\Bridge\Symfony\Uid\UuidFactory;
 use EonX\EasyActivity\Interfaces\ActivitySubjectResolverInterface;
 use EonX\EasyActivity\Interfaces\ActorResolverInterface;
 use EonX\EasyActivity\Logger\AsyncActivityLogger;
@@ -29,12 +30,11 @@ use EonX\EasyDoctrine\ORM\Decorators\EntityManagerDecorator;
 use EonX\EasyDoctrine\Subscribers\EntityEventSubscriber;
 use EonX\EasyEventDispatcher\Bridge\Symfony\EventDispatcher;
 use EonX\EasyEventDispatcher\Interfaces\EventDispatcherInterface;
-use EonX\EasyRandom\RandomGenerator;
-use EonX\EasyRandom\UuidV4\SymfonyUidUuidV4Generator;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Uid\Factory\UuidFactory as SymfonyUuidFactory;
 
 final class EntityManagerStub extends EntityManager
 {
@@ -97,10 +97,9 @@ final class EntityManagerStub extends EntityManager
             $entityManager->getConnection()
                 ->executeQuery($migrateStatement);
         }
-        $randomGenerator = new RandomGenerator();
-        $randomGenerator->setUuidV4Generator(new SymfonyUidUuidV4Generator());
+        $uuidFactory = new UuidFactory(new SymfonyUuidFactory());
         $dbalStore = new DoctrineDbalStore(
-            $randomGenerator,
+            $uuidFactory,
             $entityManager->getConnection(),
             self::ACTIVITY_TABLE_NAME
         );


### PR DESCRIPTION
Currently we use `\EonX\EasyRandom\RandomGenerator::uuidV4()` to generate IDs for `ActivityLog`.
It makes sense to use `Symfony\Component\Uid\Factory\UuidFactory` for the following reasons:
* consistency with other tables
* UuidV6, that Symfony uses by default, has advantages over UuidV4

How this change will affect projects:
* Projects that uses UuidV4 (has a `default_uuid_version = 4` setting) will not be affected
* Projects that uses UuidV6 will save activity logs with a new ID format. But as UuidV4  is randomly generated, this change should not break anything.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes