### PR TITLE
[ErrorHanlder] Add additional exception to support validation error building

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -77,6 +77,7 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
                 \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_API_PLATFORM, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_NO_PARAMETER_SYMFONY, $message) === 1,
             UnexpectedValueException::class =>
+                \preg_match(self::MESSAGE_PATTERN_TYPE_ERROR, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_INVALID_DATE, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_INVALID_IRI, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_NESTED_DOCUMENTS_NOT_ALLOWED, $message) === 1 ||


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes

- Add `NotNormalizableValueException` exception support with the message pattern - `/The type of the "(\w+)" attribute must be "(\w+)", "(\w+)" given/`