### PR TITLE
hotfix/easy-activity-microseconds

### DIFF
--- a/packages/EasyActivity/src/Bridge/Doctrine/DoctrineDbalStore.php
+++ b/packages/EasyActivity/src/Bridge/Doctrine/DoctrineDbalStore.php
@@ -40,8 +40,10 @@ final class DoctrineDbalStore implements StoreInterface
     {
         $data = [
             'id' => $this->idFactory->create(),
-            'created_at' => $logEntry->getCreatedAt(),
-            'updated_at' => $logEntry->getUpdatedAt(),
+            'created_at' => $logEntry->getCreatedAt()
+                ->format('Y-m-d H:i:s.u'),
+            'updated_at' => $logEntry->getUpdatedAt()
+                ->format('Y-m-d H:i:s.u'),
             'actor_type' => $logEntry->getActorType(),
             'actor_id' => $logEntry->getActorId(),
             'actor_name' => $logEntry->getActorName(),

--- a/packages/EasyActivity/tests/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriberTest.php
+++ b/packages/EasyActivity/tests/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriberTest.php
@@ -87,7 +87,7 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
 
     public function testLoggerSucceedsForDeletedSubjects(): void
     {
-        Carbon::setTestNow('2021-10-10 10:00:00');
+        Carbon::setTestNow('2021-10-10 10:00:00.001001');
         $entityManager = EntityManagerStub::createFromEasyActivityConfig(
             [
                 'subjects' => [
@@ -131,14 +131,14 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
                 'comments' => [],
                 'id' => 1,
             ]),
-            'created_at' => '2021-10-10 10:00:00',
-            'updated_at' => '2021-10-10 10:00:00',
+            'created_at' => '2021-10-10 10:00:00.001001',
+            'updated_at' => '2021-10-10 10:00:00.001001',
         ], $logEntries[1]);
     }
 
     public function testLoggerSucceedsForUpdatedSubjects(): void
     {
-        Carbon::setTestNow('2021-10-10 10:00:00');
+        Carbon::setTestNow('2021-10-10 10:00:00.899933');
         $entityManager = EntityManagerStub::createFromEasyActivityConfig(
             [
                 'subjects' => [
@@ -175,8 +175,8 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
                 'title' => 'Title 1',
             ]),
             'subject_old_data' => null,
-            'created_at' => '2021-10-10 10:00:00',
-            'updated_at' => '2021-10-10 10:00:00',
+            'created_at' => '2021-10-10 10:00:00.899933',
+            'updated_at' => '2021-10-10 10:00:00.899933',
         ], $logEntries[0]);
         self::assertEquals([
             'actor_type' => ActivityLogEntry::DEFAULT_ACTOR_TYPE,
@@ -191,8 +191,8 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
             'subject_old_data' => \json_encode([
                 'title' => 'Title 1',
             ]),
-            'created_at' => '2021-10-10 10:00:00',
-            'updated_at' => '2021-10-10 10:00:00',
+            'created_at' => '2021-10-10 10:00:00.899933',
+            'updated_at' => '2021-10-10 10:00:00.899933',
         ], $logEntries[1]);
     }
 


### PR DESCRIPTION
* add microseconds

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

(string) carbon datetime return datetime without microseconds. ->format with microseconds added 