### PR TITLE
feature/compute-changesets-of-collections

### DIFF
--- a/packages/EasyActivity/tests/ActivityLogEntryFactoryResolversTest.php
+++ b/packages/EasyActivity/tests/ActivityLogEntryFactoryResolversTest.php
@@ -37,7 +37,7 @@ final class ActivityLogEntryFactoryResolversTest extends AbstractTestCase
             }
         );
         $author = new Author();
-        $author->setId(1);
+        $author->setId('00000000-0000-0000-0000-000000000000');
 
         $result = $factory->create(
             ActivityLogEntry::ACTION_UPDATE,
@@ -79,7 +79,7 @@ final class ActivityLogEntryFactoryResolversTest extends AbstractTestCase
             }
         );
         $author = new Author();
-        $author->setId(1);
+        $author->setId('00000000-0000-0000-0000-000000000000');
 
         $result = $factory->create(
             ActivityLogEntry::ACTION_UPDATE,

--- a/packages/EasyActivity/tests/ActivityLogEntryFactoryTest.php
+++ b/packages/EasyActivity/tests/ActivityLogEntryFactoryTest.php
@@ -88,7 +88,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         /** @var \EonX\EasyActivity\ActivityLogEntry $result */
         $result = $factory->create(
             ActivityLogEntry::ACTION_CREATE,
-            (new Article())->setId(2),
+            (new Article())->setId('00000000-0000-0000-0000-000000000000'),
             ['title' => [null, 'New Title']]
         );
 
@@ -103,7 +103,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         self::assertSame(ActivityLogEntry::DEFAULT_ACTOR_TYPE, $result->getActorType());
         self::assertSame(ActivityLogEntry::ACTION_CREATE, $result->getAction());
         self::assertNull($result->getActorName());
-        self::assertSame('2', $result->getSubjectId());
+        self::assertSame('00000000-0000-0000-0000-000000000000', $result->getSubjectId());
         self::assertSame(Article::class, $result->getSubjectType());
         self::assertEqualsCanonicalizing(Carbon::getTestNow(), $result->getCreatedAt());
         self::assertEqualsCanonicalizing(Carbon::getTestNow(), $result->getUpdatedAt());
@@ -113,12 +113,13 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
     {
         $factory = new ActivityLogFactoryStub([Article::class => []], []);
         $comment1 = (new Comment())
-            ->setId(1)
+            ->setId('00000000-0000-0000-0000-000000000000')
             ->setMessage('Test 1');
         $comment2 = (new Comment())
-            ->setId(2)
+            ->setId('00000000-0000-0000-0000-000000000001')
             ->setMessage('Test 2');
         $article = (new Article())
+            ->setId('00000000-0000-0000-0000-000000000002')
             ->setTitle('Related objects')
             ->setContent('Content')
             ->addComment($comment1)
@@ -138,7 +139,10 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         self::assertEquals(
             [
                 'content' => 'Content',
-                'comments' => [['id' => 1], ['id' => 2]],
+                'comments' => [
+                    ['id' => '00000000-0000-0000-0000-000000000000'],
+                    ['id' => '00000000-0000-0000-0000-000000000001'],
+                ],
             ],
             \json_decode((string)$result->getSubjectData(), true)
         );
@@ -148,10 +152,11 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
     {
         $factory = new ActivityLogFactoryStub([Article::class => []], []);
         $author = new Author();
-        $author->setId(2);
+        $author->setId('00000000-0000-0000-0000-000000000000');
         $author->setName('John');
         $author->setPosition(1);
         $article = new Article();
+        $article->setId('00000000-0000-0000-0000-000000000001');
         $article->setTitle('Related objects');
         $article->setAuthor($author);
 
@@ -169,7 +174,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         self::assertEquals(
             [
                 'title' => 'Related objects',
-                'author' => ['id' => 2],
+                'author' => ['id' => '00000000-0000-0000-0000-000000000000'],
             ],
             \json_decode((string)$result->getSubjectData(), true)
         );
@@ -189,10 +194,11 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
             []
         );
         $author = new Author();
-        $author->setId(2);
+        $author->setId('00000000-0000-0000-0000-000000000000');
         $author->setName('John');
         $author->setPosition(1);
         $article = new Article();
+        $article->setId('00000000-0000-0000-0000-000000000001');
         $article->setTitle('Related objects');
         $article->setAuthor($author);
 
@@ -242,11 +248,13 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         $author = new Author();
         $author->setName('John');
         $author->setPosition(1);
-        $author->setId(1);
+        $author->setId('00000000-0000-0000-0000-000000000000');
+        $article = new Article();
+        $article->setId('00000000-0000-0000-0000-000000000001');
 
         $result = $factory->create(
             ActivityLogEntry::ACTION_UPDATE,
-            new Article(),
+            $article,
             [
                 'title' => ['Title 2', 'Title'],
                 'content' => ['Content 2', 'Content'],

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/CircularReferenceHandlerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/CircularReferenceHandlerTest.php
@@ -19,11 +19,14 @@ final class CircularReferenceHandlerTest extends AbstractSymfonyTestCase
     {
         $entityManager = EntityManagerStub::createFromEventManager();
         $handler = new CircularReferenceHandler($entityManager);
-        $article = (new Article())->setId(1);
+        $article = (new Article())->setId('00000000-0000-0000-0000-000000000000');
 
         $result = $handler($article, 'json', []);
 
-        self::assertSame('EonX\EasyActivity\Tests\Fixtures\Article#1 (circular reference)', $result);
+        self::assertSame(
+            'EonX\EasyActivity\Tests\Fixtures\Article#00000000-0000-0000-0000-000000000000 (circular reference)',
+            $result
+        );
     }
 
     public function testInvokeSucceedsWithoutId(): void

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
@@ -26,7 +26,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
      */
     public function provideDataForSerializeSucceeds(): iterable
     {
-        $entityId = 1;
+        $entityId = '00000000-0000-0000-0000-000000000000';
         $authorName = 'John Doe';
         $authorPosition = 1;
         $author = new Author();
@@ -42,7 +42,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
             ],
             'subject' => new ActivitySubject((string)$entityId, Author::class, [], [], []),
             'disallowedProperties' => null,
-            'expectedResult' => '{"id":1,"name":"John Doe","position":1}',
+            'expectedResult' => '{"id":"00000000-0000-0000-0000-000000000000","name":"John Doe","position":1}',
         ];
 
         $disallowedProperties = [
@@ -99,7 +99,8 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
             'subject' => new ActivitySubject((string)$entityId, Article::class, [], [], []),
             'disallowedProperties' => null,
             'expectedResult' => \sprintf(
-                '{"author":{"id":1},"comments":[],"content":"text","createdAt":"%s","id":1}',
+                '{"author":{"id":"00000000-0000-0000-0000-000000000000"},"comments":[],"content":"text",' .
+                '"createdAt":"%s","id":"00000000-0000-0000-0000-000000000000"}',
                 $moment->format(DateTimeInterface::ATOM)
             ),
         ];
@@ -126,7 +127,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
             ],
             'subject' => new ActivitySubject((string)$entityId, Author::class, [], [], $allowedProperties),
             'disallowedProperties' => null,
-            'expectedResult' => '{"id":1,"name":"John Doe"}',
+            'expectedResult' => '{"id":"00000000-0000-0000-0000-000000000000","name":"John Doe"}',
         ];
 
         $allowedProperties = [
@@ -143,7 +144,8 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
             ],
             'subject' => new ActivitySubject((string)$entityId, Article::class, [], [], $allowedProperties),
             'disallowedProperties' => null,
-            'expectedResult' => '{"author":{"id":1,"name":"John Doe"},"content":"text"}',
+            'expectedResult' => '{"author":{"id":"00000000-0000-0000-0000-000000000000","name":"John Doe"},' .
+                '"content":"text"}',
         ];
 
         $allowedProperties = [
@@ -173,7 +175,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
         ];
 
         $comment = (new Comment())
