### PR TITLE
[EasyDoctrine] Fix infinite recursion in the `DeferredEntityEventDispatcher`

### DIFF
--- a/packages/EasyDoctrine/src/Dispatchers/DeferredEntityEventDispatcher.php
+++ b/packages/EasyDoctrine/src/Dispatchers/DeferredEntityEventDispatcher.php
@@ -134,6 +134,7 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
             return;
         }
 
+        $events = [];
         try {
             $mergedEntityChangeSets = [];
             foreach ($this->entityChangeSets as $levelChangeSets) {
@@ -148,10 +149,14 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
             foreach ($mergedEntityChangeSets as $oid => $entityChangeSet) {
                 $event = $this->createEntityEvent($oid, $entityChangeSet);
 
-                $this->eventDispatcher->dispatch($event);
+                $events[] = $event;
             }
         } finally {
             $this->clear();
+        }
+
+        foreach ($events as $event) {
+            $this->eventDispatcher->dispatch($event);
         }
     }
 

--- a/packages/EasyDoctrine/tests/Stubs/EventDispatcherStub.php
+++ b/packages/EasyDoctrine/tests/Stubs/EventDispatcherStub.php
@@ -4,14 +4,29 @@ declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Tests\Stubs;
 
+use Closure;
 use EonX\EasyEventDispatcher\Interfaces\EventDispatcherInterface;
 
 final class EventDispatcherStub implements EventDispatcherInterface
 {
     /**
+     * @var array<string, callable>
+     */
+    private array $dispatchCallbacks = [];
+
+    /**
      * @var object[]
      */
-    private $events = [];
+    private array $events = [];
+
+    /**
+     * @param class-string $class
+     * @param Closure(mixed): void $callback
+     */
+    public function addDispatchCallback(string $class, Closure $callback): void
+    {
+        $this->dispatchCallbacks[$class] = $callback;
+    }
 
     /**
      * @param object $event
@@ -19,6 +34,11 @@ final class EventDispatcherStub implements EventDispatcherInterface
     public function dispatch($event)
     {
         $this->events[] = $event;
+
+        $callback = $this->dispatchCallbacks[\get_class($event)] ?? null;
+        if ($callback !== null) {
+            $callback($event);
+        }
 
         return $event;
     }


### PR DESCRIPTION
When we call `EntityManager::flush` in a listener for `EntityActionEventInterface` infinite recursion occurs. 
We are trying to process the same `$this->entityChangeSets` each time.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
