### PR TITLE
[EasyEncryption] Added the `sign` method to AwsPkcs11Encryptor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -199,6 +199,9 @@
             "php-http/discovery": true,
             "symfony/runtime": true
         },
+        "audit": {
+            "abandoned": "report"
+        },
         "platform": {
             "ext-openswoole": "22.0"
         },

--- a/packages/EasyEncryption/src/AwsPkcs11Encryptor.php
+++ b/packages/EasyEncryption/src/AwsPkcs11Encryptor.php
@@ -77,7 +77,7 @@ final class AwsPkcs11Encryptor extends AbstractEncryptor implements AwsPkcs11Enc
 
             return $this
                 ->findKey($keyAsString)
-                ->sign(new Mechanism(\Pkcs11\CKM_SHA512_HMAC), $text);
+                ->sign(new Mechanism(\Pkcs11\CKM_SHA512_HMAC, null), $text);
         });
     }
 

--- a/packages/EasyEncryption/src/Interfaces/AwsPkcs11EncryptorInterface.php
+++ b/packages/EasyEncryption/src/Interfaces/AwsPkcs11EncryptorInterface.php
@@ -6,4 +6,6 @@ namespace EonX\EasyEncryption\Interfaces;
 interface AwsPkcs11EncryptorInterface extends EncryptorInterface
 {
     public function reset(): void;
+
+    public function sign(string $text, ?string $keyName = null): string;
 }


### PR DESCRIPTION
[EasyEncryption] Added the `sign` method to the `AwsPkcs11Encryptor` encryptor.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