-            ->setId(1)
+            ->setId('00000000-0000-0000-0000-000000000000')
             ->setMessage('some-message');
         $article = new Article();
         $article->addComment($comment);
@@ -186,12 +188,13 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
             'data' => [
                 'comments' => [$comment],
             ],
-            'subject' => new ActivitySubject((string)$entityId, Article::class, [], [], $allowedProperties),
+            'subject' => new ActivitySubject($entityId, Article::class, [], [], $allowedProperties),
             'disallowedProperties' => null,
             'expectedResult' => \sprintf(
                 '{"comments":[{"article":{"author":null,"comments":' .
-                '["EonX\\\EasyActivity\\\Tests\\\Fixtures\\\Comment#1 (circular reference)"],' .
-                '"createdAt":"%s","id":null},"id":1,"message":"some-message"}]}',
+                '["EonX\\\EasyActivity\\\Tests\\\Fixtures\\\Comment#00000000-0000-0000-0000-000000000000' .
+                ' (circular reference)"],"createdAt":"%s"},"id":"00000000-0000-0000-0000-000000000000",' .
+                '"message":"some-message"}]}',
                 $expectedCreatedAt
             ),
         ];

--- a/packages/EasyActivity/tests/Fixtures/Article.php
+++ b/packages/EasyActivity/tests/Fixtures/Article.php
@@ -45,10 +45,10 @@ class Article
 
     /**
      * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Column(type="guid")
      *
-     * @var int
+     * @var string
      */
     private $id;
 
@@ -98,7 +98,7 @@ class Article
         return $this->createdAt;
     }
 
-    public function getId(): ?int
+    public function getId(): string
     {
         return $this->id;
     }
@@ -129,7 +129,7 @@ class Article
         return $this;
     }
 
-    public function setId(int $id): self
+    public function setId(string $id): self
     {
         $this->id = $id;
 

--- a/packages/EasyActivity/tests/Fixtures/Author.php
+++ b/packages/EasyActivity/tests/Fixtures/Author.php
@@ -13,10 +13,10 @@ class Author
 {
     /**
      * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Column(type="guid")
      *
-     * @var int
+     * @var string
      */
     private $id;
 
@@ -34,7 +34,7 @@ class Author
      */
     private $position;
 
-    public function getId(): int
+    public function getId(): string
     {
         return $this->id;
     }
@@ -49,7 +49,7 @@ class Author
         return $this->position;
     }
 
-    public function setId(int $id): void
+    public function setId(string $id): void
     {
         $this->id = $id;
     }

--- a/packages/EasyActivity/tests/Fixtures/Comment.php
+++ b/packages/EasyActivity/tests/Fixtures/Comment.php
@@ -20,10 +20,10 @@ class Comment
 
     /**
      * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Column(type="guid")
      *
-     * @var int
+     * @var string
      */
     private $id;
 
@@ -38,7 +38,7 @@ class Comment
         return $this->article;
     }
 
-    public function getId(): int
+    public function getId(): string
     {
         return $this->id;
     }
@@ -55,7 +55,7 @@ class Comment
         return $this;
     }
 
-    public function setId(int $id): self
+    public function setId(string $id): self
     {
         $this->id = $id;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 

 When we update OneToMany entities we want to keep track of collections.  The feature allows us to save the ids of objects that were added/removed from a collection