### PR TITLE
[EasyTest] Deprecate the "willThrowException" method of the "HttpClientStub" stub

### DIFF
--- a/packages/EasyTest/src/Stub/HttpClient/HttpClientStub.php
+++ b/packages/EasyTest/src/Stub/HttpClient/HttpClientStub.php
@@ -151,6 +151,9 @@ final class HttpClientStub extends MockHttpClient
         $this->defaultResponse = new MockResponse((string)\json_encode($body));
     }
 
+    /**
+     * @deprecated Since 5.7.2, will be removed in 6.0.0. Use addResponse() with proper HTTP status code instead.
+     */
     public function willThrowException(?Throwable $expectedException = null): self
     {
         $this->expectedException = $expectedException


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 

Implementation of the `willThrowException` method of the `HttpClientStub` stub is bad. By using the `willThrowException` method the stub throws an exception while we instantiate a response object. It's wrong because at this point there is no actual request is made. To emulate an exception we have to use the `forRequest` - `addResponse` methods call chain. For example:

```php
...
->forRequest(Request::METHOD_GET, 'http://example.test/users')
->addResponse([], ['http_code' => 500]);
```