### PR TITLE
[EasyTest] Updated `MessengerAssertionsTrait` to allow delays between worker runs

### DIFF
--- a/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
+++ b/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
@@ -116,6 +116,7 @@ trait MessengerAssertionsTrait
 
     /**
      * @param array<int, class-string<\Throwable>|array<class-string<\Throwable>, int|string>> $expectedExceptions
+     * @param array<int> $expectedDelays Expected delays in seconds between worker runs
      */
     public static function consumeAsyncMessages(array $expectedExceptions = [], array $expectedDelays = []): void
     {

--- a/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
+++ b/packages/EasyTest/src/Traits/MessengerAssertionsTrait.php
@@ -5,6 +5,7 @@ namespace EonX\EasyTest\Traits;
 
 use PHPUnit\Framework\Constraint\IsEqual;
 use RuntimeException;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
@@ -116,7 +117,7 @@ trait MessengerAssertionsTrait
     /**
      * @param array<int, class-string<\Throwable>|array<class-string<\Throwable>, int|string>> $expectedExceptions
      */
-    public static function consumeAsyncMessages(array $expectedExceptions = []): void
+    public static function consumeAsyncMessages(array $expectedExceptions = [], array $expectedDelays = []): void
     {
         /**
          * If some exception occurs during message handling, it will be caught by Symfony Messenger Worker,
@@ -133,7 +134,7 @@ trait MessengerAssertionsTrait
             );
         }
 
-        self::runMessengerWorker('async', 'default', $expectedExceptions);
+        self::runMessengerWorker('async', 'default', $expectedExceptions, $expectedDelays);
     }
 
     /**
@@ -213,6 +214,7 @@ trait MessengerAssertionsTrait
         string $transportName,
         string $busName,
         array $expectedExceptions = [],
+        array $expectedDelays = [],
     ): void {
         /** @var \Symfony\Component\Messenger\Transport\InMemoryTransport $transport */
         $transport = self::getContainer()->get('messenger.transport.' . $transportName);
@@ -242,9 +244,14 @@ trait MessengerAssertionsTrait
 
             $messageLimitListener = new StopWorkerOnMessageLimitListener($messagesCount);
             $eventDispatcher->addSubscriber($messageLimitListener);
+            $clock = Clock::get();
 
-            $worker = new Worker(['async' => $transport], $messageBus, $eventDispatcher);
+            $worker = new Worker(['async' => $transport], $messageBus, $eventDispatcher, clock: $clock);
             $worker->run();
+
+            if (isset($expectedDelays[$tries - 1])) {
+                $clock->sleep($expectedDelays[$tries - 1]);
+            }
         }
 
         // Message handler may dispatch new messages to async transport and this can happen multiple times.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

