### PR TITLE
[EasyAsync] Add DoctrineManagersCloseConnectionMiddleware

### DIFF
--- a/packages/EasyAsync/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterMessengerMiddlewareCompilerPass.php
+++ b/packages/EasyAsync/src/Bridge/Symfony/DependencyInjection/Compiler/RegisterMessengerMiddlewareCompilerPass.php
@@ -6,6 +6,7 @@ namespace EonX\EasyAsync\Bridge\Symfony\DependencyInjection\Compiler;
 
 use EonX\EasyAsync\Bridge\BridgeConstantsInterface;
 use EonX\EasyAsync\Bridge\Symfony\Messenger\DoctrineManagersClearMiddleware;
+use EonX\EasyAsync\Bridge\Symfony\Messenger\DoctrineManagersCloseConnectionMiddleware;
 use EonX\EasyAsync\Bridge\Symfony\Messenger\DoctrineManagersSanityCheckMiddleware;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -17,6 +18,7 @@ final class RegisterMessengerMiddlewareCompilerPass implements CompilerPassInter
     private const EASY_ASYNC_MIDDLEWARE_LIST = [
         DoctrineManagersSanityCheckMiddleware::class,
         DoctrineManagersClearMiddleware::class,
+        DoctrineManagersCloseConnectionMiddleware::class,
     ];
 
     private const MESSENGER_BUS_TAG = 'messenger.bus';

--- a/packages/EasyAsync/src/Bridge/Symfony/Messenger/DoctrineManagersCloseConnectionMiddleware.php
+++ b/packages/EasyAsync/src/Bridge/Symfony/Messenger/DoctrineManagersCloseConnectionMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyAsync\Bridge\Symfony\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use EonX\EasyAsync\Doctrine\ManagersCloser;
+
+class DoctrineManagersCloseConnectionMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly ManagersCloser $managersCloser,
+        private readonly ?array $managers = null
+    ) {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            if ($envelope->last(ConsumedByWorkerStamp::class) !== null) {
+                $this->managersCloser->close($this->managers);
+            }
+        }
+    }
+}

--- a/packages/EasyAsync/src/Bridge/Symfony/Messenger/DoctrineManagersCloseConnectionMiddleware.php
+++ b/packages/EasyAsync/src/Bridge/Symfony/Messenger/DoctrineManagersCloseConnectionMiddleware.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace EonX\EasyAsync\Bridge\Symfony\Messenger;
 
