### PR TITLE
[EasyUtils] Improve JsonSanitizer: make it possible to sanitize array-type keys

### DIFF
--- a/packages/EasyUtils/src/SensitiveData/StringSanitizers/JsonStringSanitizer.php
+++ b/packages/EasyUtils/src/SensitiveData/StringSanitizers/JsonStringSanitizer.php
@@ -13,8 +13,11 @@ final class JsonStringSanitizer extends AbstractStringSanitizer
     {
         foreach ($keysToMask as $key) {
             $string = (string)\preg_replace(
-                \sprintf('/(\\\"%s\\\"\s*:\s*\\\"|"%s"\s*:\s*")([^\\\"]+)(\\\"|")/i', $key, $key),
-                '$1' . $maskPattern . '$3',
+                \sprintf(
+                    '/((\\\)?"%s(\\\)?"\s*:\s*(\\\)?(\\[|"))(?(?<=\\[)([^\\]]+)|([^\\\"]+))(\\\"|"|\\])/i',
+                    $key
+                ),
+                '$1' . $maskPattern . '$8',
                 $string
             );
         }

--- a/packages/EasyUtils/tests/AbstractSensitiveDataSanitizerTestCase.php
+++ b/packages/EasyUtils/tests/AbstractSensitiveDataSanitizerTestCase.php
@@ -111,6 +111,17 @@ abstract class AbstractSensitiveDataSanitizerTestCase extends AbstractTestCase
                 'maskTokenWithBothSpacesAndEscaping' => '{\"token\" : \"token-to-be-masked\"}',
                 'maskTokenWithDoubleSpacesAndEscaping' => '{\"token\"  :  \"token-to-be-masked\"}',
                 'maskPhoneNumber' => '{"phoneNumber":"token-to-be-masked"}',
+                'maskArray' => '{"auth":["test",null]}',
+                'maskArrayWithEscaping' => '{\"auth\":[\"test\"]}',
+                'maskArraySpaceBeforeValue' => '{"auth": ["test"]}',
+                'maskArraySpaceAfterKey' => '{"auth" :["test"]}',
+                'maskArrayWithBothSpaces' => '{"auth" : ["test"]}',
+                'maskArrayWithDoubleSpaces' => '{"auth"  :  ["test"]}',
+                'maskArraySpaceBeforeValueAndEscaping' => '{\"auth\": [\"test\"]}',
+                'maskArraySpaceAfterKeyAndEscaping' => '{\"auth\" :[\"test\"]}',
+                'maskArrayWithBothSpacesAndEscaping' => '{\"auth\" : [\"test\"]}',
+                'maskArrayWithDoubleSpacesAndEscaping' => '{\"auth\"  :  [\"test\"]}',
+
             ],
             'expectedOutput' => [
                 'maskToken' => '{"token":"*REDACTED*"}',
@@ -124,10 +135,21 @@ abstract class AbstractSensitiveDataSanitizerTestCase extends AbstractTestCase
                 'maskTokenWithBothSpacesAndEscaping' => '{\"token\" : \"*REDACTED*\"}',
                 'maskTokenWithDoubleSpacesAndEscaping' => '{\"token\"  :  \"*REDACTED*\"}',
                 'maskPhoneNumber' => '{"phoneNumber":"*REDACTED*"}',
+                'maskArray' => '{"auth":[*REDACTED*]}',
+                'maskArrayWithEscaping' => '{\"auth\":[*REDACTED*]}',
+                'maskArraySpaceBeforeValue' => '{"auth": [*REDACTED*]}',
+                'maskArraySpaceAfterKey' => '{"auth" :[*REDACTED*]}',
+                'maskArrayWithBothSpaces' => '{"auth" : [*REDACTED*]}',
+                'maskArrayWithDoubleSpaces' => '{"auth"  :  [*REDACTED*]}',
+                'maskArraySpaceBeforeValueAndEscaping' => '{\"auth\": [*REDACTED*]}',
+                'maskArraySpaceAfterKeyAndEscaping' => '{\"auth\" :[*REDACTED*]}',
+                'maskArrayWithBothSpacesAndEscaping' => '{\"auth\" : [*REDACTED*]}',
+                'maskArrayWithDoubleSpacesAndEscaping' => '{\"auth\"  :  [*REDACTED*]}',
             ],
             'maskKeys' => [
                 'token',
                 'phonenumber',
+                'auth'
             ],
         ];
         yield 'Mask card numbers' => [

--- a/packages/EasyUtils/tests/AbstractSensitiveDataSanitizerTestCase.php
+++ b/packages/EasyUtils/tests/AbstractSensitiveDataSanitizerTestCase.php
@@ -149,7 +149,7 @@ abstract class AbstractSensitiveDataSanitizerTestCase extends AbstractTestCase
             'maskKeys' => [
                 'token',
                 'phonenumber',
-                'auth'
+                'auth',
             ],
         ];
         yield 'Mask card numbers' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->


Sometimes we need to sanitize keys like `..."key":["foo", "bar"]...`  => `..."key":[*REDACTED*]...`
This PR makes it possible.