### PR TITLE
[EasyHttpClient] Limit the metadata size in the `HttpRequestSentBreadcrumbListener` listener

### DIFF
--- a/packages/EasyHttpClient/composer.json
+++ b/packages/EasyHttpClient/composer.json
@@ -14,9 +14,10 @@
         "eonx-com/easy-lock": "^4.2",
         "eonx-com/easy-webhook": "^4.2",
         "laravel/lumen-framework": "^5.8 || ^6.0 || ^8.0",
+        "mockery/mockery": "^1.4",
         "phpunit/phpunit": "^9.5",
-        "symfony/symfony": "^5.4 || ^6.0",
-        "symfony/amazon-sqs-messenger": "^5.4 || ^6.0"
+        "symfony/amazon-sqs-messenger": "^5.4 || ^6.0",
+        "symfony/symfony": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/EasyHttpClient/composer.json
+++ b/packages/EasyHttpClient/composer.json
@@ -10,6 +10,7 @@
         "nesbot/carbon": "^2.22"
     },
     "require-dev": {
+        "bugsnag/bugsnag": "^3.19",
         "doctrine/dbal": "^2.6",
         "eonx-com/easy-lock": "^4.2",
         "eonx-com/easy-webhook": "^4.2",

--- a/packages/EasyHttpClient/src/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListener.php
+++ b/packages/EasyHttpClient/src/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListener.php
@@ -7,79 +7,136 @@ namespace EonX\EasyHttpClient\Bridge\EasyBugsnag;
 use Bugsnag\Breadcrumbs\Breadcrumb;
 use Bugsnag\Client;
 use Carbon\Carbon;
+use DateTimeInterface;
 use EonX\EasyHttpClient\Events\HttpRequestSentEvent;
 use EonX\EasyHttpClient\Interfaces\EasyHttpClientConstantsInterface;
 
 final class HttpRequestSentBreadcrumbListener
 {
-    /**
-     * @var \Bugsnag\Client
-     */
-    private $client;
+    public const BREADCRUMB_NAME = 'HTTP Request Sent';
 
-    public function __construct(Client $client)
+    public const DEFAULT_TIMING_MESSAGE = 'No timing available';
+
+    // The metadata attributes priority list (low to high).
+    private const METADATA_ATTRIBUTES_PRIORITY_LIST = [
+        self::METADATA_ATTRIBUTE_RESPONSE_HEADERS,
+        self::METADATA_ATTRIBUTE_REQUEST_OPTIONS,
+        self::METADATA_ATTRIBUTE_RESPONSE_CONTENT,
+        self::METADATA_ATTRIBUTE_THROWABLE_CLASS,
+        self::METADATA_ATTRIBUTE_THROWABLE_MESSAGE,
+        self::METADATA_ATTRIBUTE_TIMING,
+        self::METADATA_ATTRIBUTE_RESPONSE_STATUS_CODE,
+        self::METADATA_ATTRIBUTE_REQUEST,
+    ];
+
+    private const METADATA_ATTRIBUTE_REQUEST = 'Request';
+
+    private const METADATA_ATTRIBUTE_REQUEST_OPTIONS = 'Request Options';
+
+    private const METADATA_ATTRIBUTE_RESPONSE_CONTENT = 'Response Content';
+
+    private const METADATA_ATTRIBUTE_RESPONSE_HEADERS = 'Response Headers';
+
+    private const METADATA_ATTRIBUTE_RESPONSE_STATUS_CODE = 'Response Status Code';
+
+    private const METADATA_ATTRIBUTE_THROWABLE_CLASS = 'Throwable Class';
+
+    private const METADATA_ATTRIBUTE_THROWABLE_MESSAGE = 'Throwable Message';
+
+    private const METADATA_ATTRIBUTE_TIMING = 'Timing';
+
+    public function __construct(private Client $client)
     {
-        $this->client = $client;
+        // The body is not required
     }
 
     public function __invoke(HttpRequestSentEvent $event): void
-    {
-        $this->handle($event);
-    }
-
-    public function handle(HttpRequestSentEvent $event): void
     {
         $receivedAt = null;
         $request = $event->getRequestData();
         $response = $event->getResponseData();
         $throwable = $event->getThrowable();
 
-        $metaData = [
-            'Request' => \sprintf('%s - %s', $request->getMethod(), $request->getUrl()),
-            'Request Options' => \json_encode($request->getOptions()),
+        $metadata = [
+            self::METADATA_ATTRIBUTE_REQUEST => \sprintf('%s - %s', $request->getMethod(), $request->getUrl()),
+            self::METADATA_ATTRIBUTE_REQUEST_OPTIONS => \json_encode($request->getOptions()),
         ];
 
         if ($response !== null) {
-            $metaData['Response Status Code'] = $response->getStatusCode();
-            $metaData['Response Content'] = $response->getContent();
-            $metaData['Response Headers'] = \json_encode($response->getHeaders());
+            $metadata[self::METADATA_ATTRIBUTE_RESPONSE_STATUS_CODE] = $response->getStatusCode();
+            $metadata[self::METADATA_ATTRIBUTE_RESPONSE_CONTENT] = $response->getContent();
+            $metadata[self::METADATA_ATTRIBUTE_RESPONSE_HEADERS] = \json_encode($response->getHeaders());
 
             $receivedAt = $response->getReceivedAt();
         }
 
         if ($throwable !== null) {
-            $metaData['Throwable Class'] = \get_class($throwable);
-            $metaData['Throwable Message'] = $throwable->getMessage();
+            $metadata[self::METADATA_ATTRIBUTE_THROWABLE_CLASS] = $throwable::class;
+            $metadata[self::METADATA_ATTRIBUTE_THROWABLE_MESSAGE] = $throwable->getMessage();
 
             $receivedAt = $event->getThrowableThrownAt();
         }
 
-        $metaData['Timing'] = $this->getTimingMessage($request->getSentAt(), $receivedAt);
+        $metadata[self::METADATA_ATTRIBUTE_TIMING] = $this->getTimingMessage($request->getSentAt(), $receivedAt);
 
-        $this->client->leaveBreadcrumb('HTTP Request Sent', Breadcrumb::REQUEST_TYPE, $metaData);
+        $this->client->leaveBreadcrumb(
+            self::BREADCRUMB_NAME,
+            Breadcrumb::REQUEST_TYPE,
+            $this->filterMetadata($metadata)
+        );
     }
 
-    private function getCarbon(\DateTimeInterface $dateTime): Carbon
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function calculateBreadcrumbSize(array $metadata): int
+    {
+        $breadcrumb = new Breadcrumb(self::BREADCRUMB_NAME, Breadcrumb::REQUEST_TYPE, $metadata);
+        $breadcrumbData = $breadcrumb->toArray();
+        $breadcrumbData['metaData'] = $metadata;
+
+        return \strlen((string)\json_encode($breadcrumbData));
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     *
+     * @return array<string, mixed>
+     */
+    private function filterMetadata(array $metadata): array
+    {
+        $metadataAttributes = self::METADATA_ATTRIBUTES_PRIORITY_LIST;
+
+        while (
+            $this->calculateBreadcrumbSize($metadata) > Breadcrumb::MAX_SIZE &&
+            \count($metadataAttributes) !== 0 &&
+            \count($metadata) !== 0
+        ) {
+            $attributeToRemove = \array_shift($metadataAttributes);
+
+            unset($metadata[$attributeToRemove]);
+        }
+
+        return $metadata;
+    }
+
+    private function getCarbonInstance(DateTimeInterface $dateTime): Carbon
     {
         if ($dateTime instanceof Carbon) {
             return $dateTime;
         }
 
-        return Carbon::createFromFormat(
-            EasyHttpClientConstantsInterface::DATE_TIME_FORMAT,
-            $dateTime->format(EasyHttpClientConstantsInterface::DATE_TIME_FORMAT),
-            $dateTime->getTimezone()
-        );
+        return Carbon::instance($dateTime);
     }
 
-    private function getTimingMessage(\DateTimeInterface $sentAt, ?\DateTimeInterface $receivedAt = null): string
+    private function getTimingMessage(DateTimeInterface $sentAt, ?DateTimeInterface $receivedAt = null): string
     {
         if ($receivedAt === null) {
-            return 'No timing available';
+            return self::DEFAULT_TIMING_MESSAGE;
         }
 
-        $sentAt = $this->getCarbon($sentAt);
-        $receivedAt = $this->getCarbon($receivedAt);
+        $sentAt = $this->getCarbonInstance($sentAt);
+        $receivedAt = $this->getCarbonInstance($receivedAt);
 
         return \sprintf(
             '%s - %s | %s',

--- a/packages/EasyHttpClient/src/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListener.php
+++ b/packages/EasyHttpClient/src/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListener.php
@@ -82,7 +82,7 @@ final class HttpRequestSentBreadcrumbListener
         $this->client->leaveBreadcrumb(
             self::BREADCRUMB_NAME,
             Breadcrumb::REQUEST_TYPE,
-            $this->filterMetadata($metadata)
+            $this->prepareMetadata($metadata)
         );
     }
 
@@ -96,28 +96,6 @@ final class HttpRequestSentBreadcrumbListener
         $breadcrumbData['metaData'] = $metadata;
 
         return \strlen((string)\json_encode($breadcrumbData));
-    }
-
-    /**
-     * @param array<string, mixed> $metadata
-     *
-     * @return array<string, mixed>
-     */
-    private function filterMetadata(array $metadata): array
-    {
-        $metadataAttributes = self::METADATA_ATTRIBUTES_PRIORITY_LIST;
-
-        while (
-            $this->calculateBreadcrumbSize($metadata) > Breadcrumb::MAX_SIZE &&
-            \count($metadataAttributes) !== 0 &&
-            \count($metadata) !== 0
-        ) {
-            $attributeToRemove = \array_shift($metadataAttributes);
-
-            unset($metadata[$attributeToRemove]);
-        }
-
-        return $metadata;
     }
 
     private function getCarbonInstance(DateTimeInterface $dateTime): Carbon
@@ -144,5 +122,27 @@ final class HttpRequestSentBreadcrumbListener
             $receivedAt->format(EasyHttpClientConstantsInterface::DATE_TIME_FORMAT),
             $receivedAt->diffForHumans($sentAt, null, true)
         );
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     *
+     * @return array<string, mixed>
+     */
+    private function prepareMetadata(array $metadata): array
+    {
+        $metadataAttributes = self::METADATA_ATTRIBUTES_PRIORITY_LIST;
+
+        while (
+            $this->calculateBreadcrumbSize($metadata) > Breadcrumb::MAX_SIZE &&
+            \count($metadataAttributes) !== 0 &&
+            \count($metadata) !== 0
+        ) {
+            $attributeToRemove = \array_shift($metadataAttributes);
+
+            unset($metadata[$attributeToRemove]);
+        }
+
+        return $metadata;
     }
 }

--- a/packages/EasyHttpClient/tests/AbstractTestCase.php
+++ b/packages/EasyHttpClient/tests/AbstractTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EonX\EasyHttpClient\Tests;
 
+use Mockery;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -13,6 +15,21 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 abstract class AbstractTestCase extends TestCase
 {
+    /**
+     * @param class-string $target
+     */
+    protected function mock(string $target, ?callable $expectations = null): MockInterface
+    {
+        /** @var \Mockery\MockInterface $mock */
+        $mock = Mockery::mock($target);
+
+        if ($expectations !== null) {
+            $expectations($mock);
+        }
+
+        return $mock;
+    }
+
     protected function tearDown(): void
     {
         $fs = new Filesystem();
@@ -21,6 +38,10 @@ abstract class AbstractTestCase extends TestCase
         if ($fs->exists($var)) {
             $fs->remove($var);
         }
+
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+
+        Mockery::close();
 
         parent::tearDown();
     }

--- a/packages/EasyHttpClient/tests/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListenerTest.php
+++ b/packages/EasyHttpClient/tests/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListenerTest.php
@@ -15,14 +15,14 @@ use EonX\EasyHttpClient\Tests\AbstractTestCase;
 use Exception;
 use Mockery\MockInterface;
 
-class HttpRequestSentBreadcrumbListenerTest extends AbstractTestCase
+final class HttpRequestSentBreadcrumbListenerTest extends AbstractTestCase
 {
     /**
      * @param array<string, mixed> $expectedMetadata
      *
      * @dataProvider provideEvents
      */
-    public function testItSucceeds(HttpRequestSentEvent $event, array $expectedMetadata): void
+    public function testPrepareMetadataSucceeds(HttpRequestSentEvent $event, array $expectedMetadata): void
     {
         $bugsnagClient = $this->mockBugsnagClient($expectedMetadata);
         $sut = new HttpRequestSentBreadcrumbListener($bugsnagClient);

--- a/packages/EasyHttpClient/tests/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListenerTest.php
+++ b/packages/EasyHttpClient/tests/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListenerTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyHttpClient\Tests\Bridge\EasyBugsnag;
+
+use Bugsnag\Breadcrumbs\Breadcrumb;
+use Bugsnag\Client;
+use Carbon\CarbonImmutable;
+use EonX\EasyHttpClient\Bridge\EasyBugsnag\HttpRequestSentBreadcrumbListener;
+use EonX\EasyHttpClient\Data\RequestData;
+use EonX\EasyHttpClient\Data\ResponseData;
+use EonX\EasyHttpClient\Events\HttpRequestSentEvent;
+use EonX\EasyHttpClient\Tests\AbstractTestCase;
+use Exception;
+use Mockery\MockInterface;
+
+class HttpRequestSentBreadcrumbListenerTest extends AbstractTestCase
+{
+    /**
+     * @param array<string, mixed> $expectedMetadata
+     *
+     * @dataProvider provideEvents
+     */
+    public function testItSucceeds(HttpRequestSentEvent $event, array $expectedMetadata): void
+    {
+        $bugsnagClient = $this->mockBugsnagClient($expectedMetadata);
+        $sut = new HttpRequestSentBreadcrumbListener($bugsnagClient);
+
+        $sut($event);
+    }
+
+    /**
+     * @return iterable<mixed>
+     *
+     * @see testItSucceeds
+     */
+    protected function provideEvents(): iterable
+    {
+        yield 'an event with response data' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                responseData: new ResponseData(
+                    content: 'some-content',
+                    headers: ['headerName' => 'header-value'],
+                    receivedAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456'),
+                    statusCode: 200
+                )
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Request Options' => '{"optionName":"option-value"}',
+                'Response Status Code' => 200,
+                'Response Content' => 'some-content',
+                'Response Headers' => '{"headerName":"header-value"}',
+                'Timing' => '08/08/2022 12:34:56.789123 - 08/08/2022 12:34:59.789456 | 3s after',
+            ],
+        ];
+
+        yield 'an event with a throwable and the throwableThrownAt value' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                throwable: new Exception('some-exception-message'),
+                throwableThrownAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456')
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Request Options' => '{"optionName":"option-value"}',
+                'Throwable Class' => 'Exception',
+                'Throwable Message' => 'some-exception-message',
+                'Timing' => '08/08/2022 12:34:56.789123 - 08/08/2022 12:34:59.789456 | 3s after',
+            ],
+        ];
+
+        yield 'an event with a throwable and without the throwableThrownAt value' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                throwable: new Exception('some-exception-message')
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Request Options' => '{"optionName":"option-value"}',
+                'Throwable Class' => 'Exception',
+                'Throwable Message' => 'some-exception-message',
+                'Timing' => HttpRequestSentBreadcrumbListener::DEFAULT_TIMING_MESSAGE,
+            ],
+        ];
+
+        yield 'an event with response data, the response headers value is too long' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                responseData: new ResponseData(
+                    content: 'some-content',
+                    headers: \array_fill(0, Breadcrumb::MAX_SIZE, '0'),
+                    receivedAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456'),
+                    statusCode: 200
+                )
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Request Options' => '{"optionName":"option-value"}',
+                'Response Status Code' => 200,
+                'Response Content' => 'some-content',
+                'Timing' => '08/08/2022 12:34:56.789123 - 08/08/2022 12:34:59.789456 | 3s after',
+            ],
+        ];
+
+        yield 'an event with response data, the request options value is too long' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: \array_fill(0, Breadcrumb::MAX_SIZE, '0'),
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                responseData: new ResponseData(
+                    content: 'some-content',
+                    headers: ['headerName' => 'header-value'],
+                    receivedAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456'),
+                    statusCode: 200
+                )
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Response Status Code' => 200,
+                'Response Content' => 'some-content',
+                'Timing' => '08/08/2022 12:34:56.789123 - 08/08/2022 12:34:59.789456 | 3s after',
+            ],
+        ];
+
+        yield 'an event with response data, the response content value is too long' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                responseData: new ResponseData(
+                    content: \str_pad('0', Breadcrumb::MAX_SIZE),
+                    headers: ['headerName' => 'header-value'],
+                    receivedAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456'),
+                    statusCode: 200
+                )
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Response Status Code' => 200,
+                'Timing' => '08/08/2022 12:34:56.789123 - 08/08/2022 12:34:59.789456 | 3s after',
+            ],
+        ];
+
+        yield 'an event with response data, the request value is too long' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: \str_pad('0', Breadcrumb::MAX_SIZE)
+                ),
+                responseData: new ResponseData(
+                    content: 'some-content',
+                    headers: ['headerName' => 'header-value'],
+                    receivedAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456'),
+                    statusCode: 200
+                )
+            ),
+            'expectedMetadata' => [],
+        ];
+
+        yield 'an event with a throwable, the request options value is too long' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: \array_fill(0, Breadcrumb::MAX_SIZE, '0'),
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                throwable: new Exception('some-exception-message'),
+                throwableThrownAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456')
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Throwable Class' => 'Exception',
+                'Throwable Message' => 'some-exception-message',
+                'Timing' => '08/08/2022 12:34:56.789123 - 08/08/2022 12:34:59.789456 | 3s after',
+            ],
+        ];
+
+        yield 'an event with a throwable, the throwable message value is too long' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: 'http://example.test/foo'
+                ),
+                throwable: new Exception(\str_pad('0', Breadcrumb::MAX_SIZE)),
+                throwableThrownAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456')
+            ),
+            'expectedMetadata' => [
+                'Request' => 'GET - http://example.test/foo',
+                'Timing' => '08/08/2022 12:34:56.789123 - 08/08/2022 12:34:59.789456 | 3s after',
+            ],
+        ];
+
+        yield 'an event with a throwable, the request value is too long' => [
+            'event' => new HttpRequestSentEvent(
+                requestData: new RequestData(
+                    method: 'GET',
+                    options: ['optionName' => 'option-value'],
+                    sentAt: CarbonImmutable::parse('08.08.2022 12:34:56.789123'),
+                    url: \str_pad('0', Breadcrumb::MAX_SIZE),
+                ),
+                throwable: new Exception('some-exception-message'),
+                throwableThrownAt: CarbonImmutable::parse('08.08.2022 12:34:59.789456')
+            ),
+            'expectedMetadata' => [],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $expectedMetadata
+     */
+    private function mockBugsnagClient(array $expectedMetadata): Client
+    {
+        /** @var \Bugsnag\Client $bugsnagClient */
+        $bugsnagClient = $this->mock(
+            Client::class,
+            static function (MockInterface $mock) use ($expectedMetadata): void {
+                $mock->shouldReceive('leaveBreadcrumb')
+                    ->once()
+                    ->with(
+                        HttpRequestSentBreadcrumbListener::BREADCRUMB_NAME,
+                        Breadcrumb::REQUEST_TYPE,
+                        $expectedMetadata
+                    );
+            }
+        );
+
+        return $bugsnagClient;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -107,9 +107,6 @@ parameters:
           path: packages/EasyErrorHandler/src/Providers/ErrorCodesProvider.php
 
         # ---- EasyHttpClient ----
-        - message: '#Method EonX\\EasyHttpClient\\Bridge\\EasyBugsnag\\HttpRequestSentBreadcrumbListener\:\:getCarbon\(\) should return Carbon\\Carbon but returns Carbon\\Carbon\|false#'
-          path: packages/EasyHttpClient/src/Bridge/EasyBugsnag/HttpRequestSentBreadcrumbListener.php
-
         # ---- EasyLock ----
         # ---- EasyLogging ----DoctrineDbalLengthAwarePaginator
         - message: '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\:\:children\(\)#'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

