### PR TITLE
[EasyUtils] Enable sensitive data sanitizer by default + implement default keys to mask

### DIFF
--- a/packages/EasyBugsnag/src/Bridge/Laravel/EasyBugsnagServiceProvider.php
+++ b/packages/EasyBugsnag/src/Bridge/Laravel/EasyBugsnagServiceProvider.php
@@ -162,7 +162,7 @@ final class EasyBugsnagServiceProvider extends ServiceProvider
 
     private function registerSensitiveDataSanitizer(): void
     {
-        if (\config('easy-bugsnag.sensitive_data_sanitizer.enabled', false)) {
+        if (\config('easy-bugsnag.sensitive_data_sanitizer.enabled', true)) {
             $this->app->singleton(
                 SensitiveDataSanitizerConfigurator::class,
                 static function (Container $app): SensitiveDataSanitizerConfigurator {

--- a/packages/EasyBugsnag/src/Bridge/Laravel/config/easy-bugsnag.php
+++ b/packages/EasyBugsnag/src/Bridge/Laravel/config/easy-bugsnag.php
@@ -66,7 +66,7 @@ return [
         /**
          * Enable sensitive data sanitization.
          */
-        'enabled' => false,
+        'enabled' => true,
     ],
 
     'session_tracking' => [

--- a/packages/EasyBugsnag/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/packages/EasyBugsnag/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -86,7 +86,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('sensitive_data_sanitizer')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->booleanNode('enabled')->defaultFalse()->end()
+                        ->booleanNode('enabled')->defaultTrue()->end()
                     ->end()
                 ->end()
                 // Session Tracking

--- a/packages/EasyBugsnag/src/Bridge/Symfony/DependencyInjection/EasyBugsnagExtension.php
+++ b/packages/EasyBugsnag/src/Bridge/Symfony/DependencyInjection/EasyBugsnagExtension.php
@@ -99,7 +99,7 @@ final class EasyBugsnagExtension extends Extension
 
         $container->setParameter(
             BridgeConstantsInterface::PARAM_SENSITIVE_DATA_SANITIZER_ENABLED,
-            $config['sensitive_data_sanitizer']['enabled'] ?? false
+            $config['sensitive_data_sanitizer']['enabled'] ?? true
         );
 
         if ($config['session_tracking']['enabled'] ?? false) {

--- a/packages/EasyBugsnag/tests/Bridge/Laravel/AbstractLaravelTestCase.php
+++ b/packages/EasyBugsnag/tests/Bridge/Laravel/AbstractLaravelTestCase.php
@@ -6,6 +6,7 @@ namespace EonX\EasyBugsnag\Tests\Bridge\Laravel;
 
 use EonX\EasyBugsnag\Bridge\Laravel\EasyBugsnagServiceProvider;
 use EonX\EasyBugsnag\Tests\AbstractTestCase;
+use EonX\EasyUtils\Bridge\Laravel\EasyUtilsServiceProvider;
 use Laravel\Lumen\Application;
 
 abstract class AbstractLaravelTestCase extends AbstractTestCase
@@ -30,6 +31,7 @@ abstract class AbstractLaravelTestCase extends AbstractTestCase
             \config($config);
         }
 
+        $app->register(EasyUtilsServiceProvider::class);
         $app->register(EasyBugsnagServiceProvider::class);
         $app->boot();
 

--- a/packages/EasyUtils/src/Bridge/BridgeConstantsInterface.php
+++ b/packages/EasyUtils/src/Bridge/BridgeConstantsInterface.php
@@ -23,6 +23,7 @@ interface BridgeConstantsInterface
     public const SENSITIVE_DATA_PARAMS = [
         self::PARAM_SENSITIVE_DATA_KEYS_TO_MASK => 'keys_to_mask',
         self::PARAM_SENSITIVE_DATA_MASK_PATTERN => 'mask_pattern',
+        self::PARAM_SENSITIVE_DATA_USE_DEFAULT_KEYS_TO_MASK => 'use_default_keys_to_mask',
     ];
 
     /**
@@ -59,6 +60,11 @@ interface BridgeConstantsInterface
      * @var string
      */
     public const PARAM_SENSITIVE_DATA_MASK_PATTERN = 'easy_utils.mask_pattern';
+
+    /**
+     * @var string
+     */
+    public const PARAM_SENSITIVE_DATA_USE_DEFAULT_KEYS_TO_MASK = 'easy_utils.use_default_keys_to_mask';
 
     /**
      * @var string

--- a/packages/EasyUtils/src/Bridge/Laravel/EasyUtilsServiceProvider.php
+++ b/packages/EasyUtils/src/Bridge/Laravel/EasyUtilsServiceProvider.php
@@ -78,6 +78,7 @@ final class EasyUtilsServiceProvider extends ServiceProvider
                 SensitiveDataSanitizerInterface::class,
                 static function (Container $container): SensitiveDataSanitizerInterface {
                     return new SensitiveDataSanitizer(
+                        \config('easy-utils.sensitive_data.use_default_keys_to_mask', true),
                         \config('easy-utils.sensitive_data.keys_to_mask', []),
                         \config('easy-utils.sensitive_data.mask_pattern'),
                         $container->tagged(BridgeConstantsInterface::TAG_SENSITIVE_DATA_OBJECT_TRANSFORMER),

--- a/packages/EasyUtils/src/Bridge/Laravel/config/easy-utils.php
+++ b/packages/EasyUtils/src/Bridge/Laravel/config/easy-utils.php
@@ -7,6 +7,7 @@ return [
         'enabled' => true,
         'keys_to_mask' => [],
         'mask_pattern' => null,
+        'use_default_keys_to_mask' => true,
         'use_default_object_transformers' => true,
         'use_default_string_sanitizers' => true,
     ],

--- a/packages/EasyUtils/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/packages/EasyUtils/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ final class Configuration implements ConfigurationInterface
                         ->booleanNode('enabled')->defaultTrue()->end()
                         ->arrayNode('keys_to_mask')->scalarPrototype()->end()->end()
                         ->scalarNode('mask_pattern')->defaultNull()->end()
+                        ->booleanNode('use_default_keys_to_mask')->defaultTrue()->end()
                         ->booleanNode('use_default_object_transformers')->defaultTrue()->end()
                         ->booleanNode('use_default_string_sanitizers')->defaultTrue()->end()
                     ->end()

--- a/packages/EasyUtils/src/Bridge/Symfony/Resources/config/sensitive_data.php
+++ b/packages/EasyUtils/src/Bridge/Symfony/Resources/config/sensitive_data.php
@@ -16,6 +16,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services
         ->set(SensitiveDataSanitizerInterface::class, SensitiveDataSanitizer::class)
+        ->arg('$useDefaultKeysToMask', param(BridgeConstantsInterface::PARAM_SENSITIVE_DATA_USE_DEFAULT_KEYS_TO_MASK))
         ->arg('$keysToMask', param(BridgeConstantsInterface::PARAM_SENSITIVE_DATA_KEYS_TO_MASK))
         ->arg('$maskPattern', param(BridgeConstantsInterface::PARAM_SENSITIVE_DATA_MASK_PATTERN))
         ->arg('$objectTransformers', tagged_iterator(BridgeConstantsInterface::TAG_SENSITIVE_DATA_OBJECT_TRANSFORMER))

--- a/packages/EasyUtils/src/SensitiveData/SensitiveDataSanitizer.php
+++ b/packages/EasyUtils/src/SensitiveData/SensitiveDataSanitizer.php
@@ -31,12 +31,20 @@ final class SensitiveDataSanitizer implements SensitiveDataSanitizerInterface
      * @param iterable<mixed>|null $stringSanitizers
      */
     public function __construct(
+        ?bool $useDefaultKeysToMask = null,
         ?array $keysToMask = null,
         ?string $maskPattern = null,
         ?iterable $objectTransformers = null,
         ?iterable $stringSanitizers = null
     ) {
-        $this->keysToMask = \array_map(fn (string $key) => \mb_strtolower($key), $keysToMask ?? []);
+        $defaultKeysToMask = ($useDefaultKeysToMask ?? true) ? self::DEFAULT_KEYS_TO_MASK : [];
+        foreach (\array_map(fn (string $key) => \mb_strtolower($key), $keysToMask ?? []) as $keyToMask) {
+            if (\in_array($keysToMask, $defaultKeysToMask, true) === false) {
+                $defaultKeysToMask[] = $keyToMask;
+            }
+        }
+
+        $this->keysToMask = $defaultKeysToMask;
         $this->maskPattern = $maskPattern ?? self::DEFAULT_MASK_PATTERN;
         $this->objectTransformers = CollectorHelper::orderLowerPriorityFirstAsArray(
             CollectorHelper::filterByClass($objectTransformers ?? [], ObjectTransformerInterface::class)

--- a/packages/EasyUtils/src/SensitiveData/SensitiveDataSanitizerInterface.php
+++ b/packages/EasyUtils/src/SensitiveData/SensitiveDataSanitizerInterface.php
@@ -6,6 +6,29 @@ namespace EonX\EasyUtils\SensitiveData;
 
 interface SensitiveDataSanitizerInterface
 {
+    public const DEFAULT_KEYS_TO_MASK = [
+        'access_key',
+        'access_secret',
+        'access_token',
+        'apikey',
+        'auth_basic',
+        'authorization',
+        'card_number',
+        'cert',
+        'cvc',
+        'cvv',
+        'number',
+        'password',
+        'php-auth-pw',
+        'php_auth_pw',
+        'php-auth-user',
+        'php_auth_user',
+        'securitycode',
+        'token',
+        'verificationcode',
+        'x-shared-key',
+    ];
+
     public const DEFAULT_MASK_PATTERN = '*REDACTED*';
 
     public function sanitize(mixed $data): mixed;

--- a/packages/EasyUtils/tests/SensitiveData/SensitiveDataSanitizerTest.php
+++ b/packages/EasyUtils/tests/SensitiveData/SensitiveDataSanitizerTest.php
@@ -31,6 +31,6 @@ final class SensitiveDataSanitizerTest extends AbstractSensitiveDataSanitizerTes
             new CreditCardNumberStringSanitizer(),
         ];
 
-        return new SensitiveDataSanitizer($keysToMask, null, $objectTransformers, $stringSanitizers);
+        return new SensitiveDataSanitizer(null, $keysToMask, null, $objectTransformers, $stringSanitizers);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
