### PR TITLE
[EasyWebhook] feature/easy-webhooks-add-config-for-timestamps-timezone

### DIFF
--- a/packages/EasyWebhook/src/Interfaces/Stores/StoreInterface.php
+++ b/packages/EasyWebhook/src/Interfaces/Stores/StoreInterface.php
@@ -21,6 +21,11 @@ interface StoreInterface
     /**
      * @var string
      */
+    public const DEFAULT_TIMEZONE = 'UTC';
+
+    /**
+     * @var string
+     */
     public const DEFAULT_WEBHOOK_ID = 'webhook-id';
 
     /**

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -17,22 +17,27 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
     /**
      * @var string|null
      */
-    private $timestampTimezone;
+    private $timestamp;
 
     public function __construct(
         RandomGeneratorInterface $random,
         Connection $conn,
         DataCleanerInterface $dataCleaner,
         ?string $table = null,
-        ?string $timestampTimezone = null
+        ?string $timestamp = null
     ) {
-        $this->timestampTimezone = $timestampTimezone;
+        $this->timestamp = $timestamp;
         parent::__construct($random, $conn, $dataCleaner, $table ?? 'easy_webhook_results');
+    }
+
+    public function getTimestamp(): ?string
+    {
+        return $this->timestamp;
     }
 
     public function store(WebhookResultInterface $result): WebhookResultInterface
     {
-        $timezone = $this->timestampTimezone ?? 'UTC';
+        $timezone = $this->timestamp ?? 'UTC';
 
         $now = Carbon::now($timezone);
         $data = $this->getData($result, $now);

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -15,6 +15,11 @@ use EonX\EasyWebhook\Interfaces\WebhookResultInterface;
 final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements ResultStoreInterface
 {
     /**
+     * @var string
+     */
+    private const DEFAULT_TIMEZONE = 'UTC';
+
+    /**
      * @var string|null
      */
     private $timestamp;
@@ -26,7 +31,7 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
         ?string $table = null,
         ?string $timestamp = null
     ) {
-        $this->timestamp = $timestamp ?? 'UTC';
+        $this->timestamp = $timestamp ?? self::DEFAULT_TIMEZONE;
         parent::__construct($random, $conn, $dataCleaner, $table ?? 'easy_webhook_results');
     }
 

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -15,7 +15,7 @@ use EonX\EasyWebhook\Interfaces\WebhookResultInterface;
 final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements ResultStoreInterface
 {
     /**
-     * @var null|string
+     * @var string|null
      */
     private $timestampTimezone;
 

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -14,18 +14,27 @@ use EonX\EasyWebhook\Interfaces\WebhookResultInterface;
 
 final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements ResultStoreInterface
 {
+    /**
+     * @var null|string
+     */
+    private $timestampTimezone;
+
     public function __construct(
         RandomGeneratorInterface $random,
         Connection $conn,
         DataCleanerInterface $dataCleaner,
-        ?string $table = null
+        ?string $table = null,
+        ?string $timestampTimezone = null
     ) {
+        $this->timestampTimezone = $timestampTimezone;
         parent::__construct($random, $conn, $dataCleaner, $table ?? 'easy_webhook_results');
     }
 
     public function store(WebhookResultInterface $result): WebhookResultInterface
     {
-        $now = Carbon::now('UTC');
+        $timezone = $this->timestampTimezone ?? 'UTC';
+
+        $now = Carbon::now($timezone);
         $data = $this->getData($result, $now);
 
         // New result with no id

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -22,27 +22,27 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
     /**
      * @var string|null
      */
-    private $timestamp;
+    private $timezone;
 
     public function __construct(
         RandomGeneratorInterface $random,
         Connection $conn,
         DataCleanerInterface $dataCleaner,
         ?string $table = null,
-        ?string $timestamp = null
+        ?string $timezone = null
     ) {
-        $this->timestamp = $timestamp ?? self::DEFAULT_TIMEZONE;
+        $this->timezone = $timezone ?? self::DEFAULT_TIMEZONE;
         parent::__construct($random, $conn, $dataCleaner, $table ?? 'easy_webhook_results');
     }
 
-    public function getTimestamp(): ?string
+    public function getTimezone(): ?string
     {
-        return $this->timestamp;
+        return $this->timezone;
     }
 
     public function store(WebhookResultInterface $result): WebhookResultInterface
     {
-        $now = Carbon::now($this->timestamp);
+        $now = Carbon::now($this->timezone);
         $data = $this->getData($result, $now);
 
         // New result with no id

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -26,7 +26,7 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
         ?string $table = null,
         ?string $timestamp = null
     ) {
-        $this->timestamp = $timestamp;
+        $this->timestamp = $timestamp ?? 'UTC';
         parent::__construct($random, $conn, $dataCleaner, $table ?? 'easy_webhook_results');
     }
 
@@ -37,9 +37,7 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
 
     public function store(WebhookResultInterface $result): WebhookResultInterface
     {
-        $timezone = $this->timestamp ?? 'UTC';
-
-        $now = Carbon::now($timezone);
+        $now = Carbon::now($this->timestamp);
         $data = $this->getData($result, $now);
 
         // New result with no id

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -10,15 +10,11 @@ use EonX\EasyRandom\Interfaces\RandomGeneratorInterface;
 use EonX\EasyUtils\ErrorDetailsHelper;
 use EonX\EasyWebhook\Interfaces\Stores\DataCleanerInterface;
 use EonX\EasyWebhook\Interfaces\Stores\ResultStoreInterface;
+use EonX\EasyWebhook\Interfaces\Stores\StoreInterface;
 use EonX\EasyWebhook\Interfaces\WebhookResultInterface;
 
 final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements ResultStoreInterface
 {
-    /**
-     * @var string
-     */
-    private const DEFAULT_TIMEZONE = 'UTC';
-
     /**
      * @var string|null
      */
@@ -31,7 +27,7 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
         ?string $table = null,
         ?string $timezone = null
     ) {
-        $this->timezone = $timezone ?? self::DEFAULT_TIMEZONE;
+        $this->timezone = $timezone ?? StoreInterface::DEFAULT_TIMEZONE;
         parent::__construct($random, $conn, $dataCleaner, $table ?? 'easy_webhook_results');
     }
 

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalResultStore.php
@@ -31,11 +31,6 @@ final class DoctrineDbalResultStore extends AbstractDoctrineDbalStore implements
         parent::__construct($random, $conn, $dataCleaner, $table ?? 'easy_webhook_results');
     }
 
-    public function getTimezone(): ?string
-    {
-        return $this->timezone;
-    }
-
     public function store(WebhookResultInterface $result): WebhookResultInterface
     {
         $now = Carbon::now($this->timezone);

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
@@ -30,9 +30,9 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
         Connection $conn,
         DataCleanerInterface $dataCleaner,
         ?string $table = null,
-        ?string $timestampTimezone = null
+        ?string $timezoneTimezone = null
     ) {
-        $this->timestampTimezone = $timestampTimezone;
+        $this->timestampTimezone = $timezoneTimezone;
         parent::__construct($random, $conn, $dataCleaner, $table ?? self::DEFAULT_TABLE);
     }
 

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
@@ -89,11 +89,6 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
         return $this->random->uuidV4();
     }
 
-    public function getTimezone(): ?string
-    {
-        return $this->timezone;
-    }
-
     public function store(WebhookInterface $webhook): WebhookInterface
     {
         $now = Carbon::now($this->timezone);

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
@@ -21,11 +21,6 @@ use EonX\EasyWebhook\Webhook;
 final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements StoreInterface, SendAfterStoreInterface
 {
     /**
-     * @var string
-     */
-    private const DEFAULT_TIMEZONE = 'UTC';
-
-    /**
      * @var string|null
      */
     private $timezone;

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
@@ -21,18 +21,23 @@ use EonX\EasyWebhook\Webhook;
 final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements StoreInterface, SendAfterStoreInterface
 {
     /**
+     * @var string
+     */
+    private const DEFAULT_TIMEZONE = 'UTC';
+
+    /**
      * @var string|null
      */
-    private $timestampTimezone;
+    private $timezone;
 
     public function __construct(
         RandomGeneratorInterface $random,
         Connection $conn,
         DataCleanerInterface $dataCleaner,
         ?string $table = null,
-        ?string $timezoneTimezone = null
+        ?string $timezone = null
     ) {
-        $this->timestampTimezone = $timezoneTimezone;
+        $this->timezone = $timezone ?? self::DEFAULT_TIMEZONE;
         parent::__construct($random, $conn, $dataCleaner, $table ?? self::DEFAULT_TABLE);
     }
 
@@ -89,11 +94,14 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
         return $this->random->uuidV4();
     }
 
+    public function getTimezone(): ?string
+    {
+        return $this->timezone;
+    }
+
     public function store(WebhookInterface $webhook): WebhookInterface
     {
-        $timezone = $this->timestampTimezone ?? 'UTC';
-
-        $now = Carbon::now($timezone);
+        $now = Carbon::now($this->timezone);
         $data = \array_merge($webhook->getExtra() ?? [], $webhook->toArray());
         $data['class'] = \get_class($webhook);
         $data['updated_at'] = $now;

--- a/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Stores/DoctrineDbalStore.php
@@ -20,12 +20,19 @@ use EonX\EasyWebhook\Webhook;
 
 final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements StoreInterface, SendAfterStoreInterface
 {
+    /**
+     * @var string|null
+     */
+    private $timestampTimezone;
+
     public function __construct(
         RandomGeneratorInterface $random,
         Connection $conn,
         DataCleanerInterface $dataCleaner,
-        ?string $table = null
+        ?string $table = null,
+        ?string $timestampTimezone = null
     ) {
+        $this->timestampTimezone = $timestampTimezone;
         parent::__construct($random, $conn, $dataCleaner, $table ?? self::DEFAULT_TABLE);
     }
 
@@ -84,7 +91,9 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
 
     public function store(WebhookInterface $webhook): WebhookInterface
     {
-        $now = Carbon::now('UTC');
+        $timezone = $this->timestampTimezone ?? 'UTC';
+
+        $now = Carbon::now($timezone);
         $data = \array_merge($webhook->getExtra() ?? [], $webhook->toArray());
         $data['class'] = \get_class($webhook);
         $data['updated_at'] = $now;

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -53,6 +53,7 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
 
         $sql = \sprintf('SELECT * FROM %s WHERE id = :id', 'easy_webhook_results');
 
+        /** @var mixed[] $data */
         $data = $conn->fetchAssociative($sql, [
             'id' => $result->getId(),
         ]);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -57,6 +57,7 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
 
         $sql = \sprintf('SELECT * FROM %s WHERE id = :id', 'easy_webhook_results');
 
+        /** @var mixed[] $data */
         $data = $conn->fetchAssociative($sql, [
             'id' => $result->getId(),
         ]);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -35,8 +35,9 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
      */
     public function testStoreWithTimezone(): void
     {
-        // Time in UTC, this is as 00:00:00.
-        Carbon::setTestNow('2022-05-19');
+        $dateNow = new Carbon();
+        // Time in UTC,
+        Carbon::setTestNow($dateNow);
 
         $webHookId = 'webhook-id';
 
@@ -62,13 +63,12 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
             'id' => $result->getId(),
         ]);
 
-        // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $expected */
         $expected = [
-            'updated_at' => '2022-05-19 10:00:00',
-            'created_at' => '2022-05-19 10:00:00',
+            'updated_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
+            'created_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
         ];
-
+        // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => (string) Arr::get($data, 'updated_at', ''),

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -28,7 +28,6 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         $store->store($result);
 
         self::assertNotEmpty($result->getId());
-        self::assertEquals('UTC', $store->getTimezone());
     }
 
     /**
@@ -68,14 +67,12 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         $expected = [
             'updated_at' => '2022-05-19 10:00:00',
             'created_at' => '2022-05-19 10:00:00',
-            'timezone' => 'Australia/Melbourne',
         ];
 
         /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => (string) Arr::get($data, 'updated_at', ''),
             'created_at' => (string) Arr::get($data, 'created_at', ''),
-            'timezone' => $store->getTimezone(),
         ];
 
         self::assertEquals($expected, $actual);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -28,7 +28,7 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         $store->store($result);
 
         self::assertNotEmpty($result->getId());
-        self::assertEquals('UTC', $store->getTimestamp());
+        self::assertEquals('UTC', $store->getTimezone());
     }
 
     /**
@@ -75,7 +75,7 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         $actual = [
             'updated_at' => (string) Arr::get($data, 'updated_at', ''),
             'created_at' => (string) Arr::get($data, 'created_at', ''),
-            'timezone' => $store->getTimestamp(),
+            'timezone' => $store->getTimezone(),
         ];
 
         self::assertEquals($expected, $actual);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -57,7 +57,6 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
 
         $sql = \sprintf('SELECT * FROM %s WHERE id = :id', 'easy_webhook_results');
 
-        /** @var mixed[] $data */
         $data = $conn->fetchAssociative($sql, [
             'id' => $result->getId(),
         ]);
@@ -75,7 +74,6 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
             'created_at' => (string) Arr::get($data, 'created_at', ''),
         ];
 
-        self::assertSame($expected, $actual);
-        self::assertNotEmpty($result->getId());
+        self::assertEquals($expected, $actual);
     }
 }

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -65,11 +65,11 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         ];
 
         $actual = [
-            'updated_at' => Arr::get($data, 'updated_at'),
-            'created_at' => Arr::get($data, 'created_at'),
+            'updated_at' => Arr::get($data, 'updated_at', ''),
+            'created_at' => Arr::get($data, 'created_at', ''),
         ];
 
         self::assertNotEmpty($result->getId());
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 }

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace EonX\EasyWebhook\Tests\Stores;
 
+use Carbon\Carbon;
 use EonX\EasyWebhook\Interfaces\WebhookInterface;
 use EonX\EasyWebhook\Stores\DoctrineDbalResultStore;
 use EonX\EasyWebhook\Tests\AbstractStoreTestCase;
 use EonX\EasyWebhook\Webhook;
 use EonX\EasyWebhook\WebhookResult;
+use Illuminate\Support\Arr;
 
 final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
 {
@@ -26,5 +28,48 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         $store->store($result);
 
         self::assertNotEmpty($result->getId());
+    }
+
+    public function testStoreWithTimezone(): void
+    {
+        // Time in UTC.
+        Carbon::setTestNow('2022-05-19 01:00:00');
+
+        $webHookId = 'webhook-id';
+
+        $conn = $this->getDoctrineDbalConnection();
+
+        $store = new DoctrineDbalResultStore(
+            $this->getRandomGenerator(),
+            $conn,
+            $this->getDataCleaner(),
+            'easy_webhook_results',
+            'Australia/Melbourne'
+        );
+        $webhook = Webhook::create('https://eonx.com', null, WebhookInterface::DEFAULT_METHOD)
+            ->id($webHookId);
+        $result = new WebhookResult($webhook);
+
+        $store->store($result);
+
+        $sql = \sprintf('SELECT * FROM %s WHERE id = :id', 'easy_webhook_results');
+
+        $data = $conn->fetchAssociative($sql, [
+            'id' => $result->getId(),
+        ]);
+
+        // Should be Australia/Melbourne TZ, +10 Hrs.
+        $expected = [
+            'updated_at' => '2022-05-19 11:00:00',
+            'created_at' => '2022-05-19 11:00:00',
+        ];
+
+        $actual = [
+            'updated_at' => Arr::get($data, 'updated_at'),
+            'created_at' => Arr::get($data, 'created_at'),
+        ];
+
+        self::assertNotEmpty($result->getId());
+        self::assertEquals($expected, $actual);
     }
 }

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -10,7 +10,6 @@ use EonX\EasyWebhook\Stores\DoctrineDbalResultStore;
 use EonX\EasyWebhook\Tests\AbstractStoreTestCase;
 use EonX\EasyWebhook\Webhook;
 use EonX\EasyWebhook\WebhookResult;
