### PR TITLE
[EasyTest] Make exception error code optional

### DIFF
--- a/packages/EasyTest/src/Traits/ExceptionTrait.php
+++ b/packages/EasyTest/src/Traits/ExceptionTrait.php
@@ -36,6 +36,14 @@ trait ExceptionTrait
             throw $this->thrownException;
         }
 
+        if (
+            $code === null
+            && $this->thrownException->getCode() !== 0
+            && \str_starts_with($expectedException, 'App\\')
+        ) {
+            self::assertNotNull($code, "Didn't you forget to define the error code?");
+        }
+
         if ($code !== null) {
             self::assertSame($code, $this->thrownException->getCode());
         }

--- a/packages/EasyTest/src/Traits/ExceptionTrait.php
+++ b/packages/EasyTest/src/Traits/ExceptionTrait.php
@@ -36,12 +36,6 @@ trait ExceptionTrait
             throw $this->thrownException;
         }
 
-        if (\str_starts_with($expectedException, 'App\\')) {
-            $message = "Didn't you forget to define the error code?";
-            self::assertNotNull($code, $message);
-            self::assertNotSame(0, $code, $message);
-        }
-
         if ($code !== null) {
             self::assertSame($code, $this->thrownException->getCode());
         }

--- a/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
+++ b/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
@@ -211,7 +211,7 @@ trait MessengerAssertionsTrait
     }
 
     /**
-     * @param array<int, class-string, array<class-string<\Throwable>, int|string>> $expectedExceptions
+     * @param array<int, class-string<\Throwable>|array<class-string<\Throwable>, int|string>> $expectedExceptions
      */
     private static function runMessengerWorker(
         string $transportName,

--- a/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
+++ b/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
@@ -118,7 +118,7 @@ trait MessengerAssertionsTrait
     }
 
     /**
-     * @param array<int, class-string, array<class-string<\Throwable>, int|string>> $expectedExceptions
+     * @param array<int, class-string<\Throwable>|array<class-string<\Throwable>, int|string>> $expectedExceptions
      */
     public static function consumeAsyncMessages(array $expectedExceptions = []): void
     {

--- a/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
+++ b/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
@@ -118,7 +118,7 @@ trait MessengerAssertionsTrait
     }
 
     /**
-     * @param array<int, array<class-string<\Throwable>, int|string>> $expectedExceptions
+     * @param array<int, class-string, array<class-string<\Throwable>, int|string>> $expectedExceptions
      */
     public static function consumeAsyncMessages(array $expectedExceptions = []): void
     {
@@ -211,7 +211,7 @@ trait MessengerAssertionsTrait
     }
 
     /**
-     * @param array<int, array<class-string<\Throwable>, int|string>> $expectedExceptions
+     * @param array<int, class-string, array<class-string<\Throwable>, int|string>> $expectedExceptions
      */
     private static function runMessengerWorker(
         string $transportName,
@@ -266,11 +266,20 @@ trait MessengerAssertionsTrait
         foreach ($transport->getRejected() as $envelope) {
             /** @var \Symfony\Component\Messenger\Stamp\ErrorDetailsStamp $errorDetailsStamp */
             foreach ($envelope->all(ErrorDetailsStamp::class) as $errorDetailsStamp) {
-                foreach ($expectedExceptions as $key => $expectedExceptionPair) {
+                foreach ($expectedExceptions as $key => $expectedExceptionPairOrClass) {
+                    // if $expectedExceptionPairOrClass is a string = exceptionClass
+                    if ($expectedExceptionPairOrClass === $errorDetailsStamp->getExceptionClass() &&
+                        $errorDetailsStamp->getExceptionCode() === 0
+                    ) {
+                        unset($expectedExceptions[$key]);
+
+                        continue 2;
+                    }
+                    // if $expectedExceptionPairOrClass is an array{exceptionClass => exceptionCode}
                     if (
-                        isset($expectedExceptionPair[$errorDetailsStamp->getExceptionClass()])
+                        isset($expectedExceptionPairOrClass[$errorDetailsStamp->getExceptionClass()])
                         && (
-                            $expectedExceptionPair[$errorDetailsStamp->getExceptionClass()]
+                            $expectedExceptionPairOrClass[$errorDetailsStamp->getExceptionClass()]
                             === $errorDetailsStamp->getExceptionCode()
                         )
                     ) {


### PR DESCRIPTION
* error code is optional

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Exception error code is optional. 

Two options to use in test:
Current:
`self::consumeAsyncMessages([[FilesystemException::class => 0]]);`
New one:
`self::consumeAsyncMessages([FilesystemException::class]);`

And we can check exceptions without code: 
`$this->assertThrownException(FileParsingException::class);`

