### PR TITLE
[EasyErrorHandler] Update default translation domain for Symfony bridge

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -42,7 +42,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('override_api_platform_listener')->defaultTrue()->end()
                 ->booleanNode('use_default_builders')->defaultTrue()->end()
                 ->booleanNode('use_default_reporters')->defaultTrue()->end()
-                ->scalarNode('translation_domain')->defaultValue('EasyErrorHandlerBundle')->end()
+                ->scalarNode('translation_domain')->defaultValue('messages')->end()
                 ->arrayNode('response')
                     ->addDefaultsIfNotSet()
                     ->children()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Using `messages` as default translation domain will make it easier for applications to translate their own messages.