### PR TITLE
[EasyErrorHandler] Updates the `ErrorLogLevelResolver` resolver

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/Bugsnag/Resolvers/DefaultBugsnagIgnoreExceptionsResolver.php
+++ b/packages/EasyErrorHandler/src/Bridge/Bugsnag/Resolvers/DefaultBugsnagIgnoreExceptionsResolver.php
@@ -5,6 +5,7 @@ namespace EonX\EasyErrorHandler\Bridge\Bugsnag\Resolvers;
 
 use EonX\EasyErrorHandler\Bridge\Bugsnag\Interfaces\BugsnagIgnoreExceptionsResolverInterface;
 use EonX\EasyErrorHandler\Bridge\Symfony\Builder\ApiPlatformValidationErrorResponseBuilder;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
@@ -24,7 +25,10 @@ final class DefaultBugsnagIgnoreExceptionsResolver implements BugsnagIgnoreExcep
         ?array $ignoredExceptions = null,
         ?bool $ignoreValidationErrors = null,
     ) {
-        $this->ignoredExceptions = $ignoredExceptions ?? [HttpExceptionInterface::class];
+        $this->ignoredExceptions = $ignoredExceptions ?? [
+            HttpExceptionInterface::class,
+            RequestExceptionInterface::class,
+        ];
         $this->ignoreValidationErrors = $ignoreValidationErrors ?? true;
     }
 

--- a/packages/EasyErrorHandler/src/ErrorLogLevelResolver.php
+++ b/packages/EasyErrorHandler/src/ErrorLogLevelResolver.php
@@ -6,6 +6,7 @@ namespace EonX\EasyErrorHandler;
 use EonX\EasyErrorHandler\Interfaces\ErrorLogLevelResolverInterface;
 use EonX\EasyErrorHandler\Interfaces\Exceptions\LogLevelAwareExceptionInterface;
 use Monolog\Logger;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
@@ -22,7 +23,10 @@ final class ErrorLogLevelResolver implements ErrorLogLevelResolverInterface
     public function __construct(
         ?array $exceptionLogLevels = null,
     ) {
-        $this->exceptionLogLevels = $exceptionLogLevels ?? [HttpExceptionInterface::class => Logger::DEBUG];
+        $this->exceptionLogLevels = $exceptionLogLevels ?? [
+            HttpExceptionInterface::class => Logger::DEBUG,
+            RequestExceptionInterface::class => Logger::DEBUG,
+        ];
     }
 
     public function getLogLevel(Throwable $throwable): int

--- a/packages/EasyErrorHandler/tests/ErrorLogLevelResolverTest.php
+++ b/packages/EasyErrorHandler/tests/ErrorLogLevelResolverTest.php
@@ -8,6 +8,7 @@ use EonX\EasyErrorHandler\Tests\Stubs\BaseExceptionStub;
 use InvalidArgumentException;
 use Monolog\Logger;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
@@ -26,6 +27,12 @@ final class ErrorLogLevelResolverTest extends AbstractTestCase
 
         yield 'Debug default Symfony HTTP exception' => [
             'throwable' => new NotFoundHttpException(),
+            'expectedLogLevel' => Logger::DEBUG,
+            'exceptionLogLevels' => null,
+        ];
+
+        yield 'Debug default Symfony request exception' => [
+            'throwable' => new SuspiciousOperationException(),
             'expectedLogLevel' => Logger::DEBUG,
             'exceptionLogLevels' => null,
         ];


### PR DESCRIPTION
Updates the `ErrorLogLevelResolver` resolver by adding the `RequestExceptionInterface` interface to the `exceptionLogLevels` list.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
