### PR TITLE
[Easy Doctrine] Use stringable interface to compare objects

### DIFF
--- a/packages/EasyActivity/tests/Fixtures/Article.php
+++ b/packages/EasyActivity/tests/Fixtures/Article.php
@@ -16,14 +16,14 @@ use Doctrine\ORM\Mapping as ORM;
 class Article
 {
     /**
-     * @ORM\ManyToOne(targetEntity=Author::class)
+     * @ORM\ManyToOne(targetEntity=\EonX\EasyActivity\Tests\Fixtures\Author::class)
      *
      * @var \EonX\EasyActivity\Tests\Fixtures\Author
      */
     private $author;
 
     /**
-     * @ORM\OneToMany(targetEntity=Comment::class, mappedBy="article", cascade={"persist"})
+     * @ORM\OneToMany(targetEntity=\EonX\EasyActivity\Tests\Fixtures\Comment::class, mappedBy="article", cascade={"persist"})
      *
      * @var \Doctrine\Common\Collections\Collection<string|int, \EonX\EasyActivity\Tests\Fixtures\Comment>
      */

--- a/packages/EasyActivity/tests/Fixtures/Comment.php
+++ b/packages/EasyActivity/tests/Fixtures/Comment.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Comment
 {
     /**
-     * @ORM\ManyToOne(targetEntity=Article::class, inversedBy="comments")
+     * @ORM\ManyToOne(targetEntity=\EonX\EasyActivity\Tests\Fixtures\Article::class, inversedBy="comments")
      *
      * @var \EonX\EasyActivity\Tests\Fixtures\Article
      */

--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Pagination/CustomPaginatorInterface.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Pagination/CustomPaginatorInterface.php
@@ -28,7 +28,7 @@ interface CustomPaginatorInterface
      *
      * @return mixed[]
      *
-     * @Groups({CustomPaginatorInterface::SERIALIZER_GROUP})
+     * @Groups({\EonX\EasyCore\Bridge\Symfony\ApiPlatform\Pagination\CustomPaginatorInterface::SERIALIZER_GROUP})
      */
     public function getItems(): array;
 
@@ -37,7 +37,7 @@ interface CustomPaginatorInterface
      *
      * @return mixed[]
      *
-     * @Groups({CustomPaginatorInterface::SERIALIZER_GROUP})
+     * @Groups({\EonX\EasyCore\Bridge\Symfony\ApiPlatform\Pagination\CustomPaginatorInterface::SERIALIZER_GROUP})
      */
     public function getPagination(): array;
 }

--- a/packages/EasyDoctrine/src/Subscribers/EntityEventSubscriber.php
+++ b/packages/EasyDoctrine/src/Subscribers/EntityEventSubscriber.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\PersistentCollection;
 use EonX\EasyDoctrine\Dispatchers\DeferredEntityEventDispatcherInterface;
 use EonX\EasyDoctrine\Interfaces\EntityEventSubscriberInterface;
+use Stringable;
 
 final class EntityEventSubscriber implements EntityEventSubscriberInterface
 {
@@ -123,6 +124,11 @@ final class EntityEventSubscriber implements EntityEventSubscriberInterface
                 ($changeSetItem[1] ?? null) instanceof DateTimeInterface) {
                 return $changeSetItem[0]->format(self::DATETIME_COMPARISON_FORMAT) !==
                     $changeSetItem[1]->format(self::DATETIME_COMPARISON_FORMAT);
+            }
+
+            if (($changeSetItem[0] ?? null) instanceof Stringable &&
+                ($changeSetItem[1] ?? null) instanceof Stringable) {
+                return (string)$changeSetItem[0] !== (string)$changeSetItem[1];
             }
 
             return true;

--- a/packages/EasyDoctrine/tests/Fixtures/Price.php
+++ b/packages/EasyDoctrine/tests/Fixtures/Price.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyDoctrine\Tests\Fixtures;
+
+use Stringable;
+
+final class Price implements Stringable
+{
+    private string $amount;
+
+    private string $currency;
+
+    public function __construct(string $amount, string $currency)
+    {
+        $this->amount = $amount;
+        $this->currency = $currency;
+    }
+
+    public function __toString()
+    {
+        return \sprintf('%s %s', $this->amount, $this->currency);
+    }
+
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(string $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+}

--- a/packages/EasyDoctrine/tests/Fixtures/PriceType.php
+++ b/packages/EasyDoctrine/tests/Fixtures/PriceType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EonX\EasyDoctrine\Tests\Fixtures;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+
+final class PriceType extends StringType
+{
+    public const NAME = 'PRICE';
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): Price
+    {
+        $price = \explode(' ', $value);
+
+        return new Price($price[0], $price[1]);
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/packages/EasyDoctrine/tests/Fixtures/Product.php
+++ b/packages/EasyDoctrine/tests/Fixtures/Product.php
@@ -23,8 +23,8 @@ class Product
     #[ORM\Column(type: Types::STRING, length: 128)]
     private string $name;
 
-    #[ORM\Column(type: Types::BIGINT)]
-    private string $price;
+    #[ORM\Column(type: PriceType::NAME)]
+    private Price $price;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<string|int, \EonX\EasyDoctrine\Tests\Fixtures\Tag>
@@ -67,7 +67,7 @@ class Product
         return $this->name;
     }
 
-    public function getPrice(): string
+    public function getPrice(): Price
     {
         return $this->price;
     }
@@ -101,7 +101,7 @@ class Product
         return $this;
     }
 
-    public function setPrice(string $price): self
+    public function setPrice(Price $price): self
     {
         $this->price = $price;
 

--- a/packages/EasyDoctrine/tests/Stubs/EntityManagerStub.php
+++ b/packages/EasyDoctrine/tests/Stubs/EntityManagerStub.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EonX\EasyDoctrine\Tests\Stubs;
 
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
@@ -13,6 +14,7 @@ use EonX\EasyDoctrine\Bridge\Symfony\DependencyInjection\Factory\ObjectCopierFac
 use EonX\EasyDoctrine\Dispatchers\DeferredEntityEventDispatcher;
 use EonX\EasyDoctrine\ORM\Decorators\EntityManagerDecorator;
 use EonX\EasyDoctrine\Subscribers\EntityEventSubscriber;
+use EonX\EasyDoctrine\Tests\Fixtures\PriceType;
 use EonX\EasyEventDispatcher\Bridge\Symfony\EventDispatcher;
 use EonX\EasyEventDispatcher\Interfaces\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyEventDispatcher;
@@ -71,6 +73,9 @@ final class EntityManagerStub
         $schema = \array_map(function ($class) use ($entityManager) {
             return $entityManager->getClassMetadata($class);
         }, $fixtures);
+        if (Type::hasType(PriceType::NAME) === false) {
+            Type::addType(PriceType::NAME, PriceType::class);
+        }
 
         $schemaTool = new SchemaTool($entityManager);
         $schemaTool->dropSchema([]);

--- a/packages/EasyDoctrine/tests/Subscribers/EntityEventSubscriberTest.php
+++ b/packages/EasyDoctrine/tests/Subscribers/EntityEventSubscriberTest.php
@@ -95,6 +95,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         /** @var \EonX\EasyDoctrine\Tests\Fixtures\Category $category */
         $category = $entityManager->getRepository(Category::class)->find(1);
         $category->setActiveTill(new DateTimeImmutable($activeTill));
+        /** @var \EonX\EasyDoctrine\Tests\Fixtures\Product $product */
         $product = $entityManager->getRepository(Product::class)->find(1);
         $product->setPrice(new Price('1000', 'USD'));
 

--- a/packages/EasyDoctrine/tests/Subscribers/EntityEventSubscriberTest.php
+++ b/packages/EasyDoctrine/tests/Subscribers/EntityEventSubscriberTest.php
@@ -13,6 +13,7 @@ use EonX\EasyDoctrine\Events\EntityDeletedEvent;
 use EonX\EasyDoctrine\Events\EntityUpdatedEvent;
 use EonX\EasyDoctrine\Tests\AbstractTestCase;
 use EonX\EasyDoctrine\Tests\Fixtures\Category;
+use EonX\EasyDoctrine\Tests\Fixtures\Price;
 use EonX\EasyDoctrine\Tests\Fixtures\Product;
 use EonX\EasyDoctrine\Tests\Fixtures\Tag;
 use EonX\EasyDoctrine\Tests\Stubs\EntityManagerStub;
@@ -64,13 +65,13 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         );
     }
 
