### PR TITLE
[ErrorHandler] Add MissingConstructorArgumentsException Symfony's 6.3 exception message support

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -142,14 +142,14 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
         }
 
         if ($throwable instanceof MissingConstructorArgumentsException) {
+            // Symfony < v6.3
             $matches = [];
             \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_API_PLATFORM, $throwable->getMessage(), $matches);
             if ($matches !== []) {
                 $data[$violationsKey][$matches[2]] = [self::VIOLATION_VALUE_SHOULD_BE_PRESENT];
             }
-        }
 
-        if ($throwable instanceof MissingConstructorArgumentsException) {
+            // Symfony >= v6.3
             $matches = [];
             \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_SYMFONY, $throwable->getMessage(), $matches);
             $matches = \explode('", "', $matches[2] ?? '');

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -36,8 +36,11 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
 
     private const MESSAGE_PATTERN_NOT_IRI = '/Expected IRI or nested document for attribute "(\w+)", "(\w+)" given/';
 
-    private const MESSAGE_PATTERN_NO_PARAMETER = '/Cannot create an instance of [\"]?([\w\\\\]+)[\"]? from serialized' .
-    ' data because its constructor requires parameter "(\w+)" to be present/';
+    private const MESSAGE_PATTERN_NO_PARAMETER_API_PLATFORM = '/Cannot create an instance of [\"]?([\w\\\\]+)[\"]?' .
+    ' from serialized data because its constructor requires parameter "(\w+)" to be present/';
+
+    private const MESSAGE_PATTERN_NO_PARAMETER_SYMFONY = '/Cannot create an instance of [\"]?([\w\\\\]+)[\"]?' .
+    ' from serialized data because its constructor requires the following parameters to be present : "(.*)"/';
 
     private const MESSAGE_PATTERN_TYPE_ERROR = '/The type of the "(\w+)" attribute must be "(\w+)", "(\w+)" given/';
 
@@ -84,7 +87,8 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
             $invalidArgumentExceptionClass, LegacyInvalidArgumentException::class =>
                 \preg_match(self::MESSAGE_PATTERN_TYPE_ERROR, $message) === 1,
             MissingConstructorArgumentsException::class =>
-                \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER, $message) === 1,
+                \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_API_PLATFORM, $message) === 1 ||
+                \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_SYMFONY, $message) === 1,
             UnexpectedValueException::class =>
                 \preg_match(self::MESSAGE_PATTERN_TYPE_ERROR, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_INVALID_DATE, $message) === 1 ||
@@ -139,10 +143,20 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
 
         if ($throwable instanceof MissingConstructorArgumentsException) {
             $matches = [];
-            \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER, $throwable->getMessage(), $matches);
-            $data[$violationsKey] = [
-                $matches[2] => [self::VIOLATION_VALUE_SHOULD_BE_PRESENT],
-            ];
+            \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_API_PLATFORM, $throwable->getMessage(), $matches);
+            if ($matches !== []) {
+                $data[$violationsKey][$matches[2]] = [self::VIOLATION_VALUE_SHOULD_BE_PRESENT];
+            }
+        }
+
+        if ($throwable instanceof MissingConstructorArgumentsException) {
+            $matches = [];
+            \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_SYMFONY, $throwable->getMessage(), $matches);
+            $matches = \explode('", "', $matches[2] ?? '');
+            foreach ($matches as $match) {
+                $match = \str_replace('$', '', $match);
+                $data[$violationsKey][$match] = [self::VIOLATION_VALUE_SHOULD_BE_PRESENT];
+            }
         }
 
         if ($throwable instanceof UnexpectedValueException) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes 


Since version 6.3 Symfony is throwing MissingConstructorArgumentsException with its own message that a bit different from api-platform's message. 
So this PR fixes it.