### PR TITLE
[EasyCore] Make AbstractInputDataTransformer more generic

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
@@ -51,7 +51,7 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
     /**
      * @param array<string, mixed>|null $context
      */
-    abstract protected function doTransform(object $dto, ?array $context = null): object;
+    abstract protected function doTransform(object $object, ?array $context = null): object;
 
     abstract protected function getApiResourceClass(): string;
 

--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
@@ -34,7 +34,7 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
             return false;
         }
 
-        return $to === $apiResourceClass && ($context['input']['class'] ?? null) === $this->getInputDtoClass();
+        return $to === $apiResourceClass && ($context['input']['class'] ?? null) === $this->getInputClass();
     }
 
     /**
@@ -55,7 +55,7 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
 
     abstract protected function getApiResourceClass(): string;
 
-    abstract protected function getInputDtoClass(): string;
+    abstract protected function getInputClass(): string;
 
     /**
      * @param object $object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes

In some cases, we need to transform the API resource object.
This PR make a method and a variable name more generic.

This PR introduce BC, but it can be easy refactored.