### PR TITLE
[EasyDoctrine] Make change set clearing extensible

### DIFF
--- a/packages/EasyActivity/tests/Stubs/EntityManagerStub.php
+++ b/packages/EasyActivity/tests/Stubs/EntityManagerStub.php
@@ -25,8 +25,10 @@ use EonX\EasyActivity\Tests\Fixtures\Article;
 use EonX\EasyActivity\Tests\Fixtures\Author;
 use EonX\EasyActivity\Tests\Fixtures\Comment;
 use EonX\EasyDoctrine\Bridge\Symfony\DependencyInjection\Factory\ObjectCopierFactory;
+use EonX\EasyDoctrine\Cleaners\DateTimeChangesetCleaner;
 use EonX\EasyDoctrine\Dispatchers\DeferredEntityEventDispatcher;
 use EonX\EasyDoctrine\ORM\Decorators\EntityManagerDecorator;
+use EonX\EasyDoctrine\Providers\ChangesetCleanerProvider;
 use EonX\EasyDoctrine\Subscribers\EntityEventSubscriber;
 use EonX\EasyEventDispatcher\Bridge\Symfony\EventDispatcher;
 use EonX\EasyEventDispatcher\Interfaces\EventDispatcherInterface;
@@ -54,7 +56,11 @@ final class EntityManagerStub
         array $subscribedEntities = [],
         array $fixtures = [],
     ) {
-        $eventSubscriber = new EntityEventSubscriber($dispatcher, $subscribedEntities);
+        $eventSubscriber = new EntityEventSubscriber(
+            $dispatcher,
+            $subscribedEntities,
+            new ChangesetCleanerProvider([new DateTimeChangesetCleaner()])
+        );
         $eventManager = new EventManager();
         $eventManager->addEventSubscriber($eventSubscriber);
         $entityManagerStub = self::createFromEventManager($eventManager, $fixtures);

--- a/packages/EasyDoctrine/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyDoctrine/src/Bridge/Symfony/Resources/config/services.php
@@ -7,7 +7,10 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use EonX\EasyDoctrine\Bridge\Symfony\DependencyInjection\Factory\ObjectCopierFactory;
 use EonX\EasyDoctrine\Dispatchers\DeferredEntityEventDispatcher;
 use EonX\EasyDoctrine\Dispatchers\DeferredEntityEventDispatcherInterface;
+use EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface;
+use EonX\EasyDoctrine\Interfaces\ChangesetCleanerProviderInterface;
 use EonX\EasyDoctrine\Interfaces\ObjectCopierInterface;
+use EonX\EasyDoctrine\Providers\ChangesetCleanerProvider;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -21,4 +24,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->factory([ObjectCopierFactory::class, 'create']);
 
     $services->set(DeferredEntityEventDispatcherInterface::class, DeferredEntityEventDispatcher::class);
+
+    $services
+        ->instanceof(ChangesetCleanerInterface::class)
+        ->tag('easy_doctrine.changeset_cleaner');
+    $services->set(ChangesetCleanerProviderInterface::class, ChangesetCleanerProvider::class)
+        ->arg('$cleaners', tagged_iterator('easy_doctrine.changeset_cleaner'));
 };

--- a/packages/EasyDoctrine/src/Cleaners/DateTimeChangesetCleaner.php
+++ b/packages/EasyDoctrine/src/Cleaners/DateTimeChangesetCleaner.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Cleaners;
@@ -7,7 +8,7 @@ use DateTimeInterface;
 use EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface;
 
 /**
- * @implements ChangesetCleanerInterface<DateTimeInterface>
+ * @implements \EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<\DateTimeInterface>
  */
 final class DateTimeChangesetCleaner implements ChangesetCleanerInterface
 {

--- a/packages/EasyDoctrine/src/Cleaners/DateTimeChangesetCleaner.php
+++ b/packages/EasyDoctrine/src/Cleaners/DateTimeChangesetCleaner.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyDoctrine\Cleaners;
+
+use DateTimeInterface;
+use EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface;
+
+/**
+ * @implements ChangesetCleanerInterface<DateTimeInterface>
+ */
+final class DateTimeChangesetCleaner implements ChangesetCleanerInterface
+{
+    /**
+     * @var string
+     */
+    private const DATETIME_COMPARISON_FORMAT = 'Y-m-d H:i:s.uP';
+
+    public function supports(string $class): bool
+    {
+        return \is_subclass_of($class, DateTimeInterface::class);
+    }
+
+    public function shouldBeCleared(object $oldValue, object $newValue): bool
+    {
+        return $oldValue->format(self::DATETIME_COMPARISON_FORMAT) ===
+            $newValue->format(self::DATETIME_COMPARISON_FORMAT);
+    }
+}

--- a/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerInterface.php
+++ b/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EonX\EasyDoctrine\Interfaces;
 
 /**

--- a/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerInterface.php
+++ b/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EonX\EasyDoctrine\Interfaces;
+
+/**
+ * @template T of object
+ */
+interface ChangesetCleanerInterface
+{
+    /**
+     * @param class-string $class
+     */
+    public function supports(string $class): bool;
+
+    /**
+     * @param T $oldValue
+     * @param T $newValue
+     */
+    public function shouldBeCleared(object $oldValue, object $newValue): bool;
+}

--- a/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerProviderInterface.php
+++ b/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EonX\EasyDoctrine\Interfaces;
+
+interface ChangesetCleanerProviderInterface
+{
+    /**
+     * @param class-string $oldClass
+     * @param class-string $newClass
+     *
+     * @return \EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<object>|null
+     */
+    public function getChangesetCleaner(string $oldClass, string $newClass): ?ChangesetCleanerInterface;
+}

--- a/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerProviderInterface.php
+++ b/packages/EasyDoctrine/src/Interfaces/ChangesetCleanerProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EonX\EasyDoctrine\Interfaces;
 
 interface ChangesetCleanerProviderInterface

--- a/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
+++ b/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
@@ -20,9 +20,11 @@ final class ChangesetCleanerProvider implements ChangesetCleanerProviderInterfac
     private array $cleanersByClass = [];
 
     /**
-     * @param iterable<\EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<object>> $cleaners
+     * @param iterable<\EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<T>> $cleaners
+     *
+     * @template T of object
      */
-    public function __construct(iterable $cleaners)
+    public function __construct(array $cleaners)
     {
         $this->cleaners = $cleaners;
     }

--- a/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
+++ b/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
@@ -24,7 +24,7 @@ final class ChangesetCleanerProvider implements ChangesetCleanerProviderInterfac
      *
      * @template T of object
      */
-    public function __construct(array $cleaners)
+    public function __construct(iterable $cleaners)
     {
         $this->cleaners = $cleaners;
     }

--- a/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
+++ b/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
@@ -32,13 +32,16 @@ final class ChangesetCleanerProvider implements ChangesetCleanerProviderInterfac
             return $this->cleanersByClass[$oldClass];
         }
 
