### PR TITLE
[EasyApiPlatform] Limited the `api-platform/core` version to `3.1.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symplify/package-builder": "^11.0"
     },
     "require-dev": {
-        "api-platform/core": "^3.1",
+        "api-platform/core": "~3.1.0",
         "auth0/auth0-php": "^8.6",
         "bugsnag/bugsnag-laravel": "^2.26",
         "dg/bypass-finals": "^1.4",

--- a/packages/EasyApiPlatform/composer.json
+++ b/packages/EasyApiPlatform/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "api-platform/core": "^3.1",
+        "api-platform/core": "~3.1.0",
         "doctrine/dbal": "^3.0",
         "doctrine/orm": "^2.14",
         "doctrine/persistence": "^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
