### PR TITLE
[EasySwoole] Fix OptionHelper::getArray()

### DIFF
--- a/packages/EasySwoole/src/Helpers/OptionHelper.php
+++ b/packages/EasySwoole/src/Helpers/OptionHelper.php
@@ -52,7 +52,7 @@ final class OptionHelper
             return \explode(',', $value);
         }
 
-        return \array_filter(\is_array($value) ? $value : [$value], fn (mixed $value): bool => $value !== null);
+        return \array_filter(\is_array($value) ? $value : [$value], static fn (mixed $value): bool => $value !== null);
     }
 
     public static function getBoolean(string $option, ?string $env = null): bool

--- a/packages/EasySwoole/src/Helpers/OptionHelper.php
+++ b/packages/EasySwoole/src/Helpers/OptionHelper.php
@@ -52,7 +52,7 @@ final class OptionHelper
             return \explode(',', $value);
         }
 
-        return \array_filter(\is_array($value) ? $value : [$value]);
+        return \array_filter(\is_array($value) ? $value : [$value], fn (mixed $value): bool => $value !== null);
     }
 
     public static function getBoolean(string $option, ?string $env = null): bool

--- a/packages/EasySwoole/tests/Helpers/OptionHelperTest.php
+++ b/packages/EasySwoole/tests/Helpers/OptionHelperTest.php
@@ -10,6 +10,26 @@ use PHPUnit\Framework\Attributes\DataProvider;
 final class OptionHelperTest extends AbstractTestCase
 {
     /**
+     * @see testGetArray
+     */
+    public static function providerTestGetArray(): iterable
+    {
+        yield 'Empty values preserved' => [
+            [
+                'settings' => [
+                    'max_request' => 0,
+                    'empty_string' => '',
+                ],
+            ],
+            'settings',
+            [
+                'max_request' => 0,
+                'empty_string' => '',
+            ],
+        ];
+    }
+
+    /**
      * @see testGetBoolean
      */
     public static function providerTestGetBoolean(): iterable
@@ -115,6 +135,14 @@ final class OptionHelperTest extends AbstractTestCase
             'invalid',
             false,
         ];
+    }
+
+    #[DataProvider('providerTestGetArray')]
+    public function testGetArray(array $options, string $key, array $expected): void
+    {
+        OptionHelper::setOptions($options);
+
+        self::assertSame($expected, OptionHelper::getArray($key));
     }
 
     #[DataProvider('providerTestGetBoolean')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
