### PR TITLE
[EasySecurity] Add check isMainRequest

### DIFF
--- a/packages/EasySecurity/src/Bridge/Symfony/Listeners/FromRequestSecurityContextConfiguratorListener.php
+++ b/packages/EasySecurity/src/Bridge/Symfony/Listeners/FromRequestSecurityContextConfiguratorListener.php
@@ -31,6 +31,10 @@ final class FromRequestSecurityContextConfiguratorListener
 
     public function __invoke(RequestEvent $event): void
     {
+        if ($event->isMainRequest() === false) {
+            return;
+        }
+
         $this->securityContextResolver->setConfigurator(new FromRequestConfigurator(
             $event->getRequest(),
             $this->configurators


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

We should reset the security context and setup configurators only for the main request.
