### PR TITLE
[EasyErrorHandler] Add logic to handle Symfony Messenger UnrecoverableMessageHandlingException

### DIFF
--- a/packages/EasyErrorHandler/src/ErrorHandler.php
+++ b/packages/EasyErrorHandler/src/ErrorHandler.php
@@ -17,6 +17,7 @@ use EonX\EasyUtils\CollectorHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Throwable;
 
 final class ErrorHandler implements ErrorHandlerInterface
@@ -103,6 +104,15 @@ final class ErrorHandler implements ErrorHandlerInterface
             foreach ($throwable->getNestedExceptions() as $nestedThrowable) {
                 $this->report($nestedThrowable);
             }
+
+            return;
+        }
+
+        // Symfony Messenger UnrecoverableMessageHandlingException
+        if (\class_exists(UnrecoverableMessageHandlingException::class)
+            && $throwable instanceof UnrecoverableMessageHandlingException
+            && $throwable->getPrevious() instanceof Throwable) {
+            $this->report($throwable->getPrevious());
 
             return;
         }


### PR DESCRIPTION
- Add logic to handle Symfony Messenger UnrecoverableMessageHandlingException

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
