### PR TITLE
[EasyPagination] Fix EloquentPaginatorTrait::fetchResult to use v3's way of fetching result

### DIFF
--- a/packages/EasyPagination/src/Traits/EloquentPaginatorTrait.php
+++ b/packages/EasyPagination/src/Traits/EloquentPaginatorTrait.php
@@ -125,6 +125,6 @@ trait EloquentPaginatorTrait
      */
     private function fetchResults(Builder $queryBuilder): array
     {
-        return \array_values($queryBuilder->get()->getDictionary());
+        return \iterator_to_array($queryBuilder->get()->getIterator());
     }
 }


### PR DESCRIPTION
- v3's fetching of results works `\iterator_to_array($queryBuilder->get()->getIterator());`
- v4's `\array_values($queryBuilder->get()->getDictionary());` returns incorrect result since in `getDictionary`, `$values->getKey()` is null thus returning a single value array[null] = last value of the result (older rows replaced).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
