### PR TITLE
[EasyLock] Add schema configuration

### DIFF
--- a/packages/EasyActivity/tests/Stubs/EntityManagerStub.php
+++ b/packages/EasyActivity/tests/Stubs/EntityManagerStub.php
@@ -36,7 +36,7 @@ use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Uid\Factory\UuidFactory as SymfonyUuidFactory;
 
-final class EntityManagerStub extends EntityManager
+final class EntityManagerStub
 {
     public const ACTIVITY_TABLE_NAME = 'test_easy_activity_logs';
 
@@ -148,7 +148,7 @@ final class EntityManagerStub extends EntityManager
 
         $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
 
-        $entityManager = parent::create($conn, $config, $eventManager);
+        $entityManager = EntityManager::create($conn, $config, $eventManager);
         $schema = \array_map(function ($class) use ($entityManager) {
             return $entityManager->getClassMetadata($class);
         }, $fixtures);

--- a/packages/EasyDoctrine/tests/Stubs/EntityManagerStub.php
+++ b/packages/EasyDoctrine/tests/Stubs/EntityManagerStub.php
@@ -17,7 +17,7 @@ use EonX\EasyEventDispatcher\Bridge\Symfony\EventDispatcher;
 use EonX\EasyEventDispatcher\Interfaces\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;
 
-final class EntityManagerStub extends EntityManager
+final class EntityManagerStub
 {
     /**
      * @param \EonX\EasyDoctrine\Dispatchers\DeferredEntityEventDispatcher $dispatcher
@@ -67,7 +67,7 @@ final class EntityManagerStub extends EntityManager
 
         $config->setMetadataDriverImpl(new AttributeDriver([]));
 
-        $entityManager = parent::create($conn, $config, $eventManager);
+        $entityManager = EntityManager::create($conn, $config, $eventManager);
         $schema = \array_map(function ($class) use ($entityManager) {
             return $entityManager->getClassMetadata($class);
         }, $fixtures);

--- a/packages/EasyLock/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyLock/src/Bridge/Symfony/Resources/config/services.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use EonX\EasyLock\Bridge\BridgeConstantsInterface;
-use EonX\EasyLock\Bridge\Symfony\SchemaListener\EasyLockDoctrineSchemaSubscriber;
+use EonX\EasyLock\Bridge\Symfony\Subscribers\EasyLockDoctrineSchemaSubscriber;
 use EonX\EasyLock\Interfaces\LockServiceInterface;
 use EonX\EasyLock\LockService;
 

--- a/packages/EasyLock/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyLock/src/Bridge/Symfony/Resources/config/services.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use EonX\EasyLock\Bridge\BridgeConstantsInterface;
+use EonX\EasyLock\Bridge\Symfony\SchemaListener\EasyLockDoctrineSchemaSubscriber;
 use EonX\EasyLock\Interfaces\LockServiceInterface;
 use EonX\EasyLock\LockService;
 
@@ -15,4 +16,9 @@ return static function (ContainerConfigurator $container): void {
         ->set(LockServiceInterface::class, LockService::class)
         ->arg('$store', service(BridgeConstantsInterface::SERVICE_STORE))
         ->tag('monolog.logger', ['channel' => BridgeConstantsInterface::LOG_CHANNEL]);
+
+    $services
+        ->set(EasyLockDoctrineSchemaSubscriber::class)
+        ->arg('$persistingStore', service(BridgeConstantsInterface::SERVICE_STORE))
+        ->tag('doctrine.event_subscriber');
 };

--- a/packages/EasyLock/src/Bridge/Symfony/SchemaListener/EasyLockDoctrineSchemaSubscriber.php
+++ b/packages/EasyLock/src/Bridge/Symfony/SchemaListener/EasyLockDoctrineSchemaSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyLock\Bridge\Symfony\SchemaListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Store\DoctrineDbalStore;
+
+final class EasyLockDoctrineSchemaSubscriber implements EventSubscriber
+{
+    public function __construct(private PersistingStoreInterface $persistingStore)
+    {
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            ToolEvents::postGenerateSchema,
+        ];
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        if ($this->persistingStore instanceof DoctrineDbalStore) {
+            $this->persistingStore->configureSchema($event->getSchema());
+        }
+    }
+}

--- a/packages/EasyLock/src/Bridge/Symfony/Subscribers/EasyLockDoctrineSchemaSubscriber.php
+++ b/packages/EasyLock/src/Bridge/Symfony/Subscribers/EasyLockDoctrineSchemaSubscriber.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace EonX\EasyLock\Bridge\Symfony\SchemaListener;
+namespace EonX\EasyLock\Bridge\Symfony\Subscribers;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -219,10 +219,6 @@ parameters:
         - message: '#Function swoole_(dd|dump)\(\) has parameter \$vars with no type specified#'
           path: packages/EasySwoole/src/Resources/functions/dump.php
 
-        # ---- EasyTest ----
-        - message: '#Unsafe usage of new static\(\)#'
-          path: packages/EasyTest/src/InvalidDataMaker/AbstractInvalidDataMaker.php
-
         # ---- EasyUtils ----
         - message: '#Comparison operation ">" between 0 and 0 is always false#'
           path: packages/EasyUtils/src/Helpers/EnvVarSubstitutionHelper.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This PR adds the `lock_keys` table to schema configuration.
In this case, Doctrine automatically generates migration and tracks this table.
