### PR TITLE
hotfix/easy-error-handler-error-codes-exclude-dirs

### DIFF
--- a/packages/EasyErrorHandler/src/Providers/ErrorCodesFromEnumProvider.php
+++ b/packages/EasyErrorHandler/src/Providers/ErrorCodesFromEnumProvider.php
@@ -62,6 +62,7 @@ final class ErrorCodesFromEnumProvider implements ErrorCodesProviderInterface
         $files = (new Finder())
             ->in($this->projectDir)
             ->name('*.php')
+            ->exclude(['vendor', 'var', 'tests'])
             ->files();
 
         $enums = [];


### PR DESCRIPTION
* exclude dirs

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Some dirs were excluded from scanning for performance purposes