### PR TITLE
hotfix/easy-error-handler-nikic-parser-require-dev

### DIFF
--- a/packages/EasyErrorHandler/composer.json
+++ b/packages/EasyErrorHandler/composer.json
@@ -7,13 +7,13 @@
         "php": "^8.1",
         "eonx-com/easy-logging": "^4.4",
         "eonx-com/easy-utils": "^4.4",
-        "nesbot/carbon": "^2.22",
-        "nikic/php-parser": "^4.15"
+        "nesbot/carbon": "^2.22"
     },
     "require-dev": {
         "eonx-com/easy-bugsnag": "^4.4",
         "phpunit/phpunit": "^9.5",
         "laravel/lumen-framework": "^5.8 || ^6.0 || ^8.0",
+        "nikic/php-parser": "^4.15",
         "symfony/symfony": "^5.4 || ^6.0"
     },
     "autoload": {


### PR DESCRIPTION
* nikic/php-parser  moved to require-dev

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

nikic/php-parser moved to require-dev in EasyErrorHandler as it's used only on dev environment. (fixes for my previous error)