-use Illuminate\Support\Arr;
 
 final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
 {
@@ -65,8 +64,8 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         ];
 
         $actual = [
-            'updated_at' => Arr::get($data, 'updated_at', ''),
-            'created_at' => Arr::get($data, 'created_at', ''),
+            'updated_at' => $data['updated_at'] ?? '',
+            'created_at' => $data['created_at'] ?? '',
         ];
 
         self::assertNotEmpty($result->getId());

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -35,8 +35,8 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
      */
     public function testStoreWithTimezone(): void
     {
-        // Time in UTC.
-        Carbon::setTestNow('2022-05-19 01:00:00');
+        // Time in UTC, this is as 00:00:00.
+        Carbon::setTestNow('2022-05-19');
 
         $webHookId = 'webhook-id';
 
@@ -65,14 +65,14 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $expected */
         $expected = [
-            'updated_at' => '2022-05-19 11:00:00',
-            'created_at' => '2022-05-19 11:00:00',
+            'updated_at' => '2022-05-19 10:00:00',
+            'created_at' => '2022-05-19 10:00:00',
         ];
 
         /** @var array<string, string> $actual */
         $actual = [
-            'updated_at' => (string) Arr::get($data, 'updated_at',''),
-            'created_at' => (string) Arr::get($data, 'created_at',''),
+            'updated_at' => (string) Arr::get($data, 'updated_at', ''),
+            'created_at' => (string) Arr::get($data, 'created_at', ''),
         ];
 
         self::assertSame($expected, $actual);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -58,11 +58,13 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         ]);
 
         // Should be Australia/Melbourne TZ, +10 Hrs.