+use EonX\EasyAsync\Doctrine\ManagersCloser;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
-use EonX\EasyAsync\Doctrine\ManagersCloser;
 
 class DoctrineManagersCloseConnectionMiddleware implements MiddlewareInterface
 {
+    /**
+     * @param null|string[] $managers
+     */
     public function __construct(
         private readonly ManagersCloser $managersCloser,
         private readonly ?array $managers = null
@@ -21,7 +24,8 @@ class DoctrineManagersCloseConnectionMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         try {
-            return $stack->next()->handle($envelope, $stack);
+            return $stack->next()
+                ->handle($envelope, $stack);
         } finally {
             if ($envelope->last(ConsumedByWorkerStamp::class) !== null) {
                 $this->managersCloser->close($this->managers);

--- a/packages/EasyAsync/src/Doctrine/ManagersCloser.php
+++ b/packages/EasyAsync/src/Doctrine/ManagersCloser.php
@@ -13,7 +13,7 @@ final class ManagersCloser
 {
     public function __construct(
         private readonly ManagerRegistry $registry,
-        private readonly ?LoggerInterface $logger = new NullLogger()
+        private readonly LoggerInterface $logger = new NullLogger()
     ) {
     }
 
@@ -28,8 +28,7 @@ final class ManagersCloser
         foreach ($managers as $managerName) {
             $manager = $this->registry->getManager($managerName);
             if ($manager instanceof EntityManagerInterface) {
-                $this->registry->getManager($managerName)
-                    ->getConnection()
+                $manager->getConnection()
                     ->close();
 
                 continue;

--- a/packages/EasyAsync/src/Doctrine/ManagersCloser.php
+++ b/packages/EasyAsync/src/Doctrine/ManagersCloser.php
@@ -19,9 +19,6 @@ final class ManagersCloser
 
     /**
      * @param string[]|null $managers
-     *
-     * @throws \EonX\EasyAsync\Doctrine\Exceptions\DoctrineConnectionNotOkException
-     * @throws \EonX\EasyAsync\Doctrine\Exceptions\DoctrineManagerClosedException
      */
     public function close(?array $managers = null): void
     {

--- a/packages/EasyAsync/src/Doctrine/ManagersCloser.php
+++ b/packages/EasyAsync/src/Doctrine/ManagersCloser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyAsync\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+final class ManagersCloser
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+        private readonly ?LoggerInterface $logger = new NullLogger()
+    ) {
+    }
+
+    /**
+     * @param string[]|null $managers
+     *
+     * @throws \EonX\EasyAsync\Doctrine\Exceptions\DoctrineConnectionNotOkException
+     * @throws \EonX\EasyAsync\Doctrine\Exceptions\DoctrineManagerClosedException
+     */
+    public function close(?array $managers = null): void
+    {
+        // If no managers given, default to all
+        $managers = $managers ?? \array_keys($this->registry->getManagerNames());
+
+        foreach ($managers as $managerName) {
+            $manager = $this->registry->getManager($managerName);
+            if ($manager instanceof EntityManagerInterface) {
+                $this->registry->getManager($managerName)
+                    ->getConnection()
+                    ->close();
+
+                continue;
+            }
+
+            $this->logger->warning(\sprintf(
+                'Type "%s" for manager "%s" not supported by manager closer',
+                \get_class($manager),
+                $managerName
+            ));
+        }
+    }
+}

--- a/packages/EasyAsync/tests/Doctrine/ManagersCloserTest.php
+++ b/packages/EasyAsync/tests/Doctrine/ManagersCloserTest.php
@@ -10,7 +10,6 @@ use EonX\EasyAsync\Tests\AbstractStoreTestCase;
 use EonX\EasyAsync\Tests\Doctrine\Stubs\EntityManagerForSanityStub;
 use EonX\EasyAsync\Tests\Doctrine\Stubs\ManagerRegistryStub;
 use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
 
 final class ManagersCloserTest extends AbstractStoreTestCase
@@ -39,7 +38,7 @@ final class ManagersCloserTest extends AbstractStoreTestCase
         /** @var \Psr\Log\LoggerInterface $logger */
         $logger = $this->mock(LoggerInterface::class, function (LegacyMockInterface $logger): void {
             $logger->shouldReceive('warning')
-            ->once();
+                ->once();
         });
 
         (new ManagersCloser($registry, $logger))->close();

--- a/packages/EasyAsync/tests/Doctrine/ManagersCloserTest.php
+++ b/packages/EasyAsync/tests/Doctrine/ManagersCloserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyAsync\Tests\Doctrine;
+
+use Doctrine\Persistence\ObjectManager;
+use EonX\EasyAsync\Doctrine\ManagersCloser;
+use EonX\EasyAsync\Tests\AbstractStoreTestCase;
+use EonX\EasyAsync\Tests\Doctrine\Stubs\EntityManagerForSanityStub;
+use EonX\EasyAsync\Tests\Doctrine\Stubs\ManagerRegistryStub;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+
+final class ManagersCloserTest extends AbstractStoreTestCase
+{
+    public function testCloseNotEntityManagerInstance(): void
+    {
+        $registry = new ManagerRegistryStub([
+            'default' => new EntityManagerForSanityStub(true),
+        ]);
+
+        /** @var \Psr\Log\LoggerInterface $logger */
+        $logger = $this->mock(LoggerInterface::class, function (LegacyMockInterface $logger): void {
+            $logger->shouldNotReceive('warning');
+        });
+
+        (new ManagersCloser($registry, $logger))->close();
+    }
+
+    public function testCloseSuccessful(): void
+    {
+        $notEmInstance = $this->mock(ObjectManager::class);
+        $registry = new ManagerRegistryStub([
+            'default' => $notEmInstance,
+        ]);
+
+        /** @var \Psr\Log\LoggerInterface $logger */
+        $logger = $this->mock(LoggerInterface::class, function (LegacyMockInterface $logger): void {
+            $logger->shouldReceive('warning')
+            ->once();
+        });
+
+        (new ManagersCloser($registry, $logger))->close();
+    }
+}

--- a/packages/EasyAsync/tests/Doctrine/ManagersCloserTest.php
+++ b/packages/EasyAsync/tests/Doctrine/ManagersCloserTest.php
@@ -30,6 +30,7 @@ final class ManagersCloserTest extends AbstractStoreTestCase
 
     public function testCloseSuccessful(): void
     {
+        /** @var \Doctrine\Persistence\ObjectManager $notEmInstance */
         $notEmInstance = $this->mock(ObjectManager::class);
         $registry = new ManagerRegistryStub([
             'default' => $notEmInstance,


### PR DESCRIPTION
Add DoctrineManagersCloseConnectionMiddleware to close entity manager connections every after a message is processed to save number of connections.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->
