### PR TITLE
[EasyTest] Allow to extend `HttpClientStub`

### DIFF
--- a/packages/EasyTest/src/Stub/HttpClient/HttpClientStub.php
+++ b/packages/EasyTest/src/Stub/HttpClient/HttpClientStub.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Throwable;
 
-final class HttpClientStub extends MockHttpClient
+class HttpClientStub extends MockHttpClient
 {
     use HttpClientTrait;
 


### PR DESCRIPTION
Currently `\EonX\EasyTest\Stub\HttpClient\HttpClientStub` is a final class. So we can't extend it and create a custom Stub for some clients.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
