### PR TITLE
[EasyPagination] Do not apply GetItemsCriteria to primaryKey QueryBuilder

### DIFF
--- a/packages/EasyPagination/src/Traits/DoctrineCommonPaginatorTrait.php
+++ b/packages/EasyPagination/src/Traits/DoctrineCommonPaginatorTrait.php
@@ -92,7 +92,6 @@ trait DoctrineCommonPaginatorTrait
         // Fetch PrimaryKey for current page, and all criteria
         $this->applyCommonCriteria($fetchPrimaryKeysQueryBuilder);
         $this->applyFilterCriteria($fetchPrimaryKeysQueryBuilder);
-        $this->applyGetItemsCriteria($fetchPrimaryKeysQueryBuilder);
         $this->applyPagination($fetchPrimaryKeysQueryBuilder);
 
         // Override select to fetch only primary key

--- a/packages/EasyPagination/src/Traits/EloquentPaginatorTrait.php
+++ b/packages/EasyPagination/src/Traits/EloquentPaginatorTrait.php
@@ -85,7 +85,6 @@ trait EloquentPaginatorTrait
         // Apply pagination and criteria to get primary keys only for current page, and criteria
         $this->applyCommonCriteria($primaryKeyQueryBuilder);
         $this->applyFilterCriteria($primaryKeyQueryBuilder);
-        $this->applyGetItemsCriteria($primaryKeyQueryBuilder);
         $this->applyPagination($primaryKeyQueryBuilder);
 
         $primaryKeyIndex = $this->getPrimaryKeyIndexWithDefault();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
