### PR TITLE
[EasyCore] Allow to reset simple data persister services

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/DependencyInjection/Compiler/ApiPlatformDataPersistersPass.php
+++ b/packages/EasyCore/src/Bridge/Symfony/DependencyInjection/Compiler/ApiPlatformDataPersistersPass.php
@@ -105,7 +105,8 @@ final class ApiPlatformDataPersistersPass implements CompilerPassInterface
             ->setAutowired(true)
             ->setArgument('$container', new Reference('service_container'))
             ->setArgument('$simplePersisters', $this->getSimplePersisters($container))
-            ->setArgument('$persisters', new TaggedIteratorArgument(self::ORIGINAL_PERSISTER_TAG));
+            ->setArgument('$persisters', new TaggedIteratorArgument(self::ORIGINAL_PERSISTER_TAG))
+            ->addTag('kernel.reset', ['method' => 'reset']);
 
         // If not debug, simply set data persister to chain simple one.
         if ($debug === false) {
@@ -118,7 +119,8 @@ final class ApiPlatformDataPersistersPass implements CompilerPassInterface
         $container->setDefinition(self::CHAIN_SIMPLE_PERSISTER_ID, $chainSimplePersisterDef);
 
         $traceablePersisterDef = (new Definition(TraceableChainSimpleDataPersister::class))
-            ->setArgument('$decorated', new Reference(self::CHAIN_SIMPLE_PERSISTER_ID));
+            ->setArgument('$decorated', new Reference(self::CHAIN_SIMPLE_PERSISTER_ID))
+            ->addTag('kernel.reset', ['method' => 'reset']);
 
         $container->setDefinition(self::ORIGINAL_PERSISTER_ID, $traceablePersisterDef);
         $container->setDefinition(self::ORIGINAL_DEBUG_PERSISTER_ID, $traceablePersisterDef);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