+        /** @var array<string, string> $expected */
         $expected = [
             'updated_at' => '2022-05-19 11:00:00',
             'created_at' => '2022-05-19 11:00:00',
         ];
 
+        /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => $data['updated_at'] ?? '',
             'created_at' => $data['created_at'] ?? '',

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -10,6 +10,7 @@ use EonX\EasyWebhook\Stores\DoctrineDbalResultStore;
 use EonX\EasyWebhook\Tests\AbstractStoreTestCase;
 use EonX\EasyWebhook\Webhook;
 use EonX\EasyWebhook\WebhookResult;
+use Illuminate\Support\Arr;
 
 final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
 {
@@ -29,6 +30,9 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         self::assertNotEmpty($result->getId());
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
     public function testStoreWithTimezone(): void
     {
         // Time in UTC.
@@ -67,11 +71,11 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
 
         /** @var array<string, string> $actual */
         $actual = [
-            'updated_at' => $data['updated_at'] ?? '',
-            'created_at' => $data['created_at'] ?? '',
+            'updated_at' => (string) Arr::get($data, 'updated_at',''),
+            'created_at' => (string) Arr::get($data, 'created_at',''),
         ];
 
-        self::assertNotEmpty($result->getId());
         self::assertSame($expected, $actual);
+        self::assertNotEmpty($result->getId());
     }
 }

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -35,9 +35,8 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
      */
     public function testStoreWithTimezone(): void
     {
-        $dateNow = new Carbon();
-        // Time in UTC,
-        Carbon::setTestNow($dateNow);
+        // Time in UTC, this is at 00:00:00.
+        Carbon::setTestNow('2022-05-19');
 
         $webHookId = 'webhook-id';
 
@@ -63,12 +62,13 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
             'id' => $result->getId(),
         ]);
 
