### PR TITLE
[EasyHttpClient] Rename log channel for HTTP requests

### DIFF
--- a/packages/EasyHttpClient/src/Bridge/BridgeConstantsInterface.php
+++ b/packages/EasyHttpClient/src/Bridge/BridgeConstantsInterface.php
@@ -9,7 +9,7 @@ interface BridgeConstantsInterface
     /**
      * @var string
      */
-    public const LOG_CHANNEL = 'http_client';
+    public const LOG_CHANNEL = 'easy_http_client';
 
     /**
      * @var string


### PR DESCRIPTION
The `http_client` log channel [is used for symfony/http-client](https://github.com/symfony/symfony/blob/123b1651c4a7e219ba59074441badfac65525efe/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php#L32).

This causes a problem: when we log messages from the `http_channel` we have duplicated messages from `eonx-com/easy-http-client` and `symfony/http-client`.

In EonX projects we use the `EasyHttpClientBridgeConstantsInterface::LOG_CHANNEL` constant. So, renaming should not break our projects.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes

