### PR TITLE
[EasyApiPlatform] Fix `CarbonImmutableNormalizer` type detection issue

### DIFF
--- a/packages/EasyApiPlatform/src/Normalizers/CarbonImmutableNormalizer.php
+++ b/packages/EasyApiPlatform/src/Normalizers/CarbonImmutableNormalizer.php
@@ -14,11 +14,21 @@ final class CarbonImmutableNormalizer extends DateTimeNormalizer
         ?string $format = null,
         ?array $context = null,
     ): CarbonImmutable {
-        return CarbonImmutable::parse(parent::denormalize($data, $type, $format, $context ?? []));
+        return new CarbonImmutable(parent::denormalize($data, $type, $format, $context ?? []));
     }
 
     public function hasCacheableSupportsMethod(): bool
     {
         return true;
+    }
+
+    public function supportsDenormalization(
+        mixed $data,
+        string $type,
+        ?string $format = null,
+        ?array $context = null
+    ): bool {
+        return $type === CarbonImmutable::class
+            || parent::supportsDenormalization($data, $type, $format, $context ?? []);
     }
 }

--- a/packages/EasyApiPlatform/src/Normalizers/CarbonImmutableNormalizer.php
+++ b/packages/EasyApiPlatform/src/Normalizers/CarbonImmutableNormalizer.php
@@ -22,13 +22,9 @@ final class CarbonImmutableNormalizer extends DateTimeNormalizer
         return true;
     }
 
-    public function supportsDenormalization(
-        mixed $data,
-        string $type,
-        ?string $format = null,
-        ?array $context = null
-    ): bool {
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    {
         return $type === CarbonImmutable::class
-            || parent::supportsDenormalization($data, $type, $format, $context ?? []);
+            || parent::supportsDenormalization($data, $type, $format);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

When denormalizing Api Resource Symfony guess type by Doctrine type, but when denormalizing DTO type guessed by field type.
