### PR TITLE
[EasyCore] Return integers in pagination data

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Pagination/CustomPaginator.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Pagination/CustomPaginator.php
@@ -40,12 +40,12 @@ final class CustomPaginator implements CustomPaginatorInterface
         $hasPreviousPage = $this->decorated->getCurrentPage() - 1 > 0;
 
         return [
-            'currentPage' => $this->decorated->getCurrentPage(),
+            'currentPage' => (int)$this->decorated->getCurrentPage(),
             'hasNextPage' => $hasNextPage,
             'hasPreviousPage' => $hasPreviousPage,
-            'itemsPerPage' => $this->decorated->getItemsPerPage(),
-            'totalItems' => $this->decorated->getTotalItems(),
-            'totalPages' => $this->decorated->getLastPage(),
+            'itemsPerPage' => (int)$this->decorated->getItemsPerPage(),
+            'totalItems' => (int)$this->decorated->getTotalItems(),
+            'totalPages' => (int)$this->decorated->getLastPage(),
         ];
     }
 }


### PR DESCRIPTION
- Return int values in pagination data.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a   <!-- #-prefixed issue number(s), if any -->

Starting from Symfony 6.2 its serializer encodes json with `JSON_PRESERVE_ZERO_FRACTION` by default, this way we getting float values in pagination data in the response (bcs api-platform's paginator returns float values):
![image](https://user-images.githubusercontent.com/13186130/214096451-a8ea2bba-a5d9-4fb9-ab93-1e51e9ccbd3d.png)
Sure, we can use next serializer configuration, but it will affect on all data in the response:
```
$frameworkConfig
    ->serializer()
    ->defaultContext('json_encode_options', \JSON_ERROR_NONE);
```