### PR TITLE
[EasyUtils] Support non-string env vars in substitution helper

### DIFF
--- a/packages/EasyUtils/src/Helpers/EnvVarSubstitutionHelper.php
+++ b/packages/EasyUtils/src/Helpers/EnvVarSubstitutionHelper.php
@@ -44,7 +44,7 @@ class EnvVarSubstitutionHelper
             self::$unresolved = 0;
 
             foreach ($envs as $name => $value) {
-                self::$values[$name] = self::doResolveVariables($value);
+                self::$values[$name] = \is_string($value) ? self::doResolveVariables($value) : $value;
             }
 
             $currentAttempt++;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
