### PR TITLE
[EasyWebhook] feature/easy-webhooks-add-config-for-timestamps-timezone

### DIFF
--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -25,7 +25,9 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
 
     public function store(WebhookResultInterface $result): WebhookResultInterface
     {
-        $now = Carbon::now('UTC');
+        $timezone = \config('easy-webhook.timezone', 'UTC');
+
+        $now = Carbon::now($timezone);
         $data = $this->getData($result, $now);
 
         // New result with no id

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
@@ -84,7 +84,9 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
 
     public function store(WebhookInterface $webhook): WebhookInterface
     {
-        $now = Carbon::now('UTC');
+        $timezone = \config('easy-webhook.timezone', 'UTC');
+
+        $now = Carbon::now($timezone);
         $data = \array_merge($webhook->getExtra() ?? [], $webhook->toArray());
         $data['class'] = \get_class($webhook);
         $data['updated_at'] = $now;


### PR DESCRIPTION
- added timezone configuration for timestamps of easy_webhooks and easy_webhook_results.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes  <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
