### PR TITLE
[EasySwoole] Stopping a worker safely when app state is compromised

### DIFF
--- a/packages/EasySwoole/src/Runtime/EasySwooleRunner.php
+++ b/packages/EasySwoole/src/Runtime/EasySwooleRunner.php
@@ -87,7 +87,7 @@ final class EasySwooleRunner implements RunnerInterface
 
                 // Stop worker if app state compromised
                 if ($hfRequest->attributes->get(RequestAttributesInterface::EASY_SWOOLE_APP_STATE_COMPROMISED, false)) {
-                    $server->stop($server->getWorkerId());
+                    $server->stop($server->getWorkerId(), true);
                 }
             }
         );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -219,6 +219,9 @@ parameters:
         - message: '#Function swoole_(dd|dump)\(\) has parameter \$vars with no type specified#'
           path: packages/EasySwoole/src/Resources/functions/dump.php
 
+        - message: '#Method Swoole\\Server\:\:stop\(\) invoked with 2 parameters, 0\-1 required#'
+          path: packages/EasySwoole/src/Runtime/EasySwooleRunner.php
+
         # ---- EasyTest ----
         - message: '#Unsafe usage of new static\(\)#'
           path: packages/EasyTest/src/InvalidDataMaker/AbstractInvalidDataMaker.php


### PR DESCRIPTION
When app state is compromised we stop a worker immediately. It leads to 502 error from ELB.
This PR adds an argument to stop a worker [safely](https://openswoole.com/docs/modules/swoole-server-stop#stopping-a-worker-safely).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
