### PR TITLE
[EasyErrorHandler] Allowed custom response codes.

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Listener/ExceptionEventListener.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Listener/ExceptionEventListener.php
@@ -24,6 +24,7 @@ final class ExceptionEventListener
             return;
         }
 
+        $event->allowCustomResponseCode();
         $event->setResponse($this->errorHandler->render($event->getRequest(), $event->getThrowable()));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Without this call we get the 500 http status code in some conditions (`\Symfony\Component\HttpKernel\HttpKernel::handleThrowable`):
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/1703419/205859072-be54c4d0-6d96-4646-bd94-fe4ab606c2a8.png">

