### PR TITLE
[EasyErrorHandler] Add TypeError case to ApiPlatformValidationErrorResponseBuilder

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -25,8 +25,8 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
     private const MESSAGE_PATTERN_ATTRIBUTE_TYPE_ERROR = '/The type of the "(\w+)" attribute for class "(.*)" must be' .
     ' one of "(\w+)" \("(\w+)" given\)\./';
 
-    private const MESSAGE_PATTERN_CONSTRUCTOR_TYPE_ERROR = '/[\"]?([\w\\\\]+)\:\:__construct\(\): Argument' .
-    ' #[\d]+ \(\$(\w+)\) must be of type [\"]?([\w\\\\]+), [\"]?([\w\\\\]+) given/';
+    private const MESSAGE_PATTERN_CONSTRUCTOR_TYPE_ERROR = '/(.+)Argument .+' .
+    '\(\$(\w+)\) must be of type ([\w\\\\]+), ([\w\\\\]+) given/';
 
     private const MESSAGE_PATTERN_INPUT_DATA_MISFORMATTED = '/The input data is misformatted\./';
 

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -49,6 +49,8 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
 
     private const VALUE_NULL = 'NULL';
 
+    private const VIOLATION_PATTERN_INVALID_IRI_ERROR = 'This value should be %s IRI.';
+
     private const VIOLATION_PATTERN_TYPE_ERROR = 'The type of the value should be "%s", "%s" given.';
 
     private const VIOLATION_VALUE_SHOULD_BE_IRI = 'This value should be an IRI.';
@@ -202,11 +204,12 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
         if ($throwable instanceof TypeError) {
             $matches = [];
             \preg_match(self::MESSAGE_PATTERN_CONSTRUCTOR_TYPE_ERROR, $throwable->getMessage(), $matches);
+            $explodedIri = \explode('\\', $matches[3]);
             $data[$violationsKey] = [
                 $matches[2] => [
                     $matches[4] === self::VALUE_NULL
                         ? (new NotNull())->message
-                        : \sprintf(self::VIOLATION_PATTERN_TYPE_ERROR, $matches[3], $matches[4]),
+                        : \sprintf(self::VIOLATION_PATTERN_INVALID_IRI_ERROR, \end($explodedIri)),
                 ],
             ];
         }

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -12,6 +12,7 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Throwable;
+use TypeError;
 
 final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorResponseBuilder
 {
@@ -23,6 +24,9 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
 
     private const MESSAGE_PATTERN_ATTRIBUTE_TYPE_ERROR = '/The type of the "(\w+)" attribute for class "(.*)" must be' .
     ' one of "(\w+)" \("(\w+)" given\)\./';
+
+    private const MESSAGE_PATTERN_CONSTRUCTOR_TYPE_ERROR = '/[\"]?([\w\\\\]+)\:\:__construct\(\): Argument' .
+    ' #[\d]+ \(\$(\w+)\) must be of type [\"]?([\w\\\\]+), [\"]?([\w\\\\]+) given/';
 
     private const MESSAGE_PATTERN_INPUT_DATA_MISFORMATTED = '/The input data is misformatted\./';
 
@@ -83,6 +87,8 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
                 \preg_match(self::MESSAGE_PATTERN_NESTED_DOCUMENTS_NOT_ALLOWED, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_NOT_IRI, $message) === 1 ||
                 \preg_match(self::MESSAGE_PATTERN_INPUT_DATA_MISFORMATTED, $message) === 1,
+            TypeError::class =>
+                \preg_match(self::MESSAGE_PATTERN_CONSTRUCTOR_TYPE_ERROR, $message) === 1,
             default => false
         };
     }
@@ -191,6 +197,18 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
 
                     break;
             }
+        }
+
+        if ($throwable instanceof TypeError) {
+            $matches = [];
+            \preg_match(self::MESSAGE_PATTERN_CONSTRUCTOR_TYPE_ERROR, $throwable->getMessage(), $matches);
+            $data[$violationsKey] = [
+                $matches[2] => [
+                    $matches[4] === self::VALUE_NULL
+                        ? (new NotNull())->message
+                        : \sprintf(self::VIOLATION_PATTERN_TYPE_ERROR, $matches[3], $matches[4]),
+                ],
+            ];
         }
 
         return parent::buildData($throwable, $data);


### PR DESCRIPTION
- added 500 error transformation when an ineligible entity iri passed

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
