### PR TITLE
[EasyActivity] Skip API Platform serializers

### DIFF
--- a/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Serializers/SymfonyActivitySubjectDataSerializer.php
@@ -83,6 +83,8 @@ final class SymfonyActivitySubjectDataSerializer implements ActivitySubjectDataS
             }
         }
 
+        $context['iri'] = 'not-needed-for-activity-log';
+
         $context[AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER] = $this->circularReferenceHandler;
 
         if (\count($data) === 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

The bug appears when using Symfony serializer (default bundle configuration) and API Platform installed.
When we try to serialize deleted entity data, when it is an API resource, the API Platform try to generate IRI.
For IRI generation it uses the original object which is already deleted from DB and doesn't have an ID.

