### PR TITLE
[EasySwoole] Added the `do_not_log_paths` option to the configuration

### DIFF
--- a/packages/EasySwoole/src/Bridge/BridgeConstantsInterface.php
+++ b/packages/EasySwoole/src/Bridge/BridgeConstantsInterface.php
@@ -6,63 +6,29 @@ namespace EonX\EasySwoole\Bridge;
 
 interface BridgeConstantsInterface
 {
-    /**
-     * @var string
-     */
+    public const PARAM_ACCESS_LOG_DO_NOT_LOG_PATHS = 'easy_swoole.access_log_do_not_log_paths';
+
     public const PARAM_ACCESS_LOG_TIMEZONE = 'easy_swoole.access_log_timezone';
 
-    /**
-     * @var string
-     */
     public const PARAM_REQUEST_LIMITS_MAX = 'easy_swoole.request_limits.max';
 
-    /**
-     * @var string
-     */
     public const PARAM_REQUEST_LIMITS_MIN = 'easy_swoole.request_limits.min';
 
-    /**
-     * @var string
-     */
-    public const PARAM_RESET_EASY_BATCH_PROCESSOR = 'easy_swoole.reset_easy_batch_processor';
-
-    /**
-     * @var string
-     */
     public const PARAM_RESET_DOCTRINE_DBAL_CONNECTIONS = 'easy_swoole.reset_doctrine_dbal_connections';
 
-    /**
-     * @var string
-     */
+    public const PARAM_RESET_EASY_BATCH_PROCESSOR = 'easy_swoole.reset_easy_batch_processor';
+
     public const PARAM_STATIC_PHP_FILES_ALLOWED_DIRS = 'easy_swoole.static_php_files_allowed_dirs';
 
-    /**
-     * @var string
-     */
     public const PARAM_STATIC_PHP_FILES_ALLOWED_FILENAMES = 'easy_swoole.static_php_files_allowed_filenames';
 
-    /**
-     * @var string
-     */
     public const SERVICE_ACCESS_LOG_LOGGER = 'easy_swoole.access_log_logger';
 
-    /**
-     * @var string
-     */
     public const SERVICE_FILESYSTEM = 'easy_swoole.filesystem';
 
-    /**
-     * @var string
-     */
     public const TAG_APP_STATE_CHECKER = 'easy_swoole.app_state_checker';
 
-    /**
-     * @var string
-     */
     public const TAG_APP_STATE_INITIALIZER = 'easy_swoole.app_state_initializer';
 
-    /**
-     * @var string
-     */
     public const TAG_APP_STATE_RESETTER = 'easy_swoole.app_state_resetter';
 }

--- a/packages/EasySwoole/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/packages/EasySwoole/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -21,6 +21,22 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('enabled')->defaultTrue()->end()
+                        ->arrayNode('do_not_log_paths')
+                            ->beforeNormalization()
+                                ->always(static function ($value): array {
+                                    if ($value === null) {
+                                        $value = [];
+                                    }
+
+                                    return \array_map(static function ($mapValue): string {
+                                        return u((string)$mapValue)
+                                            ->ensureStart('/')
+                                            ->toString();
+                                    }, \is_array($value) ? $value : [$value]);
+                                })
+                            ->end()
+                            ->scalarPrototype()->end()
+                        ->end()
                         ->scalarNode('timezone')->defaultValue('UTC')->end()
                     ->end()
                 ->end()

