### PR TITLE
[EasyDoctrine] Fix timezone issue in CarbonImmutableDateTime

### DIFF
--- a/packages/EasyDoctrine/src/DBAL/Types/CarbonImmutableDateTimeMicrosecondsType.php
+++ b/packages/EasyDoctrine/src/DBAL/Types/CarbonImmutableDateTimeMicrosecondsType.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace EonX\EasyDoctrine\DBAL\Types;
 
 use Carbon\CarbonImmutable;
+use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
 
 final class CarbonImmutableDateTimeMicrosecondsType extends DateTimeImmutableType
 {
+    private static ?DateTimeZone $utc = null;
+
     /**
      * @var string
      */
@@ -44,8 +48,8 @@ final class CarbonImmutableDateTimeMicrosecondsType extends DateTimeImmutableTyp
             return $value;
         }
 
-        if ($value instanceof DateTimeInterface) {
-            return $value->format(self::FORMAT_PHP_DATETIME);
+        if ($value instanceof DateTimeImmutable || $value instanceof DateTime) {
+            return $value->setTimezone(self::getUtc())->format(self::FORMAT_PHP_DATETIME);
         }
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTimeInterface']);
@@ -66,10 +70,10 @@ final class CarbonImmutableDateTimeMicrosecondsType extends DateTimeImmutableTyp
             return CarbonImmutable::instance($value);
         }
 
-        $dateTime = DateTimeImmutable::createFromFormat(self::FORMAT_PHP_DATETIME, $value);
+        $dateTime = DateTimeImmutable::createFromFormat(self::FORMAT_PHP_DATETIME, $value, self::getUtc());
 
         if ($dateTime === false) {
-            $dateTime = \date_create_immutable($value);
+            $dateTime = \date_create_immutable($value, self::getUtc());
         }
 
         if ($dateTime instanceof DateTimeInterface) {
@@ -95,5 +99,13 @@ final class CarbonImmutableDateTimeMicrosecondsType extends DateTimeImmutableTyp
         }
 
         return self::FORMAT_DB_DATETIME;
+    }
+
+    private static function getUtc(): \DateTimeZone
+    {
+        if (self::$utc === null) {
+            self::$utc = new \DateTimeZone('UTC');
+        }
+        return self::$utc;
     }
 }

--- a/packages/EasyDoctrine/src/DBAL/Types/CarbonImmutableDateTimeMicrosecondsType.php
+++ b/packages/EasyDoctrine/src/DBAL/Types/CarbonImmutableDateTimeMicrosecondsType.php
@@ -101,11 +101,12 @@ final class CarbonImmutableDateTimeMicrosecondsType extends DateTimeImmutableTyp
         return self::FORMAT_DB_DATETIME;
     }
 
-    private static function getUtc(): \DateTimeZone
+    private static function getUtc(): DateTimeZone
     {
         if (self::$utc === null) {
-            self::$utc = new \DateTimeZone('UTC');
+            self::$utc = new DateTimeZone('UTC');
         }
+
         return self::$utc;
     }
 }

--- a/packages/EasyDoctrine/tests/DBAL/Types/CarbonImmutableDateTimeMicrosecondsTypeTest.php
+++ b/packages/EasyDoctrine/tests/DBAL/Types/CarbonImmutableDateTimeMicrosecondsTypeTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Tests\DBAL\Types;
 
+use Carbon\CarbonImmutable;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Types\ConversionException;
@@ -26,13 +28,16 @@ final class CarbonImmutableDateTimeMicrosecondsTypeTest extends AbstractTestCase
      */
     public function provideConvertToDatabaseValues(): iterable
     {
-        $datetime = new DateTimeImmutable();
-
         yield 'null value' => [null, null];
 
         yield 'datetime value' => [
-            $datetime,
-            $datetime->format(CarbonImmutableDateTimeMicrosecondsType::FORMAT_PHP_DATETIME),
+            new DateTimeImmutable('2022-01-01T10:00:00+00:00'),
+            '2022-01-01 10:00:00.000000',
+        ];
+
+        yield 'datetime value with timezone' => [
+            new CarbonImmutable('2022-01-01T10:00:00+09:00'),
+            '2022-01-01 01:00:00.000000',
         ];
     }
 
