### PR TITLE
[EasyDoctrine] ad wrapInTransaction method to EntityManagerDecorator

### DIFF
--- a/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
+++ b/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
@@ -81,7 +81,7 @@ final class EntityManagerDecorator extends DoctrineEntityManagerDecorator
      * @throws \Doctrine\ORM\ORMException
      * @throws \Throwable
      */
-    public function wrapInTransaction(callable $func)
+    public function wrapInTransaction(callable $func): mixed
     {
         $this->beginTransaction();
 

--- a/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
+++ b/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
@@ -64,6 +64,8 @@ final class EntityManagerDecorator extends DoctrineEntityManagerDecorator
      * @return mixed
      *
      * @throws \Throwable
+     *
+     * @deprecated
      */
     public function transactional($func)
     {
@@ -71,6 +73,16 @@ final class EntityManagerDecorator extends DoctrineEntityManagerDecorator
             throw new InvalidArgumentException('Expected argument of type "callable", got "' . \gettype($func) . '"');
         }
 
+        return $this->wrapInTransaction($func);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Throwable
+     */
+    public function wrapInTransaction(callable $func)
+    {
         $this->beginTransaction();
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->

- Add wrapInTransaction method to EntityManagerDecorator.
- Deprecate `EntityManagerDecorator::transactional()`