### PR TITLE
[EasySwoole] Fixed "SymfonyServicesAppStateResetter"

### DIFF
--- a/packages/EasySwoole/src/Bridge/Symfony/AppStateResetters/SymfonyServicesAppStateResetter.php
+++ b/packages/EasySwoole/src/Bridge/Symfony/AppStateResetters/SymfonyServicesAppStateResetter.php
@@ -57,6 +57,9 @@ final class SymfonyServicesAppStateResetter extends ServicesResetter implements 
 
     protected function shouldReset(string $service): bool
     {
-        return u($service)->containsAny('cache') === false;
+        return \str_starts_with($service, 'cache.') === false
+            && \str_starts_with($service, 'cache_') === false
+            && \str_ends_with($service, '.cache') === false
+            && \str_ends_with($service, '_cache') === false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

We have the following bug when we use the latest version of EasySwoole with EasyAdmin:
![image](https://github.com/eonx-com/easy-monorepo/assets/1703419/e7cc6c25-3123-4822-9206-5b3c45305ca9)

This bug was introduced in v4.3.21 (+4.3.22). To fix it we must reset the `form.choice_list_factory.cached` service at the end of each request.
