### PR TITLE
[EasyBatch] Prevent running emergency logic on already completed batch

### DIFF
--- a/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/ProcessBatchForBatchItemHandler.php
+++ b/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/ProcessBatchForBatchItemHandler.php
@@ -33,6 +33,11 @@ final class ProcessBatchForBatchItemHandler implements MessageHandlerInterface
         $batchItem = $this->batchItemRepository->findOrFail($message->getBatchItemId());
         $batch = $this->batchRepository->findOrFail($batchItem->getBatchId());
 
+        // Prevent running logic on already completed batch
+        if ($batch->isCompleted()) {
+            return;
+        }
+
         // Update batch metadata to reflect emergency flow triggered
         $updateFreshBatch = static function (BatchInterface $freshBatch) use ($message): void {
             $metadata = $freshBatch->getMetadata() ?? [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