-    public function testEventIsNotDispatchedForEqualDates(): void
+    public function testEventIsNotDispatchedForEqualObjects(): void
     {
         $eventDispatcher = new EventDispatcherStub();
         $entityManager = EntityManagerStub::createFromSymfonyEventDispatcher(
             $eventDispatcher,
-            [Category::class],
-            [Category::class]
+            [Category::class, Product::class],
+            [Category::class, Product::class]
         );
         $activeTill = '2022-12-20 16:23:52';
         $entityManager->getConnection()
@@ -82,11 +83,21 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                     'activeTill' => $activeTill,
                 ]
             );
+        $entityManager->getConnection()
+            ->insert(
+                'product',
+                [
+                    'id' => 1,
+                    'name' => 'Laptop',
+                    'price' => '1000 USD',
+                ]
+            );
         /** @var \EonX\EasyDoctrine\Tests\Fixtures\Category $category */
         $category = $entityManager->getRepository(Category::class)->find(1);
         $category->setActiveTill(new DateTimeImmutable($activeTill));
+        $product = $entityManager->getRepository(Product::class)->find(1);
+        $product->setPrice(new Price('1000', 'USD'));
 
-        $entityManager->persist($category);
         $entityManager->flush();
 
         $events = $eventDispatcher->getDispatchedEvents();