+        $cleanerForClass = null;
         foreach ($this->cleaners as $cleaner) {
             if ($cleaner->supports($oldClass) && $cleaner->supports($newClass)) {
-                $this->cleanersByClass[$oldClass] = $cleaner;
-                $this->cleanersByClass[$newClass] = $cleaner;
-                return $cleaner;
+                $cleanerForClass = $cleaner;
+                break;
             }
         }
+
+        $this->cleanersByClass[$oldClass] = $cleanerForClass;
+        $this->cleanersByClass[$newClass] = $cleanerForClass;
 
         return null;
     }

--- a/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
+++ b/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyDoctrine\Providers;
+
+use EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface;
+use EonX\EasyDoctrine\Interfaces\ChangesetCleanerProviderInterface;
+
+final class ChangesetCleanerProvider implements ChangesetCleanerProviderInterface
+{
+    /**
+     * @var iterable<\EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<object>>
+     */
+    private iterable $cleaners;
+
+    /**
+     * @var array<class-string, \EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<object>>
+     */
+    private array $cleanersByClass = [];
+
+    /**
+     * @param iterable<\EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<object>> $cleaners
+     */
+    public function __construct(iterable $cleaners)
+    {
+        $this->cleaners = $cleaners;
+    }
+
+    public function getChangesetCleaner(string $oldClass, string $newClass): ?ChangesetCleanerInterface
+    {
+        if (isset($this->cleanersByClass[$oldClass], $this->cleanersByClass[$newClass])) {
+            return $this->cleanersByClass[$oldClass];
+        }
+
+        foreach ($this->cleaners as $cleaner) {
+            if ($cleaner->supports($oldClass) && $cleaner->supports($newClass)) {
+                $this->cleanersByClass[$oldClass] = $cleaner;
+                $this->cleanersByClass[$newClass] = $cleaner;
+                return $cleaner;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
+++ b/packages/EasyDoctrine/src/Providers/ChangesetCleanerProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace EonX\EasyDoctrine\Providers;
@@ -14,7 +15,7 @@ final class ChangesetCleanerProvider implements ChangesetCleanerProviderInterfac
     private iterable $cleaners;
 
     /**
-     * @var array<class-string, \EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<object>>
+     * @var array<class-string, \EonX\EasyDoctrine\Interfaces\ChangesetCleanerInterface<object>|null>
      */
     private array $cleanersByClass = [];
 
@@ -43,6 +44,6 @@ final class ChangesetCleanerProvider implements ChangesetCleanerProviderInterfac
         $this->cleanersByClass[$oldClass] = $cleanerForClass;
         $this->cleanersByClass[$newClass] = $cleanerForClass;
 
-        return null;
+        return $cleanerForClass;
     }
 }

--- a/packages/EasyDoctrine/tests/Stubs/EntityManagerStub.php
+++ b/packages/EasyDoctrine/tests/Stubs/EntityManagerStub.php
@@ -10,8 +10,10 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Tools\SchemaTool;
 use EonX\EasyDoctrine\Bridge\Symfony\DependencyInjection\Factory\ObjectCopierFactory;
+use EonX\EasyDoctrine\Cleaners\DateTimeChangesetCleaner;
 use EonX\EasyDoctrine\Dispatchers\DeferredEntityEventDispatcher;
 use EonX\EasyDoctrine\ORM\Decorators\EntityManagerDecorator;
+use EonX\EasyDoctrine\Providers\ChangesetCleanerProvider;
 use EonX\EasyDoctrine\Subscribers\EntityEventSubscriber;
 use EonX\EasyEventDispatcher\Bridge\Symfony\EventDispatcher;
 use EonX\EasyEventDispatcher\Interfaces\EventDispatcherInterface;
@@ -33,7 +35,11 @@ final class EntityManagerStub
         array $subscribedEntities = [],
         array $fixtures = [],
     ) {
-        $eventSubscriber = new EntityEventSubscriber($dispatcher, $subscribedEntities);
+        $eventSubscriber = new EntityEventSubscriber(
+            $dispatcher,
+            $subscribedEntities,
+            new ChangesetCleanerProvider([new DateTimeChangesetCleaner()])
+        );
         $eventManager = new EventManager();
         $eventManager->addEventSubscriber($eventSubscriber);
         $entityManagerStub = self::createFromEventManager($eventManager, $fixtures);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

We can have different types in change sets and this feature helps us to make the clearing process extensible.