--- a/packages/EasySwoole/src/Bridge/Symfony/DependencyInjection/EasySwooleExtension.php
+++ b/packages/EasySwoole/src/Bridge/Symfony/DependencyInjection/EasySwooleExtension.php
@@ -18,15 +18,16 @@ use Symfony\Contracts\Service\ResetInterface;
 final class EasySwooleExtension extends Extension
 {
     private const ACCESS_LOG_CONFIG = [
+        'do_not_log_paths' => BridgeConstantsInterface::PARAM_ACCESS_LOG_DO_NOT_LOG_PATHS,
         'timezone' => BridgeConstantsInterface::PARAM_ACCESS_LOG_TIMEZONE,
-    ];
-
-    private const EASY_BATCH_CONFIG = [
-        'reset_batch_processor' => BridgeConstantsInterface::PARAM_RESET_EASY_BATCH_PROCESSOR,
     ];
 
     private const DOCTRINE_CONFIG = [
         'reset_dbal_connections' => BridgeConstantsInterface::PARAM_RESET_DOCTRINE_DBAL_CONNECTIONS,
+    ];
+
+    private const EASY_BATCH_CONFIG = [
+        'reset_batch_processor' => BridgeConstantsInterface::PARAM_RESET_EASY_BATCH_PROCESSOR,
     ];
 
     private const REQUEST_LIMITS_CONFIG = [

--- a/packages/EasySwoole/src/Bridge/Symfony/Listeners/AccessLogListener.php
+++ b/packages/EasySwoole/src/Bridge/Symfony/Listeners/AccessLogListener.php
@@ -10,16 +10,26 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 final class AccessLogListener extends AbstractTerminateEventListener
 {
+    /**
+     * @param string[] $doNotLogPaths
+     */
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly HttpFoundationAccessLogFormatterInterface $accessLogFormatter
+        private readonly HttpFoundationAccessLogFormatterInterface $accessLogFormatter,
+        private readonly array $doNotLogPaths
     ) {
     }
 
     protected function doInvoke(TerminateEvent $event): void
     {
+        $request = $event->getRequest();
+
+        if (\in_array($request->getPathInfo(), $this->doNotLogPaths, true)) {
+            return;
+        }
+
         $this->logger->debug(
-            $this->accessLogFormatter->formatAccessLog($event->getRequest(), $event->getResponse())
+            $this->accessLogFormatter->formatAccessLog($request, $event->getResponse())
         );
     }
 }

--- a/packages/EasySwoole/src/Bridge/Symfony/Resources/config/access_log.php
+++ b/packages/EasySwoole/src/Bridge/Symfony/Resources/config/access_log.php
@@ -33,5 +33,6 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(AccessLogListener::class)
         ->arg('$logger', service(BridgeConstantsInterface::SERVICE_ACCESS_LOG_LOGGER))
+        ->arg('$doNotLogPaths', param(BridgeConstantsInterface::PARAM_ACCESS_LOG_DO_NOT_LOG_PATHS))
         ->tag('kernel.event_listener');
 };

