### PR TITLE
[EasySwoole] Fix PDOClientPool::make() when exception triggered

### DIFF
--- a/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
+++ b/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
@@ -32,7 +32,8 @@ final class PDOClientPool extends ClientPool
      */
     protected function heartbeat(): void
     {
-        $poolProperty = $this->getParentReflectionClass()->getProperty('pool');
+        $poolProperty = $this->getParentReflectionClass()
+            ->getProperty('pool');
 
         /** @var \OpenSwoole\Coroutine\Channel $pool */
         $pool = $poolProperty->getValue($this);
@@ -69,7 +70,9 @@ final class PDOClientPool extends ClientPool
      */
     protected function make(): void
     {
-        $numProperty = $this->getParentReflectionClass()->getProperty('num');
+        $numProperty = $this->getParentReflectionClass()
+            ->getProperty('num');
+
         $originalNumValue = $numProperty->getValue($this);
 
         try {

--- a/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
+++ b/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
@@ -12,6 +12,9 @@ use UnexpectedValueException;
 
 final class PDOClientPool extends ClientPool
 {
+    /**
+     * @var null|\ReflectionClass<\OpenSwoole\Core\Coroutine\Pool\ClientPool>
+     */
     private ?ReflectionClass $parentReflection = null;
 
     public function __construct(
@@ -84,6 +87,9 @@ final class PDOClientPool extends ClientPool
         }
     }
 
+    /**
+     * @return \ReflectionClass<\OpenSwoole\Core\Coroutine\Pool\ClientPool>
+     */
     private function getParentReflectionClass(): ReflectionClass
     {
         if ($this->parentReflection !== null) {

--- a/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
+++ b/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
@@ -13,7 +13,7 @@ use UnexpectedValueException;
 final class PDOClientPool extends ClientPool
 {
     /**
-     * @var null|\ReflectionClass<\OpenSwoole\Core\Coroutine\Pool\ClientPool>
+     * @var \ReflectionClass<\OpenSwoole\Core\Coroutine\Pool\ClientPool>|null
      */
     private ?ReflectionClass $parentReflection = null;
 
@@ -66,7 +66,7 @@ final class PDOClientPool extends ClientPool
 
     /**
      * @throws \ReflectionException
-     * @throws Throwable
+     * @throws \Throwable
      */
     protected function make(): void
     {

--- a/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
+++ b/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/PDOClientPool.php
@@ -26,30 +26,6 @@ final class PDOClientPool extends ClientPool
 
     /**
      * @throws \ReflectionException
-     * @throws Throwable
-     */
-    protected function make(): void
-    {
-        $numProperty = $this->getParentReflectionClass()->getProperty('num');
-        $originalNumValue = $numProperty->getValue($this);
-
-        try {
-            parent::make();
-        } catch (Throwable $throwable) {
-            $newNumValue = $numProperty->getValue($this);
-
-            // If num value was increased and not decreased again because of the exception
-            // then decrease it to keep the pool state correct, looks like a bug in openswoole
-            if ($newNumValue > 0 && $newNumValue > $originalNumValue) {
-                $numProperty->setValue($newNumValue - 1);
-            }
-
-            throw $throwable;
-        }
-    }
-
-    /**
-     * @throws \ReflectionException
      */
     protected function heartbeat(): void
     {
@@ -82,6 +58,30 @@ final class PDOClientPool extends ClientPool
                 $this->put($client);
             }
         });
+    }
+
+    /**
+     * @throws \ReflectionException
+     * @throws Throwable
+     */
+    protected function make(): void
+    {
+        $numProperty = $this->getParentReflectionClass()->getProperty('num');
+        $originalNumValue = $numProperty->getValue($this);
+
+        try {
+            parent::make();
+        } catch (Throwable $throwable) {
+            $newNumValue = $numProperty->getValue($this);
+
+            // If num value was increased and not decreased again because of the exception
+            // then decrease it to keep the pool state correct, looks like a bug in openswoole
+            if ($newNumValue > 0 && $newNumValue > $originalNumValue) {
+                $numProperty->setValue($newNumValue - 1);
+            }
+
+            throw $throwable;
+        }
     }
 
     private function getParentReflectionClass(): ReflectionClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
