### PR TITLE
[EasyUtils] `UrlStringSanitizer` and `JsonStringSanitizer` are sensitive to case

### DIFF
--- a/packages/EasyUtils/src/SensitiveData/StringSanitizers/JsonStringSanitizer.php
+++ b/packages/EasyUtils/src/SensitiveData/StringSanitizers/JsonStringSanitizer.php
@@ -13,7 +13,7 @@ final class JsonStringSanitizer extends AbstractStringSanitizer
     {
         foreach ($keysToMask as $key) {
             $string = (string)\preg_replace(
-                \sprintf('/(\\\"%s\\\"\s*:\s*\\\"|"%s"\s*:\s*")([^\\\"]+)(\\\"|")/', $key, $key),
+                \sprintf('/(\\\"%s\\\"\s*:\s*\\\"|"%s"\s*:\s*")([^\\\"]+)(\\\"|")/i', $key, $key),
                 '$1' . $maskPattern . '$3',
                 $string
             );

--- a/packages/EasyUtils/src/SensitiveData/StringSanitizers/UrlStringSanitizer.php
+++ b/packages/EasyUtils/src/SensitiveData/StringSanitizers/UrlStringSanitizer.php
@@ -13,7 +13,7 @@ final class UrlStringSanitizer extends AbstractStringSanitizer
     {
         foreach ($keysToMask as $key) {
             $string = (string)\preg_replace(
-                \sprintf('/(%s=|\[%s\]=)([^&]+)/', $key, $key),
+                \sprintf('/(%s=|\[%s\]=)([^&]+)/i', $key, $key),
                 '$1' . $maskPattern,
                 $string
             );

--- a/packages/EasyUtils/tests/AbstractSensitiveDataSanitizerTestCase.php
+++ b/packages/EasyUtils/tests/AbstractSensitiveDataSanitizerTestCase.php
@@ -88,13 +88,14 @@ abstract class AbstractSensitiveDataSanitizerTestCase extends AbstractTestCase
         ];
         yield 'Mask keys in URL' => [
             'input' => [
-                'maskToken' => 'tcp://my-name@yeah?token=token-to-be-masked',
+                'maskToken' => 'tcp://my-name@yeah?token=token-to-be-masked&PhoneNumber=61000000001&test=1',
             ],
             'expectedOutput' => [
-                'maskToken' => 'tcp://my-name@yeah?token=*REDACTED*',
+                'maskToken' => 'tcp://my-name@yeah?token=*REDACTED*&PhoneNumber=*REDACTED*&test=1',
             ],
             'maskKeys' => [
                 'token',
+                'phonenumber',
             ],
         ];
         yield 'Mask keys in JSON' => [
@@ -109,6 +110,7 @@ abstract class AbstractSensitiveDataSanitizerTestCase extends AbstractTestCase
                 'maskTokenSpaceAfterKeyAndEscaping' => '{\"token\" :\"token-to-be-masked\"}',
                 'maskTokenWithBothSpacesAndEscaping' => '{\"token\" : \"token-to-be-masked\"}',
                 'maskTokenWithDoubleSpacesAndEscaping' => '{\"token\"  :  \"token-to-be-masked\"}',
+                'maskPhoneNumber' => '{"phoneNumber":"token-to-be-masked"}',
             ],
             'expectedOutput' => [
                 'maskToken' => '{"token":"*REDACTED*"}',
@@ -121,9 +123,11 @@ abstract class AbstractSensitiveDataSanitizerTestCase extends AbstractTestCase
                 'maskTokenSpaceAfterKeyAndEscaping' => '{\"token\" :\"*REDACTED*\"}',
                 'maskTokenWithBothSpacesAndEscaping' => '{\"token\" : \"*REDACTED*\"}',
                 'maskTokenWithDoubleSpacesAndEscaping' => '{\"token\"  :  \"*REDACTED*\"}',
+                'maskPhoneNumber' => '{"phoneNumber":"*REDACTED*"}',
             ],
             'maskKeys' => [
                 'token',
+                'phonenumber',
             ],
         ];
         yield 'Mask card numbers' => [


### PR DESCRIPTION
The `easy_utils.keys_to_mask` parameters contains keys in lower case. Therefore, parameters in mixed case are not masked in URL and JSON. 

For example, when we log an HTTP query with body `Action=Publish&Version=2010-03-31&PhoneNumber=%2B6100000000&Message=Your+code+to+change+the+email+address+is+567376.`, the `PhoneNumber` parameter is not masked.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