+        // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $expected */
         $expected = [
-            'updated_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
-            'created_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
+            'updated_at' => '2022-05-19 10:00:00',
+            'created_at' => '2022-05-19 10:00:00',
         ];
-        // Should be Australia/Melbourne TZ, +10 Hrs.
+
         /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => (string) Arr::get($data, 'updated_at', ''),

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalResultStoreTest.php
@@ -28,6 +28,7 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         $store->store($result);
 
         self::assertNotEmpty($result->getId());
+        self::assertEquals('UTC', $store->getTimestamp());
     }
 
     /**
@@ -67,12 +68,14 @@ final class DoctrineDbalResultStoreTest extends AbstractStoreTestCase
         $expected = [
             'updated_at' => '2022-05-19 10:00:00',
             'created_at' => '2022-05-19 10:00:00',
+            'timezone' => 'Australia/Melbourne',
         ];
 
         /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => (string) Arr::get($data, 'updated_at', ''),
             'created_at' => (string) Arr::get($data, 'created_at', ''),
+            'timezone' => $store->getTimestamp(),
         ];
 
         self::assertEquals($expected, $actual);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -11,6 +11,7 @@ use EonX\EasyWebhook\Stores\DoctrineDbalStore;
 use EonX\EasyWebhook\Tests\AbstractStoreTestCase;
 use EonX\EasyWebhook\Webhook;
 use Illuminate\Database\Capsule\Manager;
+use Illuminate\Support\Arr;
 
 final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTestCase
 {
@@ -29,6 +30,9 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
         self::assertInstanceOf(WebhookInterface::class, $store->find($id));
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
     public function testStoreWithTimezone(): void
     {
         // Time in UTC.
@@ -66,8 +70,8 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
         ];
         /** @var array<string, string> $actual */
         $actual = [
-            'updated_at' => $data['updated_at'] ?? '',
-            'created_at' => $data['created_at'] ?? '',
+            'updated_at' => (string) Arr::get($data, 'updated_at',''),
+            'created_at' => (string) Arr::get($data, 'created_at',''),
         ];
 
         self::assertSame($expected, $actual);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -57,7 +57,6 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
 
         $sql = \sprintf('SELECT * FROM %s WHERE id = :id', 'easy_webhooks');
 
