### PR TITLE
[EasyErrorHandler] Validation exception instead of 500 when input data is misformatted

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -163,7 +163,7 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
                 case \preg_match(self::MESSAGE_PATTERN_INPUT_DATA_MISFORMATTED, $throwable->getMessage()) === 1:
                     $hasAttributeTypeError = (bool)\preg_match(
                         self::MESSAGE_PATTERN_ATTRIBUTE_TYPE_ERROR,
-                        $throwable->getPrevious()?->getMessage(),
+                        (string)$throwable->getPrevious()?->getMessage(),
                         $matches
                     );
 

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -91,7 +91,7 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
                 \preg_match(self::MESSAGE_PATTERN_INVALID_IRI, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_NESTED_DOCUMENTS_NOT_ALLOWED, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_NOT_IRI, $message) === 1 ||
-                \preg_match(self::MESSAGE_PATTERN_INPUT_DATA_MISFORMATTED, $message),
+                \preg_match(self::MESSAGE_PATTERN_INPUT_DATA_MISFORMATTED, $message) === 1,
             default => false
         };
     }


### PR DESCRIPTION
- improved easy error handler

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no   <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #
