### PR TITLE
[EasyTest] hotfix/http-client-assertion-trait

### DIFF
--- a/packages/EasyTest/src/Stub/HttpClient/HttpClientAssertionTrait.php
+++ b/packages/EasyTest/src/Stub/HttpClient/HttpClientAssertionTrait.php
@@ -7,7 +7,7 @@ namespace EonX\EasyTest\Stub\HttpClient;
 use EonX\EasyTest\Traits\HttpClientAssertionTrait as BaseTrait;
 
 /**
- * @deprecated since 4.3.5, will be removed in 4.3.6. Use EonX\EasyTest\Traits\HttpClientAssertionTrait instead.
+ * @deprecated since 4.3.5, will be removed in 5.0.0. Use EonX\EasyTest\Traits\HttpClientAssertionTrait instead.
  */
 trait HttpClientAssertionTrait
 {

--- a/packages/EasyTest/src/Stub/HttpClient/HttpClientAssertionTrait.php
+++ b/packages/EasyTest/src/Stub/HttpClient/HttpClientAssertionTrait.php
@@ -4,28 +4,12 @@ declare(strict_types=1);
 
 namespace EonX\EasyTest\Stub\HttpClient;
 
-use PHPUnit\Framework\Assert;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
+use EonX\EasyTest\Traits\HttpClientAssertionTrait as BaseTrait;
 
+/**
+ * @deprecated since 4.3.5, will be removed in 4.3.6. Use EonX\EasyTest\Traits\HttpClientAssertionTrait instead.
+ */
 trait HttpClientAssertionTrait
 {
-    public function assertAllHttpRequestsAreMade(string $httpClientName): void
-    {
-        Assert::assertFalse(
-            $this->getHttpClientStub($httpClientName)
-                ->hasUnusedResponses(),
-            "Not all requests of the [{$httpClientName}] HTTP client were made."
-        );
-    }
-
-    public function getHttpClientStub(string $name): HttpClientStub
-    {
-        /** @var \EonX\EasyTest\Stub\HttpClient\HttpClientStub $httpClient */
-        $httpClient = KernelTestCase::getContainer()->get(
-            \sprintf('%s $%s', HttpClientInterface::class, $name)
-        );
-
-        return $httpClient;
-    }
+    use BaseTrait;
 }

--- a/packages/EasyTest/src/Traits/HttpClientAssertionTrait.php
+++ b/packages/EasyTest/src/Traits/HttpClientAssertionTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyTest\Traits;
+
+use EonX\EasyTest\Stub\HttpClient\HttpClientStub;
+use PHPUnit\Framework\Assert;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+trait HttpClientAssertionTrait
+{
+    public function assertAllHttpRequestsAreMade(string $httpClientName): void
+    {
+        Assert::assertFalse(
+            $this->getHttpClientStub($httpClientName)
+                ->hasUnusedResponses(),
+            "Not all requests of the [{$httpClientName}] HTTP client were made."
+        );
+    }
+
+    public function getHttpClientStub(string $name): HttpClientStub
+    {
+        /** @var \EonX\EasyTest\Stub\HttpClient\HttpClientStub $httpClient */
+        $httpClient = KernelTestCase::getContainer()->get(
+            \sprintf('%s $%s', HttpClientInterface::class, $name)
+        );
+
+        return $httpClient;
+    }
+}


### PR DESCRIPTION
* trait moved

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->


HttpClientAssertionTrait moved to Traits folder