-        /** @var mixed[] $data */
         $data = $conn->fetchAssociative($sql, [
             'id' => $id,
         ]);
@@ -74,8 +73,7 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
             'created_at' => (string) Arr::get($data, 'created_at', ''),
         ];
 
-        self::assertSame($expected, $actual);
-        self::assertInstanceOf(WebhookInterface::class, $store->find($id));
+        self::assertEquals($expected, $actual);
     }
 
     protected function getDoctrineDbalConnection(): Connection

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -69,7 +69,7 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
             'created_at' => Arr::get($data, 'created_at'),
         ];
 
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
         self::assertInstanceOf(WebhookInterface::class, $store->find($id));
     }
 
@@ -82,7 +82,6 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
             'prefix' => '',
         ]);
 
-        return $this->doctrineDbal = $this->doctrineDbal ?? $dbManager->getConnection()
-                ->getDoctrineConnection();
+        return $this->doctrineDbal = $this->doctrineDbal ?? $dbManager->getConnection()->getDoctrineConnection();
     }
 }

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -81,6 +81,7 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
             'prefix' => '',
         ]);
 
-        return $this->doctrineDbal = $this->doctrineDbal ?? $dbManager->getConnection()->getDoctrineConnection();
+        return $this->doctrineDbal = $this->doctrineDbal ?? $dbManager->getConnection()
+            ->getDoctrineConnection();
     }
 }

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -35,8 +35,9 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
      */
     public function testStoreWithTimezone(): void
     {
-        // Time in UTC, this is at 00:00:00
-        Carbon::setTestNow('2022-05-19');
+        $dateNow = new Carbon();
+        // Time in UTC,
+        Carbon::setTestNow($dateNow);
 
         $conn = $this->getDoctrineDbalConnection();
         $id = 'my-id';
@@ -62,12 +63,12 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
             'id' => $id,
         ]);
 
