### PR TITLE
[EasyTest] Fix `MessengerAssertionsTrait::assertMessageSentToTransport`

### DIFF
--- a/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
+++ b/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EonX\EasyTest\Traits;
 
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Constraint\IsEqual;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
@@ -102,7 +103,8 @@ trait MessengerAssertionsTrait
                 foreach ($expectedProperties ?? [] as $property => $expectedValue) {
                     $actualValue = $propertyAccessor->getValue($message, $property);
 
-                    if ($actualValue !== $expectedValue) {
+                    $isEqualConstraint = new IsEqual($expectedValue);
+                    if ($isEqualConstraint->evaluate($actualValue, '', true) === false) {
                         return false;
                     }
                 }


### PR DESCRIPTION
Currently `MessengerAssertionsTrait::assertMessageSentToTransport` doesn't work correctly when a message contains value objects like `CarbonImmutable`.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
