### PR TITLE
[EasyErrorHandler] Fixed `CodeErrorResponseBuilder`

### DIFF
--- a/packages/EasyErrorHandler/src/Builders/CodeErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Builders/CodeErrorResponseBuilder.php
@@ -12,8 +12,12 @@ final class CodeErrorResponseBuilder extends AbstractSingleKeyErrorResponseBuild
 
     /**
      * @param mixed[] $data
+     *
+     * Some exceptions have the code as string, so we need return type to be int or string.
+     *
+     * @see https://www.php.net/manual/en/class.pdoexception.php#95812
      */
-    protected function doBuildValue(Throwable $throwable, array $data): int
+    protected function doBuildValue(Throwable $throwable, array $data): int|string
     {
         return $throwable->getCode();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Unexpectedly some exceptions keep the error code as string. For example, `\PDOException` (https://www.php.net/manual/en/class.pdoexception.php#95812). Because of this we have to update the `CodeErrorResponseBuilder::doBuildValue` method to allow return `int` or `string`.
