### PR TITLE
[EasyLogging] Return parametrised loggerClass argument in the LoggerFactory

### DIFF
--- a/packages/EasyLogging/src/Bridge/BridgeConstantsInterface.php
+++ b/packages/EasyLogging/src/Bridge/BridgeConstantsInterface.php
@@ -13,6 +13,8 @@ interface BridgeConstantsInterface
 
     public const PARAM_LAZY_LOGGERS = 'easy_logging.lazy_loggers';
 
+    public const PARAM_LOGGER_CLASS = 'easy_logging.logger_class';
+
     public const PARAM_SENSITIVE_DATA_SANITIZER_ENABLED = 'easy_logging.sensitive_data_sanitizer_enabled';
 
     public const PARAM_STREAM_HANDLER = 'easy_logging.stream_handler';

--- a/packages/EasyLogging/src/Bridge/Symfony/EasyLoggingSymfonyBundle.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/EasyLoggingSymfonyBundle.php
@@ -11,6 +11,7 @@ use EonX\EasyLogging\Interfaces\Config\HandlerConfigProviderInterface;
 use EonX\EasyLogging\Interfaces\Config\LoggerConfiguratorInterface;
 use EonX\EasyLogging\Interfaces\Config\ProcessorConfigProviderInterface;
 use EonX\EasyLogging\Interfaces\LoggerFactoryInterface;
+use Monolog\Logger;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -57,6 +58,8 @@ final class EasyLoggingSymfonyBundle extends AbstractBundle
             BridgeConstantsInterface::PARAM_DEFAULT_CHANNEL,
             $config['default_channel'] ?? LoggerFactoryInterface::DEFAULT_CHANNEL
         );
+
+        $params->set(BridgeConstantsInterface::PARAM_LOGGER_CLASS, Logger::class);
 
         $params->set(BridgeConstantsInterface::PARAM_STREAM_HANDLER, $config['stream_handler']);
         $params->set(BridgeConstantsInterface::PARAM_STREAM_HANDLER_LEVEL, $config['stream_handler_level']);

--- a/packages/EasyLogging/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/Resources/config/services.php
@@ -17,6 +17,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services
         ->set(LoggerFactoryInterface::class, LoggerFactory::class)
         ->arg('$defaultChannel', '%' . BridgeConstantsInterface::PARAM_DEFAULT_CHANNEL . '%')
+        ->arg('$loggerClass', '%' . BridgeConstantsInterface::PARAM_LOGGER_CLASS . '%')
         ->arg('$lazyLoggers', '%' . BridgeConstantsInterface::PARAM_LAZY_LOGGERS . '%')
         ->call('setHandlerConfigProviders', [tagged_iterator(BridgeConstantsInterface::TAG_HANDLER_CONFIG_PROVIDER)])
         ->call('setLoggerConfigurators', [tagged_iterator(BridgeConstantsInterface::TAG_LOGGER_CONFIGURATOR)])
@@ -26,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         );
 
     $services
-        ->set('easy_logging.logger', Logger::class)
+        ->set('easy_logging.logger', '%' . BridgeConstantsInterface::PARAM_LOGGER_CLASS . '%')
         ->factory([service(LoggerFactoryInterface::class), 'create'])
         ->args(['%' . BridgeConstantsInterface::PARAM_DEFAULT_CHANNEL . '%']);
 };

--- a/packages/EasyLogging/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyLogging/src/Bridge/Symfony/Resources/config/services.php
@@ -6,7 +6,6 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use EonX\EasyLogging\Bridge\BridgeConstantsInterface;
 use EonX\EasyLogging\Interfaces\LoggerFactoryInterface;
 use EonX\EasyLogging\LoggerFactory;
-use Monolog\Logger;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

--- a/packages/EasyLogging/src/LoggerFactory.php
+++ b/packages/EasyLogging/src/LoggerFactory.php
@@ -36,6 +36,8 @@ final class LoggerFactory implements LazyLoggerFactoryInterface
      */
     private array $lazyLoggers = [];
 
+    private string $loggerClass;
+
     /**
      * @var \EonX\EasyLogging\Interfaces\Config\LoggerConfiguratorInterface[]
      */
@@ -51,9 +53,10 @@ final class LoggerFactory implements LazyLoggerFactoryInterface
      */
     private array $processorConfigs = [];
 
-    public function __construct(?string $defaultChannel = null, ?array $lazyLoggers = null)
+    public function __construct(?string $defaultChannel = null, ?string $loggerClass = null, ?array $lazyLoggers = null)
     {
         $this->defaultChannel = $defaultChannel ?? self::DEFAULT_CHANNEL;
+        $this->loggerClass = $loggerClass ?? Logger::class;
 
         foreach ($lazyLoggers ?? [] as $channel) {
             $this->lazyLoggers[(string)$channel] = true;
@@ -72,7 +75,9 @@ final class LoggerFactory implements LazyLoggerFactoryInterface
             return new LazyLoggerProxy($this, $channel);
         }
 
-        $logger = new Logger($channel, $this->getHandlers($channel), $this->getProcessors($channel));
+        $loggerClass = $this->loggerClass;
+        /** @var \Monolog\Logger $logger */
+        $logger = new $loggerClass($channel, $this->getHandlers($channel), $this->getProcessors($channel));
 
         /** @var \EonX\EasyLogging\Interfaces\Config\LoggerConfiguratorInterface $configurator */
         foreach ($this->getLoggerConfigurators($channel) as $configurator) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Using logger class parameter in the LoggerFactory make configuring LoggerStub much more easier