### PR TITLE
[All packages] Add gitattributes files (PoC)

### DIFF
--- a/packages/EasyActivity/.gitattributes
+++ b/packages/EasyActivity/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyActivity/.gitattributes
+++ b/packages/EasyActivity/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyApiPlatform/.gitattributes
+++ b/packages/EasyApiPlatform/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyApiPlatform/.gitattributes
+++ b/packages/EasyApiPlatform/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyApiToken/.gitattributes
+++ b/packages/EasyApiToken/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyApiToken/.gitattributes
+++ b/packages/EasyApiToken/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyAsync/.gitattributes
+++ b/packages/EasyAsync/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyAsync/.gitattributes
+++ b/packages/EasyAsync/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyAwsCredentialsFinder/.gitattributes
+++ b/packages/EasyAwsCredentialsFinder/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyAwsCredentialsFinder/.gitattributes
+++ b/packages/EasyAwsCredentialsFinder/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyBankFiles/.gitattributes
+++ b/packages/EasyBankFiles/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyBankFiles/.gitattributes
+++ b/packages/EasyBankFiles/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyBatch/.gitattributes
+++ b/packages/EasyBatch/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyBatch/.gitattributes
+++ b/packages/EasyBatch/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyBugsnag/.gitattributes
+++ b/packages/EasyBugsnag/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyBugsnag/.gitattributes
+++ b/packages/EasyBugsnag/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyCore/.gitattributes
+++ b/packages/EasyCore/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyCore/.gitattributes
+++ b/packages/EasyCore/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyDecision/.gitattributes
+++ b/packages/EasyDecision/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyDecision/.gitattributes
+++ b/packages/EasyDecision/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyDoctrine/.gitattributes
+++ b/packages/EasyDoctrine/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyDoctrine/.gitattributes
+++ b/packages/EasyDoctrine/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyEncryption/.gitattributes
+++ b/packages/EasyEncryption/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyEncryption/.gitattributes
+++ b/packages/EasyEncryption/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyErrorHandler/.gitattributes
+++ b/packages/EasyErrorHandler/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyErrorHandler/.gitattributes
+++ b/packages/EasyErrorHandler/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyEventDispatcher/.gitattributes
+++ b/packages/EasyEventDispatcher/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyEventDispatcher/.gitattributes
+++ b/packages/EasyEventDispatcher/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyHttpClient/.gitattributes
+++ b/packages/EasyHttpClient/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyHttpClient/.gitattributes
+++ b/packages/EasyHttpClient/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyLock/.gitattributes
+++ b/packages/EasyLock/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyLock/.gitattributes
+++ b/packages/EasyLock/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyLogging/.gitattributes
+++ b/packages/EasyLogging/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyLogging/.gitattributes
+++ b/packages/EasyLogging/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyNotification/.gitattributes
+++ b/packages/EasyNotification/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyNotification/.gitattributes
+++ b/packages/EasyNotification/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyPagination/.gitattributes
+++ b/packages/EasyPagination/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyPagination/.gitattributes
+++ b/packages/EasyPagination/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyPipeline/.gitattributes
+++ b/packages/EasyPipeline/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyPipeline/.gitattributes
+++ b/packages/EasyPipeline/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyPsr7Factory/.gitattributes
+++ b/packages/EasyPsr7Factory/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyPsr7Factory/.gitattributes
+++ b/packages/EasyPsr7Factory/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyRandom/.gitattributes
+++ b/packages/EasyRandom/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyRandom/.gitattributes
+++ b/packages/EasyRandom/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyRepository/.gitattributes
+++ b/packages/EasyRepository/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyRepository/.gitattributes
+++ b/packages/EasyRepository/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyRequestId/.gitattributes
+++ b/packages/EasyRequestId/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyRequestId/.gitattributes
+++ b/packages/EasyRequestId/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasySchedule/.gitattributes
+++ b/packages/EasySchedule/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasySchedule/.gitattributes
+++ b/packages/EasySchedule/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasySecurity/.gitattributes
+++ b/packages/EasySecurity/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasySecurity/.gitattributes
+++ b/packages/EasySecurity/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasySsm/.gitattributes
+++ b/packages/EasySsm/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasySsm/.gitattributes
+++ b/packages/EasySsm/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasySwoole/.gitattributes
+++ b/packages/EasySwoole/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasySwoole/.gitattributes
+++ b/packages/EasySwoole/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyTemplatingBlock/.gitattributes
+++ b/packages/EasyTemplatingBlock/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyTemplatingBlock/.gitattributes
+++ b/packages/EasyTemplatingBlock/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyTest/.gitattributes
+++ b/packages/EasyTest/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyTest/.gitattributes
+++ b/packages/EasyTest/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyUtils/.gitattributes
+++ b/packages/EasyUtils/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyUtils/.gitattributes
+++ b/packages/EasyUtils/.gitattributes
@@ -1,2 +1,5 @@
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/packages/EasyWebhook/.gitattributes
+++ b/packages/EasyWebhook/.gitattributes
@@ -1,0 +1,3 @@
+docs/ export-ignore
+tests/ export-ignore
+phpunit.xml export-ignore

--- a/packages/EasyWebhook/.gitattributes
+++ b/packages/EasyWebhook/.gitattributes
@@ -1,3 +1,6 @@
 docs/ export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+readme.md export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->

- Add gitattributes files.

It prevents to import excluded folders while `composer install` call in projects. ([ref](https://alexbilbie.com/2012/11/exclude-objects-with-gitattributes/))
This will reduce `vendor` folder size and autoload.