### PR TITLE
[EasyCore] Added support for multiple classes to AbstractInputDataTransformer

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
@@ -66,8 +66,14 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
      */
     abstract protected function doTransform(object $object, ?array $context = null): object;
 
+    /**
+     * @return string[]|string
+     */
     abstract protected function getApiResourceClass(): array|string;
 
+    /**
+     * @return string[]|string
+     */
     abstract protected function getInputClass(): array|string;
 
     protected function isValidationNeeded(): bool

--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
@@ -34,8 +34,8 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
             return false;
         }
 
-        return is_a($to, $apiResourceClass, true) === true &&
-            is_a($context['input']['class'] ?? null, $this->getInputClass(), true) === true;
+        return is_a($to, $apiResourceClass, true) &&
+            is_a($context['input']['class'] ?? null, $this->getInputClass(), true);
     }
 
     /**

--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/DataTransformer/AbstractInputDataTransformer.php
@@ -34,7 +34,8 @@ abstract class AbstractInputDataTransformer implements DataTransformerInterface
             return false;
         }
 
-        return $to === $apiResourceClass && ($context['input']['class'] ?? null) === $this->getInputClass();
+        return is_a($to, $apiResourceClass, true) === true &&
+            is_a($context['input']['class'] ?? null, $this->getInputClass(), true) === true;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Added support for multiple classes to AbstractInputDataTransformer to cover some specific cases when we have to use one InputDataTransformer for several API resources with a common ancestor or for several DTO classes.