### PR TITLE
[EasyUtils] Added the `auth_bearer` key to `SensitiveDataSanitizerInterface::DEFAULT_KEYS_TO_MASK`

### DIFF
--- a/packages/EasyUtils/src/SensitiveData/SensitiveDataSanitizerInterface.php
+++ b/packages/EasyUtils/src/SensitiveData/SensitiveDataSanitizerInterface.php
@@ -12,6 +12,7 @@ interface SensitiveDataSanitizerInterface
         'access_token',
         'apikey',
         'auth_basic',
+        'auth_bearer',
         'authorization',
         'card_number',
         'cert',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

