### PR TITLE
[EasyDoctrine] Renamed the "$wrapped" argument to "$decorated" in the "EntityManagerDecorator" decorator

### DIFF
--- a/packages/EasyDoctrine/docs/doctrine/entity_manager_decorator.md
+++ b/packages/EasyDoctrine/docs/doctrine/entity_manager_decorator.md
@@ -11,16 +11,19 @@ Two main features of EntityManagerDecorator are Transactional and Deferred entit
 ### Transactional
 
 `$entityManager->transactional(callable $callback)` provide:
+
 - flush and commit or rollback if something goes wrong
 - close EntityManager if `Doctrine\ORM\ORMException` or `Doctrine\DBAL\Exception` is thrown
 
 #### Configuration
+
 Register the decorator
+
 ```yaml
 services:
     EonX\EasyDoctrine\ORM\Decorators\EntityManagerDecorator:
         arguments:
-            $wrapped: '@.inner'
+            $decorated: '@.inner'
         decorates: doctrine.orm.default_entity_manager
 ```
 
@@ -61,14 +64,12 @@ Register a listener:
 services:
     App\Listener\SomeEntityCreatedListener:
         tags:
-            -
-                name: kernel.event_listener
+            -   name: kernel.event_listener
                 event: EonX\EasyDoctrine\Events\EntityCreatedEvent
 
     App\Listener\SomeEntityUpdatedListener:
         tags:
-            -
-                name: kernel.event_listener
+            -   name: kernel.event_listener
                 event: EonX\EasyDoctrine\Events\EntityUpdatedEvent
 ```
 

--- a/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
+++ b/packages/EasyDoctrine/src/ORM/Decorators/EntityManagerDecorator.php
@@ -18,9 +18,9 @@ final class EntityManagerDecorator extends DoctrineEntityManagerDecorator
     public function __construct(
         private DeferredEntityEventDispatcherInterface $deferredEntityEventDispatcher,
         private EventDispatcherInterface $eventDispatcher,
-        EntityManagerInterface $wrapped,
+        EntityManagerInterface $decorated,
     ) {
-        parent::__construct($wrapped);
+        parent::__construct($decorated);
     }
 
     public function commit(): void

--- a/symfony-recipes/eonx-com/easy-doctrine/3.4/config/packages/easy_doctrine.yaml
+++ b/symfony-recipes/eonx-com/easy-doctrine/3.4/config/packages/easy_doctrine.yaml
@@ -1,5 +1,5 @@
 easy_doctrine:
-    deferred_dispatcher_entities: []
+    deferred_dispatcher_entities: [ ]
 
 services:
     _defaults:
@@ -8,14 +8,12 @@ services:
 
     EonX\EasyDoctrine\ORM\Decorators\EntityManagerDecorator:
         arguments:
-            $wrapped: '@.inner'
+            $decorated: '@.inner'
         decorates: doctrine.orm.default_entity_manager
 
     EonX\EasyDoctrine\Subscribers\EntityEventSubscriber:
         arguments:
             $entities: '%easy_doctrine.deferred_dispatcher_entities%'
         tags:
-            -
-                name: doctrine.event_subscriber
+            -   name: doctrine.event_subscriber
                 connection: default
-


### PR DESCRIPTION
Renamed the `$wrapped` argument to `$decorated` in the `EntityManagerDecorator` decorator.

