### PR TITLE
[EasyActivity] Compute changesets of collections

### DIFF
--- a/packages/EasyActivity/tests/ActivityLogEntryFactoryResolversTest.php
+++ b/packages/EasyActivity/tests/ActivityLogEntryFactoryResolversTest.php
@@ -37,7 +37,7 @@ final class ActivityLogEntryFactoryResolversTest extends AbstractTestCase
             }
         );
         $author = new Author();
-        $author->setId('00000000-0000-0000-0000-000000000000');
+        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
 
         $result = $factory->create(
             ActivityLogEntry::ACTION_UPDATE,
@@ -79,7 +79,7 @@ final class ActivityLogEntryFactoryResolversTest extends AbstractTestCase
             }
         );
         $author = new Author();
-        $author->setId('00000000-0000-0000-0000-000000000000');
+        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
 
         $result = $factory->create(
             ActivityLogEntry::ACTION_UPDATE,

--- a/packages/EasyActivity/tests/ActivityLogEntryFactoryResolversTest.php
+++ b/packages/EasyActivity/tests/ActivityLogEntryFactoryResolversTest.php
@@ -15,6 +15,7 @@ use EonX\EasyActivity\Interfaces\ActorResolverInterface;
 use EonX\EasyActivity\Tests\Fixtures\ActivityLogEntity;
 use EonX\EasyActivity\Tests\Fixtures\Author;
 use EonX\EasyActivity\Tests\Stubs\ActivityLogFactoryStub;
+use Symfony\Component\Uid\NilUuid;
 
 final class ActivityLogEntryFactoryResolversTest extends AbstractTestCase
 {
@@ -37,7 +38,7 @@ final class ActivityLogEntryFactoryResolversTest extends AbstractTestCase
             }
         );
         $author = new Author();
-        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
+        $author->setId((string) (new NilUuid()));
 
         $result = $factory->create(
             ActivityLogEntry::ACTION_UPDATE,
@@ -79,7 +80,7 @@ final class ActivityLogEntryFactoryResolversTest extends AbstractTestCase
             }
         );
         $author = new Author();
