### PR TITLE
feature/easy-core-fix-CarbonImmutableNormalizer

### DIFF
--- a/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Normalizers/CarbonImmutableNormalizer.php
+++ b/packages/EasyCore/src/Bridge/Symfony/ApiPlatform/Normalizers/CarbonImmutableNormalizer.php
@@ -19,11 +19,25 @@ final class CarbonImmutableNormalizer extends DateTimeNormalizer
         ?string $format = null,
         ?array $context = null,
     ): CarbonImmutable {
-        return CarbonImmutable::parse(parent::denormalize($data, $type, $format, $context ?? []));
+        return new CarbonImmutable(parent::denormalize($data, $type, $format, $context ?? []));
     }
 
     public function hasCacheableSupportsMethod(): bool
     {
         return true;
+    }
+
+    /**
+     * @param mixed $data
+     * @param mixed[]|null $context
+     */
+    public function supportsDenormalization(
+        mixed $data,
+        string $type,
+        ?string $format = null,
+        ?array $context = null
+    ): bool {
+        return $type === CarbonImmutable::class
+            || parent::supportsDenormalization($data, $type, $format, $context ?? []);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes


When denormalizing Api Resource Symfony guess type by Doctrine type, but when denormalizing DTO type guessed by field type.
