### PR TITLE
[Monorepo] Fix normalizers deprecations

### DIFF
--- a/packages/EasyUtils/src/Bridge/Symfony/Normalizers/IntegerNumberNormalizer.php
+++ b/packages/EasyUtils/src/Bridge/Symfony/Normalizers/IntegerNumberNormalizer.php
@@ -5,7 +5,6 @@ namespace EonX\EasyUtils\Bridge\Symfony\Normalizers;
 
 use EonX\EasyUtils\ValueObjects\Number;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 

--- a/packages/EasyUtils/src/Bridge/Symfony/Normalizers/IntegerNumberNormalizer.php
+++ b/packages/EasyUtils/src/Bridge/Symfony/Normalizers/IntegerNumberNormalizer.php
@@ -9,10 +9,7 @@ use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-final class IntegerNumberNormalizer implements
-    CacheableSupportsMethodInterface,
-    DenormalizerInterface,
-    NormalizerInterface
+final class IntegerNumberNormalizer implements DenormalizerInterface, NormalizerInterface
 {
     /**
      * @param string|null $data
@@ -26,9 +23,11 @@ final class IntegerNumberNormalizer implements
         return new Number($data);
     }
 
-    public function hasCacheableSupportsMethod(): bool
+    public function getSupportedTypes(?string $format = null): array
     {
-        return true;
+        return [
+            Number::class => true,
+        ];
     }
 
     /**

--- a/packages/EasyUtils/src/Bridge/Symfony/Normalizers/TrimStringsNormalizer.php
+++ b/packages/EasyUtils/src/Bridge/Symfony/Normalizers/TrimStringsNormalizer.php
@@ -43,10 +43,7 @@ final class TrimStringsNormalizer implements DenormalizerInterface
 
     public function getSupportedTypes(?string $format = null): array
     {
-        return [
-            'array' => true,
-            'string' => true,
-        ];
+        return [];
     }
 
     public function supportsDenormalization(

--- a/packages/EasyUtils/src/Bridge/Symfony/Normalizers/TrimStringsNormalizer.php
+++ b/packages/EasyUtils/src/Bridge/Symfony/Normalizers/TrimStringsNormalizer.php
@@ -28,14 +28,6 @@ final class TrimStringsNormalizer implements DenormalizerInterface
         $this->exceptKeys = $exceptKeys ?? [];
     }
 
-    public function getSupportedTypes(?string $format = null): array
-    {
-        return [
-            'array' => true,
-            'string' => true,
-        ];
-    }
-
     /**
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
@@ -47,6 +39,14 @@ final class TrimStringsNormalizer implements DenormalizerInterface
         $context[self::ALREADY_CALLED] = true;
 
         return $this->denormalizer->denormalize($data, $type, $format, $context);
+    }
+
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            'array' => true,
+            'string' => true,
+        ];
     }
 
     public function supportsDenormalization(

--- a/packages/EasyUtils/src/Bridge/Symfony/Normalizers/TrimStringsNormalizer.php
+++ b/packages/EasyUtils/src/Bridge/Symfony/Normalizers/TrimStringsNormalizer.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 namespace EonX\EasyUtils\Bridge\Symfony\Normalizers;
 
 use EonX\EasyUtils\StringTrimmers\StringTrimmerInterface;
-use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
-final class TrimStringsNormalizer implements ContextAwareDenormalizerInterface, DenormalizerAwareInterface
+final class TrimStringsNormalizer implements DenormalizerInterface
 {
     use DenormalizerAwareTrait;
 
@@ -27,6 +26,14 @@ final class TrimStringsNormalizer implements ContextAwareDenormalizerInterface, 
         ?array $exceptKeys = null,
     ) {
         $this->exceptKeys = $exceptKeys ?? [];
+    }
+
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            'array' => true,
+            'string' => true,
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Update TrimStringsNormalizer and IntegerNumberNormalizer to implement getSupportedTypes method