-        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
+        $author->setId((string) (new NilUuid()));
 
         $result = $factory->create(
             ActivityLogEntry::ACTION_UPDATE,

--- a/packages/EasyActivity/tests/ActivityLogEntryFactoryTest.php
+++ b/packages/EasyActivity/tests/ActivityLogEntryFactoryTest.php
@@ -11,6 +11,7 @@ use EonX\EasyActivity\Tests\Fixtures\Article;
 use EonX\EasyActivity\Tests\Fixtures\Author;
 use EonX\EasyActivity\Tests\Fixtures\Comment;
 use EonX\EasyActivity\Tests\Stubs\ActivityLogFactoryStub;
+use Symfony\Component\Uid\NilUuid;
 
 final class ActivityLogEntryFactoryTest extends AbstractTestCase
 {
@@ -88,7 +89,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         /** @var \EonX\EasyActivity\ActivityLogEntry $result */
         $result = $factory->create(
             ActivityLogEntry::ACTION_CREATE,
-            (new Article())->setId((string) (new \Symfony\Component\Uid\NilUuid())),
+            (new Article())->setId((string) (new NilUuid())),
             ['title' => [null, 'New Title']]
         );
 
@@ -103,7 +104,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         self::assertSame(ActivityLogEntry::DEFAULT_ACTOR_TYPE, $result->getActorType());
         self::assertSame(ActivityLogEntry::ACTION_CREATE, $result->getAction());
         self::assertNull($result->getActorName());
-        self::assertSame((string) (new \Symfony\Component\Uid\NilUuid()), $result->getSubjectId());
+        self::assertSame((string) (new NilUuid()), $result->getSubjectId());
         self::assertSame(Article::class, $result->getSubjectType());
         self::assertEqualsCanonicalizing(Carbon::getTestNow(), $result->getCreatedAt());
         self::assertEqualsCanonicalizing(Carbon::getTestNow(), $result->getUpdatedAt());
@@ -113,7 +114,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
     {
         $factory = new ActivityLogFactoryStub([Article::class => []], []);
         $comment1 = (new Comment())
-            ->setId((string) (new \Symfony\Component\Uid\NilUuid()))
+            ->setId((string) (new NilUuid()))
             ->setMessage('Test 1');
         $comment2 = (new Comment())
             ->setId('00000000-0000-0000-0000-000000000001')
@@ -140,7 +141,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
             [
                 'content' => 'Content',
                 'comments' => [
-                    ['id' => (string) (new \Symfony\Component\Uid\NilUuid())],
+                    ['id' => (string) (new NilUuid())],
                     ['id' => '00000000-0000-0000-0000-000000000001'],
                 ],
             ],
@@ -152,7 +153,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
     {
         $factory = new ActivityLogFactoryStub([Article::class => []], []);
         $author = new Author();
-        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
+        $author->setId((string) (new NilUuid()));
         $author->setName('John');
         $author->setPosition(1);
         $article = new Article();
@@ -174,7 +175,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         self::assertEquals(
             [
                 'title' => 'Related objects',
-                'author' => ['id' => (string) (new \Symfony\Component\Uid\NilUuid())],
+                'author' => ['id' => (string) (new NilUuid())],
             ],
             \json_decode((string)$result->getSubjectData(), true)
         );
@@ -194,7 +195,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
             []
         );
         $author = new Author();
-        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
+        $author->setId((string) (new NilUuid()));
         $author->setName('John');
         $author->setPosition(1);
         $article = new Article();
@@ -251,7 +252,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         $author = new Author();
         $author->setName('John');
         $author->setPosition(1);
-        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
+        $author->setId((string) (new NilUuid()));
         $article = new Article();
         $article->setId('00000000-0000-0000-0000-000000000001');
 

--- a/packages/EasyActivity/tests/ActivityLogEntryFactoryTest.php
+++ b/packages/EasyActivity/tests/ActivityLogEntryFactoryTest.php
@@ -88,7 +88,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         /** @var \EonX\EasyActivity\ActivityLogEntry $result */
         $result = $factory->create(
             ActivityLogEntry::ACTION_CREATE,
-            (new Article())->setId('00000000-0000-0000-0000-000000000000'),
+            (new Article())->setId((string) (new \Symfony\Component\Uid\NilUuid())),
             ['title' => [null, 'New Title']]
         );
 
@@ -103,7 +103,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         self::assertSame(ActivityLogEntry::DEFAULT_ACTOR_TYPE, $result->getActorType());
         self::assertSame(ActivityLogEntry::ACTION_CREATE, $result->getAction());
         self::assertNull($result->getActorName());
-        self::assertSame('00000000-0000-0000-0000-000000000000', $result->getSubjectId());
+        self::assertSame((string) (new \Symfony\Component\Uid\NilUuid()), $result->getSubjectId());
         self::assertSame(Article::class, $result->getSubjectType());
         self::assertEqualsCanonicalizing(Carbon::getTestNow(), $result->getCreatedAt());
         self::assertEqualsCanonicalizing(Carbon::getTestNow(), $result->getUpdatedAt());
@@ -113,7 +113,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
     {
         $factory = new ActivityLogFactoryStub([Article::class => []], []);
         $comment1 = (new Comment())
-            ->setId('00000000-0000-0000-0000-000000000000')
+            ->setId((string) (new \Symfony\Component\Uid\NilUuid()))
             ->setMessage('Test 1');
         $comment2 = (new Comment())
             ->setId('00000000-0000-0000-0000-000000000001')
@@ -140,7 +140,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
             [
                 'content' => 'Content',
                 'comments' => [
-                    ['id' => '00000000-0000-0000-0000-000000000000'],
+                    ['id' => (string) (new \Symfony\Component\Uid\NilUuid())],
                     ['id' => '00000000-0000-0000-0000-000000000001'],
                 ],
             ],
@@ -152,7 +152,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
     {
         $factory = new ActivityLogFactoryStub([Article::class => []], []);
         $author = new Author();
-        $author->setId('00000000-0000-0000-0000-000000000000');
+        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
         $author->setName('John');
         $author->setPosition(1);
         $article = new Article();
@@ -174,7 +174,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         self::assertEquals(
             [
                 'title' => 'Related objects',
-                'author' => ['id' => '00000000-0000-0000-0000-000000000000'],
+                'author' => ['id' => (string) (new \Symfony\Component\Uid\NilUuid())],
             ],
             \json_decode((string)$result->getSubjectData(), true)
         );
@@ -194,7 +194,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
             []
         );
         $author = new Author();
-        $author->setId('00000000-0000-0000-0000-000000000000');
+        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
         $author->setName('John');
         $author->setPosition(1);
         $article = new Article();
@@ -251,7 +251,7 @@ final class ActivityLogEntryFactoryTest extends AbstractTestCase
         $author = new Author();
         $author->setName('John');
         $author->setPosition(1);
-        $author->setId('00000000-0000-0000-0000-000000000000');
+        $author->setId((string) (new \Symfony\Component\Uid\NilUuid()));
         $article = new Article();
         $article->setId('00000000-0000-0000-0000-000000000001');
 

--- a/packages/EasyActivity/tests/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriberTest.php
+++ b/packages/EasyActivity/tests/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriberTest.php
@@ -240,6 +240,7 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
 
         $logEntries = $this->getLogEntries($entityManager);
         self::assertCount(3, $logEntries);
+        // Create an article
         self::assertSame('create', $logEntries[0]['action']);
         self::assertSame(
             [
@@ -248,6 +249,7 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
             ],
             \json_decode((string)$logEntries[0]['subject_data'], true)
         );
+        // Delete the comment C of the article
         self::assertSame('update', $logEntries[1]['action']);
         self::assertSame(
             [
@@ -261,6 +263,7 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
             ],
             \json_decode((string) $logEntries[1]['subject_old_data'], true)
         );
+        // Add a new comment D to the article
         self::assertSame('update', $logEntries[2]['action']);
         self::assertSame(
             [

--- a/packages/EasyActivity/tests/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriberTest.php
+++ b/packages/EasyActivity/tests/Bridge/EasyDoctrine/EasyDoctrineEntityEventsSubscriberTest.php
@@ -253,26 +253,26 @@ final class EasyDoctrineEntityEventsSubscriberTest extends AbstractSymfonyTestCa
             [
                 'comments' => [$commentA->getId(), $commentB->getId()],
             ],
-            \json_decode($logEntries[1]['subject_data'], true)
+            \json_decode((string) $logEntries[1]['subject_data'], true)
         );
         self::assertSame(
             [
                 'comments' => [$commentA->getId(), $commentB->getId(), $commentC->getId()],
             ],
-            \json_decode($logEntries[1]['subject_old_data'], true)
+            \json_decode((string) $logEntries[1]['subject_old_data'], true)
         );
         self::assertSame('update', $logEntries[2]['action']);
         self::assertSame(
             [
                 'comments' => [$commentA->getId(), $commentB->getId(), $commentD->getId()],
             ],
-            \json_decode($logEntries[2]['subject_data'], true)
+            \json_decode((string) $logEntries[2]['subject_data'], true)
         );
         self::assertSame(
             [
                 'comments' => [$commentA->getId(), $commentB->getId()],
             ],
-            \json_decode($logEntries[2]['subject_old_data'], true)
+            \json_decode((string) $logEntries[2]['subject_old_data'], true)
         );
     }
 

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/CircularReferenceHandlerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/CircularReferenceHandlerTest.php
@@ -19,7 +19,7 @@ final class CircularReferenceHandlerTest extends AbstractSymfonyTestCase
     {
         $entityManager = EntityManagerStub::createFromEventManager();
         $handler = new CircularReferenceHandler($entityManager);
-        $article = (new Article())->setId('00000000-0000-0000-0000-000000000000');
+        $article = (new Article())->setId((string) (new \Symfony\Component\Uid\NilUuid()));
 
         $result = $handler($article, 'json', []);
 

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/CircularReferenceHandlerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/CircularReferenceHandlerTest.php
@@ -9,6 +9,7 @@ use EonX\EasyActivity\Tests\Bridge\Symfony\AbstractSymfonyTestCase;
 use EonX\EasyActivity\Tests\Fixtures\Article;
 use EonX\EasyActivity\Tests\Stubs\EntityManagerStub;
 use stdClass;
+use Symfony\Component\Uid\NilUuid;
 
 /**
  * @covers \EonX\EasyActivity\Bridge\Symfony\Serializers\CircularReferenceHandler
@@ -19,7 +20,7 @@ final class CircularReferenceHandlerTest extends AbstractSymfonyTestCase
     {
         $entityManager = EntityManagerStub::createFromEventManager();
         $handler = new CircularReferenceHandler($entityManager);
-        $article = (new Article())->setId((string) (new \Symfony\Component\Uid\NilUuid()));
+        $article = (new Article())->setId((string) (new NilUuid()));
 
         $result = $handler($article, 'json', []);
 

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
@@ -197,10 +197,10 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
             'subject' => new ActivitySubject($entityId, Article::class, [], [], $allowedProperties),
             'disallowedProperties' => null,
             'expectedResult' => \sprintf(
-                '{"comments":[{"article":{"author":null,"comments":' .
-                '["EonX\\\EasyActivity\\\Tests\\\Fixtures\\\Comment#00000000-0000-0000-0000-000000000000' .
-                ' (circular reference)"],"createdAt":"%s"},"id":"00000000-0000-0000-0000-000000000000",' .
-                '"message":"some-message"}]}',
+                '{"comments":[{"article":{"author":{"id":"00000000-0000-0000-0000-000000000000","name":"John Doe"'
+                . ',"position":1},"comments":["EonX\\\EasyActivity\\\Tests\\\Fixtures\\\Comment#00000000-0000-0000-0000'
+                . '-000000000000 (circular reference)"],"createdAt":"%s","id":"00000000-0000-0000-0000-000000000001"},'
+                . '"id":"00000000-0000-0000-0000-000000000000","message":"some-message"}]}',
                 $expectedCreatedAt
             ),
         ];

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
@@ -17,6 +17,7 @@ use EonX\EasyActivity\Tests\Fixtures\Author;
 use EonX\EasyActivity\Tests\Fixtures\Comment;
 use EonX\EasyActivity\Tests\Stubs\EntityManagerStub;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Uid\NilUuid;
 
 final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTestCase
 {
@@ -27,7 +28,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
      */
     public static function provideDataForSerializeSucceeds(): iterable
     {
-        $entityId = (string) (new \Symfony\Component\Uid\NilUuid());
+        $entityId = (string) (new NilUuid());
         $authorName = 'John Doe';
         $authorPosition = 1;
         $author = new Author();
@@ -179,7 +180,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
         ];
 
         $comment = (new Comment())
-            ->setId((string) (new \Symfony\Component\Uid\NilUuid()))
+            ->setId((string) (new NilUuid()))
             ->setMessage('some-message');
         $article = new Article();
         $article->setId('00000000-0000-0000-0000-000000000001');

--- a/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
+++ b/packages/EasyActivity/tests/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializerTest.php
@@ -27,7 +27,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
      */
     public static function provideDataForSerializeSucceeds(): iterable
     {
-        $entityId = '00000000-0000-0000-0000-000000000000';
+        $entityId = (string) (new \Symfony\Component\Uid\NilUuid());
         $authorName = 'John Doe';
         $authorPosition = 1;
         $author = new Author();
@@ -179,7 +179,7 @@ final class SymfonyActivitySubjectDataSerializerTest extends AbstractSymfonyTest
         ];
 
         $comment = (new Comment())
-            ->setId('00000000-0000-0000-0000-000000000000')
+            ->setId((string) (new \Symfony\Component\Uid\NilUuid()))
             ->setMessage('some-message');
         $article = new Article();
         $article->setId('00000000-0000-0000-0000-000000000001');

--- a/packages/EasyActivity/tests/Fixtures/Article.php
+++ b/packages/EasyActivity/tests/Fixtures/Article.php
@@ -30,7 +30,7 @@ class Article
     private DateTimeInterface $createdAt;
 
     #[ORM\Column(type: Types::GUID)]
-    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\GeneratedValue(strategy: 'UUID')]
     #[ORM\Id]
     private string $id;
 

--- a/packages/EasyActivity/tests/Fixtures/Article.php
+++ b/packages/EasyActivity/tests/Fixtures/Article.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 
 #[ORM\Entity]
 class Article
@@ -30,7 +31,8 @@ class Article
     private DateTimeInterface $createdAt;
 
     #[ORM\Column(type: Types::GUID)]
-    #[ORM\GeneratedValue(strategy: 'UUID')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\Id]
     private string $id;
 

--- a/packages/EasyActivity/tests/Fixtures/Author.php
+++ b/packages/EasyActivity/tests/Fixtures/Author.php
@@ -6,12 +6,14 @@ namespace EonX\EasyActivity\Tests\Fixtures;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 
 #[ORM\Entity]
 class Author
 {
     #[ORM\Column(type: Types::GUID)]
-    #[ORM\GeneratedValue(strategy: 'UUID')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\Id]
     private string $id;
 

--- a/packages/EasyActivity/tests/Fixtures/Author.php
+++ b/packages/EasyActivity/tests/Fixtures/Author.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Author
 {
     #[ORM\Column(type: Types::GUID)]
-    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\GeneratedValue(strategy: 'UUID')]
     #[ORM\Id]
     private string $id;
 

--- a/packages/EasyActivity/tests/Fixtures/Comment.php
+++ b/packages/EasyActivity/tests/Fixtures/Comment.php
@@ -14,7 +14,7 @@ class Comment
     private Article $article;
 
     #[ORM\Column(type: Types::GUID)]
-    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\GeneratedValue(strategy: 'UUID')]
     #[ORM\Id]
     private string $id;
 

--- a/packages/EasyActivity/tests/Fixtures/Comment.php
+++ b/packages/EasyActivity/tests/Fixtures/Comment.php
@@ -6,6 +6,7 @@ namespace EonX\EasyActivity\Tests\Fixtures;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 
 #[ORM\Entity]
 class Comment
@@ -14,7 +15,8 @@ class Comment
     private Article $article;
 
     #[ORM\Column(type: Types::GUID)]
-    #[ORM\GeneratedValue(strategy: 'UUID')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\Id]
     private string $id;
 

--- a/packages/EasyDoctrine/src/Subscribers/EntityEventSubscriber.php
+++ b/packages/EasyDoctrine/src/Subscribers/EntityEventSubscriber.php
@@ -146,7 +146,7 @@ final class EntityEventSubscriber implements EntityEventSubscriberInterface
             $actualIds = \array_map($mappingIdsFunction, $collection->toArray());
             $diff = \array_diff($snapshotIds, $actualIds);
             if (\count($diff) > 0 || \count($snapshotIds) !== \count($actualIds)) {
-                /** @var array{'fieldName': string} $mapping */
+                /** @var array{fieldName: string} $mapping */
                 $mapping = $collection->getMapping();
                 $changeSet[$mapping['fieldName']] = [\array_values($snapshotIds), \array_values($actualIds)];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

The same https://github.com/eonx-com/easy-monorepo/pull/1178 but for 5.x branch