### PR TITLE
[EasyBugsnag] Avoid starting a session for stateless request

### DIFF
--- a/packages/EasyBugsnag/src/Request/HttpFoundationRequest.php
+++ b/packages/EasyBugsnag/src/Request/HttpFoundationRequest.php
@@ -72,6 +72,10 @@ final class HttpFoundationRequest implements RequestInterface
             return [];
         }
 
+        if ($this->request->attributes->get('_stateless') === true) {
+            return [];
+        }
+
         return $this->request->getSession()
             ->all();
     }


### PR DESCRIPTION
Currently EasyBugsnag starts a PHP session. For stateless API requests it may lead to the `Symfony\Component\HttpKernel\Exception\UnexpectedSessionUsageException` exception.

In this PR we use `_stateless` attribute to avoid it. This attribute is also used in [AbstractSessionListener](https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php#L205) in `symfony/http-kernel`.
Alternatively we can use `$this->request->getSession()->isStarted() === false` condition. But it looks less correct.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