@@ -43,21 +48,26 @@ final class CarbonImmutableDateTimeMicrosecondsTypeTest extends AbstractTestCase
      */
     public function provideConvertToPHPValues(): iterable
     {
-        $datetime = new DateTimeImmutable();
-        $milliseconds = $datetime->format('u');
-
         yield 'null value' => [null, null];
 
-        yield 'DateTimeInterface object' => [$datetime, $datetime];
+        yield 'DateTimeInterface object' => [
+            new DateTimeImmutable('2022-01-01 10:00:00.12345'),
+            new DateTimeImmutable('2022-01-01 10:00:00.12345'),
+        ];
 
         yield 'datetime string with milliseconds' => [
-            $datetime->format(CarbonImmutableDateTimeMicrosecondsType::FORMAT_PHP_DATETIME),
-            $datetime,
+            '2022-01-01 10:00:00.12345',
+            new DateTimeImmutable('2022-01-01 10:00:00.12345', new DateTimeZone('UTC')),
         ];
 
         yield 'datetime string' => [
-            $datetime->format('Y-m-d H:i:s'),
-            $datetime->modify("-{$milliseconds} microsecond"),
+            '2022-01-01 10:00:00',
+            new DateTimeImmutable('2022-01-01 10:00:00', new DateTimeZone('UTC')),
+        ];
+
+        yield 'datetime string with timezone' => [
+            '2022-01-01T10:00:00+09:00',
+            new DateTimeImmutable('2022-01-01 01:00:00.000000', new DateTimeZone('UTC')),
         ];
     }
 

--- a/packages/EasyDoctrine/tests/DBAL/Types/DateTimeImmutableMicrosecondsTypeTest.php
+++ b/packages/EasyDoctrine/tests/DBAL/Types/DateTimeImmutableMicrosecondsTypeTest.php
@@ -6,6 +6,7 @@ namespace EonX\EasyDoctrine\Tests\DBAL\Types;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
@@ -26,13 +27,16 @@ final class DateTimeImmutableMicrosecondsTypeTest extends AbstractTestCase
      */
     public function provideConvertToDatabaseValues(): iterable
     {
-        $datetime = new DateTimeImmutable();
-
         yield 'null value' => [null, null];
 
         yield 'datetime value' => [
-            $datetime,
-            $datetime->format(DateTimeImmutableMicrosecondsType::FORMAT_PHP_DATETIME),
+            new DateTimeImmutable('2022-01-01T10:00:00+00:00'),
+            '2022-01-01 10:00:00.000000',
+        ];
+
+        yield 'datetime value with timezone' => [
+            new DateTimeImmutable('2022-01-01T10:00:00+09:00'),
+            '2022-01-01 01:00:00.000000',
         ];
     }
 
@@ -43,21 +47,26 @@ final class DateTimeImmutableMicrosecondsTypeTest extends AbstractTestCase
      */
     public function provideConvertToPHPValues(): iterable
     {
-        $datetime = new DateTimeImmutable();
-        $milliseconds = $datetime->format('u');
-
         yield 'null value' => [null, null];
 
-        yield 'DateTimeInterface object' => [$datetime, $datetime];
+        yield 'DateTimeInterface object' => [
+            new DateTimeImmutable('2022-01-01 10:00:00.12345'),
+            new DateTimeImmutable('2022-01-01 10:00:00.12345'),
+        ];
 
         yield 'datetime string with milliseconds' => [
-            $datetime->format(DateTimeImmutableMicrosecondsType::FORMAT_PHP_DATETIME),
-            $datetime,
+            '2022-01-01 10:00:00.12345',
+            new DateTimeImmutable('2022-01-01 10:00:00.12345', new DateTimeZone('UTC')),
         ];
 
         yield 'datetime string' => [
-            $datetime->format('Y-m-d H:i:s'),
-            $datetime->modify("-{$milliseconds} microsecond"),
+            '2022-01-01 10:00:00',
+            new DateTimeImmutable('2022-01-01 10:00:00', new DateTimeZone('UTC')),
+        ];
+
+        yield 'datetime string with timezone' => [
+            '2022-01-01T10:00:00+09:00',
+            new DateTimeImmutable('2022-01-01 01:00:00.000000', new DateTimeZone('UTC')),
         ];
     }
 


### PR DESCRIPTION
Currently out DBAL Type for `DateTime`'s doesn't take into account `TimeZone`'s.

As a result, `2022-01-01T10:00:00+09:00` will be processed in DB as `2022-01-01T10:00:00+00:00`. It affects `WHERE` conditions and stored values. 

New implementation is based on advice from [doctrine documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/2.11/cookbook/working-with-datetime.html#:~:text=By%20default%20Doctrine%20assumes%20that,or%20by%20calling%20date_default_timezone_set()%20.). 
Changes may break BC in theory.  But in practice everything should be fine because we use UTC in our projects.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no 
| Tests pass?   | yes
