### PR TITLE
[EasyDoctrine] Fix AuthTokenProvider.

### DIFF
--- a/packages/EasyDoctrine/src/Bridge/AwsRds/Iam/AuthTokenProvider.php
+++ b/packages/EasyDoctrine/src/Bridge/AwsRds/Iam/AuthTokenProvider.php
@@ -12,9 +12,9 @@ use Symfony\Contracts\Cache\ItemInterface;
 
 final class AuthTokenProvider
 {
-    private const CACHE_KEY_PATTERN = 'easy_doctrine.aws_rds.iam_auth_token.%s';
-
     private const CACHE_HASH_PATTERN = '%s_%s_%s_%s';
+
+    private const CACHE_KEY_PATTERN = 'easy_doctrine.aws_rds_token.%s';
 
     private AuthTokenGenerator $authTokenGenerator;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

The OpenSwoole Table feature support keys up to 64 characters: https://github.com/search?q=repo%3Aopenswoole%2Fext-openswoole+SW_TABLE_KEY_SIZE&type=code.
<img width="723" alt="image" src="https://github.com/eonx-com/easy-monorepo/assets/1703419/e54eabcb-0e9f-4c97-846c-674bd1414d56">

Our current cache key in the `AuthTokenProvider` service looks like this `easy_doctrine.aws_rds.iam_auth_token.43dd0f66d9bb080c97698593e0cc3fde` (69 characters). Because of this we are getting the following error:

```
Warning: OpenSwoole\Table::set(): key[easy_doctrine.aws_rds.iam_auth_token.43dd0f66d9bb080c97698593e0cc3fde] is too long
```