@@ -107,7 +118,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         $dispatcher->enable();
         $product = new Product();
         $product->setName('Description 1');
-        $product->setPrice('1000');
+        $product->setPrice(new Price('1000', 'USD'));
         $entityManager->persist($product);
 
         $entityManager->flush();
@@ -129,12 +140,12 @@ final class EntityEventSubscriberTest extends AbstractTestCase
 
         $entityManager->transactional(function () use ($entityManager, $product) {
             $product->setName('Description 1');
-            $product->setPrice('1000');
+            $product->setPrice(new Price('1000', 'USD'));
             $entityManager->persist($product);
             $entityManager->flush();
             try {
                 $entityManager->transactional(function () use ($entityManager, $product) {
-                    $product->setPrice('2000');
+                    $product->setPrice(new Price('2000', 'USD'));
                     $entityManager->persist($product);
                     $entityManager->flush();
                     throw new \RuntimeException('Test', 1);
@@ -151,7 +162,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 [
                     'category' => [null, null],
                     'name' => [null, 'Description 1'],
-                    'price' => [null, '1000'],
+                    'price' => [null, new Price('1000', 'USD')],
                 ]
             ),
             $events[0]
@@ -171,7 +182,8 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         $entityManager->persist($category);
         $product = new Product();
         $product->setName('Keyboard');
-        $product->setPrice('1000');
+        $price = new Price('1000', 'USD');
+        $product->setPrice($price);
         $entityManager->persist($product);
 
         $entityManager->flush();
@@ -193,7 +205,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 $product,
                 [
                     'name' => [null, 'Keyboard'],
-                    'price' => [null, '1000'],
+                    'price' => [null, $price],
                     'category' => [null, null],
                 ]
             ),
@@ -223,7 +235,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 [
                     'id' => 1,
                     'name' => 'Keyboard',
-                    'price' => '1000',
+                    'price' => '1000 USD',
                 ]
             );
         /** @var \EonX\EasyDoctrine\Tests\Fixtures\Category $category */
@@ -231,7 +243,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         /** @var \EonX\EasyDoctrine\Tests\Fixtures\Product $product */
         $product = $entityManager->getRepository(Product::class)->find(1);
         $category->setName('Computer Peripherals');
-        $product->setPrice('2000');
+        $product->setPrice(new Price('2000', 'USD'));
 
         $entityManager->persist($category);
         $entityManager->persist($product);
@@ -252,7 +264,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
             new EntityUpdatedEvent(
                 $product,
                 [
-                    'price' => ['1000', '2000'],
+                    'price' => [new Price('1000', 'USD'), new Price('2000', 'USD')],
                 ]
             ),
             $events[1]
@@ -275,7 +287,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 }
                 $product = new Product();
                 $product->setName('Keyboard');
-                $product->setPrice('100');
+                $product->setPrice(new Price('100', 'USD'));
 
                 $entityManager->persist($product);
                 $entityManager->flush();
@@ -306,7 +318,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 $product,
                 [
                     'name' => [null, 'Keyboard'],
-                    'price' => [null, '100'],
+                    'price' => [null, new Price('100', 'USD')],
                     'category' => [null, null],
                 ]
             ),
@@ -328,7 +340,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         $entityManager->persist($category);
         $product = new Product();
         $product->setName('Keyboard');
-        $product->setPrice('1000');
+        $product->setPrice(new Price('1000', 'USD'));
         $product->setCategory($category);
         $entityManager->persist($product);
 
@@ -341,7 +353,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 $product,
                 [
                     'name' => [null, 'Keyboard'],
-                    'price' => [null, '1000'],
+                    'price' => [null, new Price('1000', 'USD')],
                     'category' => [null, $category],
                 ]
             ),
@@ -362,10 +374,10 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         $dispatcher->disable();
         $product = new Product();
         $product->setName('Description 1');
-        $product->setPrice('1000');
+        $product->setPrice(new Price('1000', 'USD'));
         $entityManager->persist($product);
         $entityManager->flush();
-        $product->setPrice('2000');
+        $product->setPrice(new Price('2000', 'USD'));
         $entityManager->flush();
 
         $events = $eventDispatcher->getDispatchedEvents();
