### PR TITLE
[ErrorHandler] hotfix for ApiPlatformValidationErrorResponseBuilder

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -154,6 +154,10 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
             \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_SYMFONY, $throwable->getMessage(), $matches);
             $matches = \explode('", "', $matches[2] ?? '');
             foreach ($matches as $match) {
+                if ($match === '') {
+                    continue;
+                }
+
                 $match = \str_replace('$', '', $match);
                 $data[$violationsKey][$match] = [self::VIOLATION_VALUE_SHOULD_BE_PRESENT];
             }

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -142,14 +142,14 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
         }
 
         if ($throwable instanceof MissingConstructorArgumentsException) {
-            // Symfony < v6.3
+            // If exception thrown in ApiPlatform's AbstractItemNormalizer
             $matches = [];
             \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_API_PLATFORM, $throwable->getMessage(), $matches);
             if ($matches !== []) {
                 $data[$violationsKey][$matches[2]] = [self::VIOLATION_VALUE_SHOULD_BE_PRESENT];
             }
 
-            // Symfony >= v6.3
+            // If exception thrown in Symfony's AbstractNormalizer
             $matches = [];
             \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_SYMFONY, $throwable->getMessage(), $matches);
             $matches = \explode('", "', $matches[2] ?? '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Huh,
`\explode('", "', $matches[2] ?? '')` can return an array with the empty line inside.
