### PR TITLE
[EasySecurity] Add deprecation for SecurityContextInterface autowiring usage

### DIFF
--- a/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterSecurityContextPass.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterSecurityContextPass.php
@@ -39,7 +39,8 @@ final class RegisterSecurityContextPass implements CompilerPassInterface
             ->setDeprecated(
                 'eonx-com/easy-security',
                 '4.1.37',
-                'The "%service_id%" service autowiring is deprecated and will be removed in 5.0. Use SecurityContextResolverInterface::resolveContext instead.'
+                'The "%service_id%" service autowiring is deprecated and will be removed in 5.0.'.
+                ' Use SecurityContextResolverInterface::resolveContext instead.'
             );
 
         if ($contextServiceId !== SecurityContextInterface::class) {

--- a/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterSecurityContextPass.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterSecurityContextPass.php
@@ -35,7 +35,12 @@ final class RegisterSecurityContextPass implements CompilerPassInterface
         $container
             ->setDefinition($contextServiceId, new Definition(SecurityContextInterface::class))
             ->setFactory([new Reference(SecurityContextResolverInterface::class), 'resolveContext'])
-            ->setPublic(true);
+            ->setPublic(true)
+            ->setDeprecated(
+                'eonx-com/easy-security',
+                '4.1.37',
+                'The "%service_id%" service autowiring is deprecated and will be removed in 5.0. Use SecurityContextResolverInterface::resolveContext instead.'
+            );
 
         if ($contextServiceId !== SecurityContextInterface::class) {
             $container->setAlias(SecurityContextInterface::class, $contextServiceId);

--- a/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterSecurityContextPass.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterSecurityContextPass.php
@@ -39,7 +39,7 @@ final class RegisterSecurityContextPass implements CompilerPassInterface
             ->setDeprecated(
                 'eonx-com/easy-security',
                 '4.1.37',
-                'The "%service_id%" service autowiring is deprecated and will be removed in 5.0.'.
+                'The "%service_id%" service autowiring is deprecated and will be removed in 5.0.' .
                 ' Use SecurityContextResolverInterface::resolveContext instead.'
             );
 


### PR DESCRIPTION
- Add deprecation for SecurityContextInterface autowiring usage

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes 
