### PR TITLE
[Monorepo] Use AsMessageHandler attribute

### DIFF
--- a/packages/EasyActivity/src/Bridge/Symfony/Messenger/ActivityLogEntryMessageHandler.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Messenger/ActivityLogEntryMessageHandler.php
@@ -5,7 +5,6 @@ namespace EonX\EasyActivity\Bridge\Symfony\Messenger;
 
 use EonX\EasyActivity\Interfaces\StoreInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 #[AsMessageHandler]
 final class ActivityLogEntryMessageHandler

--- a/packages/EasyActivity/src/Bridge/Symfony/Messenger/ActivityLogEntryMessageHandler.php
+++ b/packages/EasyActivity/src/Bridge/Symfony/Messenger/ActivityLogEntryMessageHandler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 namespace EonX\EasyActivity\Bridge\Symfony\Messenger;
 
 use EonX\EasyActivity\Interfaces\StoreInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-final class ActivityLogEntryMessageHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class ActivityLogEntryMessageHandler
 {
     public function __construct(
         private StoreInterface $store,

--- a/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/ProcessBatchForBatchItemHandler.php
+++ b/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/ProcessBatchForBatchItemHandler.php
@@ -10,9 +10,11 @@ use EonX\EasyBatch\Interfaces\BatchObjectInterface;
 use EonX\EasyBatch\Interfaces\BatchObjectManagerInterface;
 use EonX\EasyBatch\Interfaces\BatchRepositoryInterface;
 use EonX\EasyBatch\Processors\BatchProcessor;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-final class ProcessBatchForBatchItemHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class ProcessBatchForBatchItemHandler
 {
     public function __construct(
         private readonly BatchItemRepositoryInterface $batchItemRepository,

--- a/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/ProcessBatchForBatchItemHandler.php
+++ b/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/ProcessBatchForBatchItemHandler.php
@@ -11,7 +11,6 @@ use EonX\EasyBatch\Interfaces\BatchObjectManagerInterface;
 use EonX\EasyBatch\Interfaces\BatchRepositoryInterface;
 use EonX\EasyBatch\Processors\BatchProcessor;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 #[AsMessageHandler]
 final class ProcessBatchForBatchItemHandler

--- a/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/UpdateBatchItemHandler.php
+++ b/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/UpdateBatchItemHandler.php
@@ -8,9 +8,11 @@ use DateTimeInterface;
 use EonX\EasyBatch\Interfaces\BatchItemInterface;
 use EonX\EasyBatch\Interfaces\BatchItemRepositoryInterface;
 use EonX\EasyBatch\Interfaces\BatchObjectInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-final class UpdateBatchItemHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class UpdateBatchItemHandler
 {
     public function __construct(
         private readonly BatchItemRepositoryInterface $batchItemRepository,

--- a/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/UpdateBatchItemHandler.php
+++ b/packages/EasyBatch/src/Bridge/Symfony/Messenger/Emergency/UpdateBatchItemHandler.php
@@ -9,7 +9,6 @@ use EonX\EasyBatch\Interfaces\BatchItemInterface;
 use EonX\EasyBatch\Interfaces\BatchItemRepositoryInterface;
 use EonX\EasyBatch\Interfaces\BatchObjectInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 #[AsMessageHandler]
 final class UpdateBatchItemHandler

--- a/packages/EasyWebhook/src/Bridge/Symfony/Messenger/SendWebhookHandler.php
+++ b/packages/EasyWebhook/src/Bridge/Symfony/Messenger/SendWebhookHandler.php
@@ -8,7 +8,6 @@ use EonX\EasyWebhook\Exceptions\CannotRerunWebhookException;
 use EonX\EasyWebhook\Interfaces\Stores\StoreInterface;
 use EonX\EasyWebhook\Interfaces\WebhookClientInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
 #[AsMessageHandler]
 final class SendWebhookHandler

--- a/packages/EasyWebhook/src/Bridge/Symfony/Messenger/SendWebhookHandler.php
+++ b/packages/EasyWebhook/src/Bridge/Symfony/Messenger/SendWebhookHandler.php
@@ -7,9 +7,11 @@ use EonX\EasyWebhook\Bridge\Symfony\Exceptions\UnrecoverableWebhookMessageExcept
 use EonX\EasyWebhook\Exceptions\CannotRerunWebhookException;
 use EonX\EasyWebhook\Interfaces\Stores\StoreInterface;
 use EonX\EasyWebhook\Interfaces\WebhookClientInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-final class SendWebhookHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendWebhookHandler
 {
     public function __construct(
         private readonly WebhookClientInterface $client,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Use AsMessageHandler attribute instead of implementing the deprecated MessageHandlerInterface