--- a/packages/EasySwoole/tests/Bridge/Symfony/ConfigurationTest.php
+++ b/packages/EasySwoole/tests/Bridge/Symfony/ConfigurationTest.php
@@ -13,6 +13,7 @@ final class ConfigurationTest extends AbstractSymfonyTestCase
     private const DEFAULT_CONFIG = [
         'access_log' => [
             'enabled' => true,
+            'do_not_log_paths' => [],
             'timezone' => 'UTC',
         ],
         'doctrine' => [
@@ -39,110 +40,6 @@ final class ConfigurationTest extends AbstractSymfonyTestCase
     ];
 
     /**
-     * @return iterable<mixed>
-     */
-    public function providerTestConfiguration(): iterable
-    {
-        yield 'No configuration set' => [
-            [],
-            self::DEFAULT_CONFIG,
-        ];
-
-        yield 'Disable access_log' => [
-            [
-                [
-                    'access_log' => [
-                        'enabled' => false,
-                    ],
-                ],
-            ],
-            ArrayHelper::smartReplace(self::DEFAULT_CONFIG, ['access_log' => ['enabled' => false]]),
-        ];
-
-        yield 'Normalize allowed static php files' => [
-            [
-                [
-                    'static_php_files' => [
-                        'allowed_filenames' => 'hash.php',
-                    ],
-                ],
-            ],
-            ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
-                'static_php_files' => [
-                    'allowed_filenames' => ['/hash.php'],
-                ],
-            ]),
-        ];
-
-        yield 'Normalize allowed static php files - 1' => [
-            [
-                [
-                    'static_php_files' => [
-                        'allowed_filenames' => '/hash.php',
-                    ],
-                ],
-            ],
-            ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
-                'static_php_files' => [
-                    'allowed_filenames' => ['/hash.php'],
-                ],
-            ]),
-        ];
-
-        yield 'Normalize allowed static php files - support null' => [
-            [
-                [
-                    'static_php_files' => [
-                        'allowed_filenames' => null,
-                    ],
-                ],
-            ],
-            self::DEFAULT_CONFIG,
-        ];
-
-        yield 'Normalize allowed static php dirs - support null' => [
-            [
-                [
-                    'static_php_files' => [
-                        'allowed_dirs' => null,
-                    ],
-                ],
-            ],
-            self::DEFAULT_CONFIG,
-        ];
-
-        yield 'Normalize allowed static php dirs - filter empty strings' => [
-            [
-                [
-                    'static_php_files' => [
-                        'allowed_dirs' => '/',
-                    ],
-                ],
-            ],
-            ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
-                'static_php_files' => [
-                    'allowed_dirs' => ['%kernel.project_dir%/public'],
-                ],
-            ]),
-        ];
-
-        yield 'Normalize allowed static php dirs - trim trailing slash' => [
-            [
-                [
-                    'static_php_files' => [
-                        'allowed_dirs' => '/path/to/dir/',
-                    ],
-                ],
-            ],
-            ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
-                'static_php_files' => [
-                    'allowed_dirs' => ['/path/to/dir'],
-                ],
-            ]),
-        ];
-    }
-
-    /**
      * @param mixed[] $configs
      * @param mixed[] $expectedConfig
      *
@@ -153,5 +50,152 @@ final class ConfigurationTest extends AbstractSymfonyTestCase
         $config = (new Processor())->processConfiguration(new Configuration(), $configs);
 
         self::assertEquals($expectedConfig, $config);
+    }
+
+    /**
+     * @return iterable<mixed>
+     *
+     * @see testConfiguration
+     */
+    protected function providerTestConfiguration(): iterable
+    {
+        yield 'No configuration set' => [
+            'configs' => [],
+            'expectedConfig' => self::DEFAULT_CONFIG,
+        ];
+
+        yield 'Disable access_log' => [
+            'configs' => [
+                [
+                    'access_log' => [
+                        'enabled' => false,
+                    ],
+                ],
+            ],
+            'expectedConfig' => ArrayHelper::smartReplace(self::DEFAULT_CONFIG, ['access_log' => ['enabled' => false]]),
+        ];
+
+        yield 'Normalize do not log paths' => [
+            'configs' => [
+                [
+                    'access_log' => [
+                        'do_not_log_paths' => 'hash.php',
+                    ],
+                ],
+            ],
+            'expectedConfig' => ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
+                'access_log' => [
+                    'do_not_log_paths' => ['/hash.php'],
+                ],
+            ]),
+        ];
+
+        yield 'Normalize do not log paths - 1' => [
+            'configs' => [
+                [
+                    'access_log' => [
+                        'do_not_log_paths' => '/hash.php',
+                    ],
+                ],
+            ],
+            'expectedConfig' => ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
+                'access_log' => [
+                    'do_not_log_paths' => ['/hash.php'],
+                ],
+            ]),
+        ];
+
+        yield 'Normalize do not log paths - support null' => [
+            'configs' => [
+                [
+                    'access_log' => [
+                        'do_not_log_paths' => null,
+                    ],
+                ],
+            ],
+            'expectedConfig' => self::DEFAULT_CONFIG,
+        ];
+
+        yield 'Normalize allowed static php files' => [
+            'configs' => [
+                [
+                    'static_php_files' => [
+                        'allowed_filenames' => 'hash.php',
+                    ],
+                ],
+            ],
+            'expectedConfig' => ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
+                'static_php_files' => [
+                    'allowed_filenames' => ['/hash.php'],
+                ],
+            ]),
+        ];
+
+        yield 'Normalize allowed static php files - 1' => [
+            'configs' => [
+                [
+                    'static_php_files' => [
+                        'allowed_filenames' => '/hash.php',
+                    ],
+                ],
+            ],
+            'expectedConfig' => ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
+                'static_php_files' => [
+                    'allowed_filenames' => ['/hash.php'],
+                ],
+            ]),
+        ];
+
+        yield 'Normalize allowed static php files - support null' => [
+            'configs' => [
+                [
+                    'static_php_files' => [
+                        'allowed_filenames' => null,
+                    ],
+                ],
+            ],
+            'expectedConfig' => self::DEFAULT_CONFIG,
+        ];
+
+        yield 'Normalize allowed static php dirs - support null' => [
+            'configs' => [
+                [
+                    'static_php_files' => [
+                        'allowed_dirs' => null,
+                    ],
+                ],
+            ],
+            'expectedConfig' => self::DEFAULT_CONFIG,
+        ];
+
+        yield 'Normalize allowed static php dirs - filter empty strings' => [
+            'configs' => [
+                [
+                    'static_php_files' => [
+                        'allowed_dirs' => '/',
+                    ],
+                ],
+            ],
+            'expectedConfig' => ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
+                'static_php_files' => [
+                    'allowed_dirs' => ['%kernel.project_dir%/public'],
+                ],
+            ]),
+        ];
+
+        yield 'Normalize allowed static php dirs - trim trailing slash' => [
+            'configs' => [
+                [
+                    'static_php_files' => [
+                        'allowed_dirs' => '/path/to/dir/',
+                    ],
+                ],
+            ],
+            'expectedConfig' => ArrayHelper::smartReplace(self::DEFAULT_CONFIG, [
+                'static_php_files' => [
+                    'allowed_dirs' => ['/path/to/dir'],
+                ],
+            ]),
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

This PR bring the ability to exclude specific paths from the access log.