-        // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $expected */
         $expected = [
-            'updated_at' => '2022-05-19 10:00:00',
-            'created_at' => '2022-05-19 10:00:00',
+            'updated_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
+            'created_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
         ];
+        // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => (string) Arr::get($data, 'updated_at', ''),

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -57,6 +57,7 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
 
         $sql = \sprintf('SELECT * FROM %s WHERE id = :id', 'easy_webhooks');
 
+        /** @var mixed[] $data */
         $data = $conn->fetchAssociative($sql, [
             'id' => $id,
         ]);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -53,16 +53,18 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
 
         $sql = \sprintf('SELECT * FROM %s WHERE id = :id', 'easy_webhooks');
 
+        /** @var mixed[] $data */
         $data = $conn->fetchAssociative($sql, [
             'id' => $id,
         ]);
 
         // Should be Australia/Melbourne TZ, +10 Hrs.
+        /** @var array<string, string> $expected */
         $expected = [
             'updated_at' => '2022-05-19 11:00:00',
             'created_at' => '2022-05-19 11:00:00',
         ];
-
+        /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => $data['updated_at'] ?? '',
             'created_at' => $data['created_at'] ?? '',

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -35,8 +35,8 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
      */
     public function testStoreWithTimezone(): void
     {
-        // Time in UTC.
-        Carbon::setTestNow('2022-05-19 01:00:00');
+        // Time in UTC, this is at 00:00:00
+        Carbon::setTestNow('2022-05-19');
 
         $conn = $this->getDoctrineDbalConnection();
         $id = 'my-id';
@@ -65,13 +65,13 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
         // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $expected */
         $expected = [
-            'updated_at' => '2022-05-19 11:00:00',
-            'created_at' => '2022-05-19 11:00:00',
+            'updated_at' => '2022-05-19 10:00:00',
+            'created_at' => '2022-05-19 10:00:00',
         ];
         /** @var array<string, string> $actual */
         $actual = [
-            'updated_at' => (string) Arr::get($data, 'updated_at',''),
-            'created_at' => (string) Arr::get($data, 'created_at',''),
+            'updated_at' => (string) Arr::get($data, 'updated_at', ''),
+            'created_at' => (string) Arr::get($data, 'created_at', ''),
         ];
 
         self::assertSame($expected, $actual);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -35,9 +35,8 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
      */
     public function testStoreWithTimezone(): void
     {
-        $dateNow = new Carbon();
-        // Time in UTC,
-        Carbon::setTestNow($dateNow);
+        // Time in UTC, this is at 00:00:00
+        Carbon::setTestNow('2022-05-19');
 
         $conn = $this->getDoctrineDbalConnection();
         $id = 'my-id';
@@ -63,12 +62,12 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
             'id' => $id,
         ]);
 
