### PR TITLE
[EasyCore] Improve AbstractInputDataTransformer

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
@@ -28,8 +28,13 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
      */
     public function supportsTransformation(mixed $data, string $to, ?array $context = null): bool
     {
-        return $to === $this->getApiResourceClass()
-            && ($context['input']['class'] ?? null) === $this->getInputDtoClass();
+        $apiResourceClass = $this->getApiResourceClass();
+
+        if ($data instanceof $apiResourceClass) {
+            return false;
+        }
+
+        return $to === $apiResourceClass && ($context['input']['class'] ?? null) === $this->getInputDtoClass();
     }
 
     /**
@@ -38,7 +43,7 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
      */
     public function transform(mixed $object, string $to, ?array $context = null): object
     {
-        $this->validator->validate($object);
+        $this->doValidate($object);
 
         return $this->doTransform($object, $context);
     }
@@ -51,4 +56,12 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
     abstract protected function getApiResourceClass(): string;
 
     abstract protected function getInputDtoClass(): string;
+
+    /**
+     * @param object $object
+     */
+    protected function doValidate(mixed $object): void
+    {
+        $this->validator->validate($object);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The API Platform Docs recommend checking if `$data` is an instance of an object to which we want to transform.
<img width="1440" alt="Снимок экрана 2022-07-28 в 13 16 04" src="https://user-images.githubusercontent.com/6824784/181492631-ee20283a-39f5-468d-82d5-4a1bd4e14245.png">
[https://api-platform.com/docs/core/dto/#initialize-the-input-dto-for-partial-update](https://api-platform.com/docs/core/dto/#initialize-the-input-dto-for-partial-update)

We already do this in Payments. I have checked in AVC - all tests passed.

In some cases, for example, if we transform an API Resource object, we don't want to do validation.
