### PR TITLE
[EasySwoole] `StreamedResponse` not streaming

### DIFF
--- a/packages/EasySwoole/src/Helpers/HttpFoundationHelper.php
+++ b/packages/EasySwoole/src/Helpers/HttpFoundationHelper.php
@@ -52,8 +52,7 @@ final class HttpFoundationHelper
     public static function reflectHttpFoundationResponse(
         HttpFoundationResponse $hfResponse,
         Response $response,
-        int $chunkSize,
-        ?string $bufferedOutput = null
+        int $chunkSize
     ): void {
         $response->status($hfResponse->getStatusCode());
 
@@ -87,9 +86,6 @@ final class HttpFoundationHelper
                 return '';
             }, 4096);
 
-            // Send buffered output to buffer (echo, var_dump, etc)
-            echo $bufferedOutput;
-
             // Send streamed content to buffer
             $hfResponse->sendContent();
 
@@ -110,8 +106,7 @@ final class HttpFoundationHelper
         }
 
         // From here we have a normal response, simply return the content
-        // Prepend buffered output to response content (echo, var_dump, etc)
-        $content = $bufferedOutput . $hfResponse->getContent();
+        $content = (string)$hfResponse->getContent();
         $length = \mb_strlen($content);
 
         // Do not chunk response if not needed

--- a/packages/EasySwoole/src/Runtime/EasySwooleRunner.php
+++ b/packages/EasySwoole/src/Runtime/EasySwooleRunner.php
@@ -69,16 +69,12 @@ final class EasySwooleRunner implements RunnerInterface
                 $hfRequest->attributes->set(RequestAttributesInterface::EASY_SWOOLE_ENABLED, true);
 
                 // Surround handle with output buffering to support echo, var_dump, etc
-                \ob_start();
                 $hfResponse = $app->handle($hfRequest);
-                $bufferedOutput = \ob_get_contents();
-                \ob_end_clean();
 
                 HttpFoundationHelper::reflectHttpFoundationResponse(
                     $hfResponse,
                     $response,
-                    $responseChunkSize,
-                    \is_string($bufferedOutput) && $bufferedOutput !== '' ? $bufferedOutput : null
+                    $responseChunkSize
                 );
 
                 if ($app instanceof TerminableInterface) {

--- a/packages/EasySwoole/src/Runtime/EasySwooleRunner.php
+++ b/packages/EasySwoole/src/Runtime/EasySwooleRunner.php
@@ -68,7 +68,6 @@ final class EasySwooleRunner implements RunnerInterface
                 $hfRequest = HttpFoundationHelper::fromSwooleRequest($request);
                 $hfRequest->attributes->set(RequestAttributesInterface::EASY_SWOOLE_ENABLED, true);
 
-                // Surround handle with output buffering to support echo, var_dump, etc
                 $hfResponse = $app->handle($hfRequest);
 
                 HttpFoundationHelper::reflectHttpFoundationResponse(


### PR DESCRIPTION
EasySwoole surrounds `Application::handle` with output buffering to support `echo`, `var_dump`, etc.
As a result `StreamedResponse` doesn't work as expected. Instead of sending a content to the client, this content is buffered and `Allowed memory size of 268435456 bytes exhausted` occurs for big responses. 

This PR removes output buffering. `echo`/`var_dump` will be available in the docker container's stdout.
As we don't use `echo`/`var_dump` for normal responses, changes should not lead to BC breaks.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