+        // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $expected */
         $expected = [
-            'updated_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
-            'created_at' => $dateNow->copy()->setTimezone('Australia/Melbourne')->toDateTimeString(),
+            'updated_at' => '2022-05-19 10:00:00',
+            'created_at' => '2022-05-19 10:00:00',
         ];
-        // Should be Australia/Melbourne TZ, +10 Hrs.
         /** @var array<string, string> $actual */
         $actual = [
             'updated_at' => (string) Arr::get($data, 'updated_at', ''),

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreFromIlluminateDatabaseTest.php
@@ -11,7 +11,6 @@ use EonX\EasyWebhook\Stores\DoctrineDbalStore;
 use EonX\EasyWebhook\Tests\AbstractStoreTestCase;
 use EonX\EasyWebhook\Webhook;
 use Illuminate\Database\Capsule\Manager;
-use Illuminate\Support\Arr;
 
 final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTestCase
 {
@@ -65,8 +64,8 @@ final class DoctrineDbalStoreFromIlluminateDatabaseTest extends AbstractStoreTes
         ];
 
         $actual = [
-            'updated_at' => Arr::get($data, 'updated_at'),
-            'created_at' => Arr::get($data, 'created_at'),
+            'updated_at' => $data['updated_at'] ?? '',
+            'created_at' => $data['created_at'] ?? '',
         ];
 
         self::assertSame($expected, $actual);

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreTest.php
@@ -98,7 +98,6 @@ final class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $store->store($webhook);
 
         self::assertInstanceOf(WebhookInterface::class, $store->find($id));
-        self::assertEquals('UTC', $store->getTimezone());
     }
 
     private function getStore(): DoctrineDbalStore

--- a/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreTest.php
+++ b/packages/EasyWebhook/tests/Stores/DoctrineDbalStoreTest.php
@@ -98,6 +98,7 @@ final class DoctrineDbalStoreTest extends AbstractStoreTestCase
         $store->store($webhook);
 
         self::assertInstanceOf(WebhookInterface::class, $store->find($id));
+        self::assertEquals('UTC', $store->getTimezone());
     }
 
     private function getStore(): DoctrineDbalStore


### PR DESCRIPTION
- Added timezone on DoctrineDbalStore DoctrineDbalResult as optional parameter for timestamps.
---
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
