### PR TITLE
[EasySecurity] Introduce getUserIdentifier and deprecate getUniqueId methods 

### DIFF
--- a/packages/EasySecurity/src/Bridge/EasyBugsnag/SecurityContextClientConfigurator.php
+++ b/packages/EasySecurity/src/Bridge/EasyBugsnag/SecurityContextClientConfigurator.php
@@ -131,7 +131,7 @@ final class SecurityContextClientConfigurator extends AbstractClientConfigurator
     {
         return [
             'class' => \get_class($user),
-            'id' => $user->getUniqueId(),
+            'id' => $user->getUserIdentifier(),
         ];
     }
 }

--- a/packages/EasySecurity/src/Bridge/Symfony/Security/FakeUser.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Security/FakeUser.php
@@ -23,6 +23,9 @@ final class FakeUser implements UserInterface, SymfonyUserInterface
         // Do nothing.
     }
 
+    /**
+     * @deprecated Will be removed after drop Symfony 5.4 support
+     */
     public function getPassword(): ?string
     {
         return null;
@@ -36,11 +39,17 @@ final class FakeUser implements UserInterface, SymfonyUserInterface
         return [];
     }
 
+    /**
+     * @deprecated Will be removed after drop Symfony 5.4 support
+     */
     public function getSalt(): ?string
     {
         return null;
     }
 
+    /**
+     * @deprecated Will be removed in 5.0.0
+     */
     public function getUniqueId(): string
     {
         return self::ID_USERNAME;
@@ -51,6 +60,9 @@ final class FakeUser implements UserInterface, SymfonyUserInterface
         return self::ID_USERNAME;
     }
 
+    /**
+     * @deprecated Will be removed after drop Symfony 5.4 support
+     */
     public function getUsername(): string
     {
         return self::ID_USERNAME;

--- a/packages/EasySecurity/src/Bridge/Symfony/Security/SecurityContextAuthenticator.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Security/SecurityContextAuthenticator.php
@@ -53,7 +53,7 @@ final class SecurityContextAuthenticator extends AbstractAuthenticator implement
 
         // From here we know we have a user, simply fake it in symfony
         return new SelfValidatingPassport(
-            new UserBadge((string)$user->getUniqueId(), function () use ($user): UserInterface {
+            new UserBadge($user->getUserIdentifier(), function () use ($user): UserInterface {
                 return $user instanceof UserInterface ? $user : new FakeUser();
             })
         );

--- a/packages/EasySecurity/src/Interfaces/UserInterface.php
+++ b/packages/EasySecurity/src/Interfaces/UserInterface.php
@@ -9,7 +9,6 @@ interface UserInterface
     /**
      * @return null|int|string
      * @deprecated Will be removed in 5.0.0
-     *
      */
     public function getUniqueId();
 

--- a/packages/EasySecurity/src/Interfaces/UserInterface.php
+++ b/packages/EasySecurity/src/Interfaces/UserInterface.php
@@ -8,6 +8,10 @@ interface UserInterface
 {
     /**
      * @return null|int|string
+     * @deprecated Will be removed in 5.0.0
+     *
      */
     public function getUniqueId();
+
+    public function getUserIdentifier(): string;
 }

--- a/packages/EasySecurity/tests/Bridge/Symfony/Security/FakeUserTest.php
+++ b/packages/EasySecurity/tests/Bridge/Symfony/Security/FakeUserTest.php
@@ -18,6 +18,7 @@ final class FakeUserTest extends AbstractSymfonyTestCase
         self::assertNull($user->getPassword());
         self::assertEmpty($user->getRoles());
         self::assertNull($user->getSalt());
+        self::assertEquals(FakeUser::ID_USERNAME, $user->getUserIdentifier());
         self::assertEquals(FakeUser::ID_USERNAME, $user->getUniqueId());
         self::assertEquals(FakeUser::ID_USERNAME, $user->getUsername());
     }

--- a/packages/EasySecurity/tests/Stubs/UserInterfaceStub.php
+++ b/packages/EasySecurity/tests/Stubs/UserInterfaceStub.php
@@ -8,24 +8,20 @@ use EonX\EasySecurity\Interfaces\UserInterface;
 
 final class UserInterfaceStub implements UserInterface
 {
-    /**
-     * @var null|int|string
-     */
-    private $uniqueId;
-
-    /**
-     * @param null|int|string $uniqueId
-     */
-    public function __construct($uniqueId)
+    public function __construct(private string $userIdentifier)
     {
-        $this->uniqueId = $uniqueId;
     }
 
     /**
-     * @return null|int|string
+     * @deprecated Will be removed in 5.0.0
      */
-    public function getUniqueId()
+    public function getUniqueId(): null|int|string
     {
-        return $this->uniqueId;
+        return $this->userIdentifier;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->userIdentifier;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes

Method `\EonX\EasySecurity\Interfaces\UserInterface::getUniqueId` looks confusing
- Symfony 6.0 uses only `\Symfony\Component\Security\Core\User\UserInterface::getUserIdentifier`.
- we duplicate `getUserIdentifier` and `getUniqueId` in apps.