@@ -386,11 +398,11 @@ final class EntityEventSubscriberTest extends AbstractTestCase
 
             $entityManager->transactional(function () use ($entityManager, $product) {
                 $product->setName('Description 1');
-                $product->setPrice('1000');
+                $product->setPrice(new Price('1000', 'USD'));
                 $entityManager->persist($product);
                 $entityManager->flush();
                 $entityManager->transactional(function () use ($entityManager, $product) {
-                    $product->setPrice('2000');
+                    $product->setPrice(new Price('2000', 'USD'));
                     $entityManager->persist($product);
                     $entityManager->flush();
                     throw new \RuntimeException('Test', 1);
@@ -441,7 +453,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 [
                     'id' => 1,
                     'name' => 'Keyboard',
-                    'price' => '1000',
+                    'price' => '1000 USD',
                     'category_id' => 1,
                 ]
             );
@@ -468,7 +480,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         );
         $product = new Product();
         $product->setName('Product 1');
-        $product->setPrice('1000');
+        $product->setPrice(new Price('1000', 'USD'));
         $entityManager->persist($product);
 
         $entityManager->flush();
@@ -498,7 +510,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 [
                     'id' => 1,
                     'name' => 'Keyboard',
-                    'price' => '1000',
+                    'price' => '1000 USD',
                     'category_id' => 1,
                 ]
             );
@@ -532,10 +544,10 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         /** @var \EonX\EasyDoctrine\Events\EntityDeletedEvent $actualEvent */
         $actualEvent = $events[0];
         self::assertInstanceOf(EntityDeletedEvent::class, $actualEvent);
-        self::assertSame($actualEvent->getChangeSet(), [
+        self::assertEquals($actualEvent->getChangeSet(), [
             'id' => [1, null],
             'name' => ['Keyboard', null],
-            'price' => ['1000', null],
+            'price' => [new Price('1000', 'USD'), null],
             'category_id' => [1, null],
             'category' => [$product->getCategory(), null],
             'tags' => [$product->getTags(), null],
@@ -545,7 +557,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         self::assertInstanceOf(Product::class, $product);
         self::assertSame(1, $product->getId());
         self::assertSame('Keyboard', $product->getName());
-        self::assertSame('1000', $product->getPrice());
+        self::assertEquals(new Price('1000', 'USD'), $product->getPrice());
         self::assertNotNull($product->getCategory());
         /** @var \EonX\EasyDoctrine\Tests\Fixtures\Category $category */
         $category = $product->getCategory();
@@ -575,18 +587,18 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 [
                     'id' => 1,
                     'name' => 'Keyboard',
-                    'price' => '1000',
+                    'price' => '1000 USD',
                 ]
             );
         /** @var \EonX\EasyDoctrine\Tests\Fixtures\Product $product */
         $product = $entityManager->getRepository(Product::class)->find(1);
 
         $entityManager->transactional(function () use ($entityManager, $product) {
-            $product->setPrice('2000');
+            $product->setPrice(new Price('2000', 'USD'));
             $entityManager->persist($product);
             $entityManager->flush();
             $entityManager->transactional(function () use ($entityManager, $product) {
-                $product->setPrice('3000');
+                $product->setPrice(new Price('3000', 'USD'));
                 $product->setName('Keyboard 2');
                 $entityManager->flush();
             });
@@ -599,7 +611,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
             new EntityUpdatedEvent(
                 $product,
                 [
-                    'price' => ['1000', '3000'],
+                    'price' => [new Price('1000', 'USD'), new Price('3000', 'USD')],
                     'name' => ['Keyboard', 'Keyboard 2'],
                 ]
             ),
@@ -619,11 +631,11 @@ final class EntityEventSubscriberTest extends AbstractTestCase
         $product = new Product();
         $entityManager->transactional(function () use ($entityManager, $product) {
             $product->setName('Description 1');
-            $product->setPrice('1000');
+            $product->setPrice(new Price('1000', 'USD'));
             $entityManager->persist($product);
             $entityManager->flush();
             $entityManager->transactional(function () use ($entityManager, $product) {
-                $product->setPrice('2000');
+                $product->setPrice(new Price('2000', 'USD'));
                 $entityManager->flush();
             });
         });
@@ -636,7 +648,7 @@ final class EntityEventSubscriberTest extends AbstractTestCase
                 $product,
                 [
                     'description' => [null, 'Description 1'],
-                    'price' => [null, '2000'],
+                    'price' => [null, new Price('2000', 'USD')],
                     'category' => [null, null],
                 ]
             ),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->


We need a way to compare objects when computing changesets
