### PR TITLE
[EasyBankFiles] Make fileUserNetTotalAmount absolute

### DIFF
--- a/packages/EasyBankFiles/src/Generators/Aba/Generator.php
+++ b/packages/EasyBankFiles/src/Generators/Aba/Generator.php
@@ -107,7 +107,7 @@ final class Generator extends BaseGenerator
             'fileUserCountOfRecordsType' => $count,
             'fileUserCreditTotalAmount' => $creditTotal,
             'fileUserDebitTotalAmount' => $debitTotal,
-            'fileUserNetTotalAmount' => $creditTotal - $debitTotal,
+            'fileUserNetTotalAmount' => \abs($creditTotal - $debitTotal),
         ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

According to NAB and Cuscal docs, this field must be unsigned.
<img width="1023" alt="Снимок экрана 2022-05-16 в 15 03 46" src="https://user-images.githubusercontent.com/6824784/168599013-4ffa9957-b9de-46a1-a09f-c81595901056.png">
<img width="1277" alt="Снимок экрана 2022-05-16 в 15 04 49" src="https://user-images.githubusercontent.com/6824784/168599028-b5dd031d-489d-434f-846d-4ee5c0d849b0.png">

