### PR TITLE
[EasyErrorHandler] Skip already reported exceptions

### DIFF
--- a/packages/EasyErrorHandler/src/Bridge/BridgeConstantsInterface.php
+++ b/packages/EasyErrorHandler/src/Bridge/BridgeConstantsInterface.php
@@ -31,6 +31,8 @@ interface BridgeConstantsInterface
 
     public const PARAM_RESPONSE_KEYS = 'easy_error_handler.param_response_keys';
 
+    public const PARAM_SKIP_REPORTED_EXCEPTIONS = 'easy_error_handler.param_skip_reported_exceptions';
+
     public const PARAM_TRANSFORM_VALIDATION_ERRORS = 'easy_error_handler.param_transform_validation_errors';
 
     public const PARAM_TRANSLATE_INTERNAL_ERROR_MESSAGES_ENABLED = 'easy_error_handler.translate_internal_error_messages_enabled';

--- a/packages/EasyErrorHandler/src/Bridge/Laravel/Provider/EasyErrorHandlerServiceProvider.php
+++ b/packages/EasyErrorHandler/src/Bridge/Laravel/Provider/EasyErrorHandlerServiceProvider.php
@@ -107,7 +107,8 @@ final class EasyErrorHandlerServiceProvider extends ServiceProvider
                 $app->tagged(BridgeConstantsInterface::TAG_ERROR_REPORTER_PROVIDER),
                 $app->make(VerboseStrategyInterface::class),
                 \config('easy-error-handler.ignored_exceptions'),
-                (bool)\config('easy-error-handler.report_retryable_exception_attempts', false)
+                (bool)\config('easy-error-handler.report_retryable_exception_attempts', false),
+                (bool)\config('easy-error-handler.skip_reported_exceptions', false)
             )
         );
 

--- a/packages/EasyErrorHandler/src/Bridge/Laravel/config/easy-error-handler.php
+++ b/packages/EasyErrorHandler/src/Bridge/Laravel/config/easy-error-handler.php
@@ -67,6 +67,11 @@ return [
      */
     'report_retryable_exception_attempts' => false,
 
+    /**
+     * Skip already reported exceptions.
+     */
+    'skip_reported_exceptions' => false,
+
     /*
     |--------------------------------------------------------------------------
     | Error response

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/EasyErrorHandlerSymfonyBundle.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/EasyErrorHandlerSymfonyBundle.php
@@ -75,6 +75,11 @@ final class EasyErrorHandlerSymfonyBundle extends AbstractBundle
             $config['report_retryable_exception_attempts'] ?? false
         );
 
+        $parameters->set(
+            BridgeConstantsInterface::PARAM_SKIP_REPORTED_EXCEPTIONS,
+            $config['skip_reported_exceptions'] ?? false
+        );
+
         $parameters->set(BridgeConstantsInterface::PARAM_IS_VERBOSE, $config['verbose']);
 
         $parameters->set(

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Resources/config/definition.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Resources/config/definition.php
@@ -35,6 +35,7 @@ return static function (DefinitionConfigurator $definition) {
                 ->scalarPrototype()->end()
             ->end()
             ->booleanNode('report_retryable_exception_attempts')->defaultFalse()->end()
+            ->booleanNode('skip_reported_exceptions')->defaultFalse()->end()
             ->booleanNode('verbose')->defaultFalse()->end()
             ->booleanNode('override_api_platform_listener')->defaultTrue()->end()
             ->booleanNode('use_default_builders')->defaultTrue()->end()

--- a/packages/EasyErrorHandler/src/Bridge/Symfony/Resources/config/services.php
+++ b/packages/EasyErrorHandler/src/Bridge/Symfony/Resources/config/services.php
@@ -58,7 +58,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->arg(
             '$reportRetryableExceptionAttempts',
             param(BridgeConstantsInterface::PARAM_REPORT_RETRYABLE_EXCEPTION_ATTEMPTS)
-        );
+        )
+        ->arg('$skipReportedExceptions', param(BridgeConstantsInterface::PARAM_SKIP_REPORTED_EXCEPTIONS));
 
     $services->set(ErrorHandlerDataCollector::class)
         ->tag('data_collector', [

--- a/packages/EasyErrorHandler/src/ErrorHandler.php
+++ b/packages/EasyErrorHandler/src/ErrorHandler.php
@@ -30,7 +30,7 @@ final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
     private array $builders;
 
     /**
-     * @var SplObjectStorage<Throwable, null>
+     * @var \SplObjectStorage<\Throwable, null>
      */
     private SplObjectStorage $handledExceptions;
 

--- a/packages/EasyErrorHandler/src/ErrorHandler.php
+++ b/packages/EasyErrorHandler/src/ErrorHandler.php
@@ -24,12 +24,15 @@ use Throwable;
 
 final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
 {
-    private SplObjectStorage $handledExceptions;
-
     /**
      * @var \EonX\EasyErrorHandler\Interfaces\ErrorResponseBuilderInterface[]
      */
     private array $builders;
+
+    /**
+     * @var SplObjectStorage<Throwable, null>
+     */
+    private SplObjectStorage $handledExceptions;
 
     /**
      * @var class-string[]

--- a/packages/EasyErrorHandler/src/ErrorHandler.php
+++ b/packages/EasyErrorHandler/src/ErrorHandler.php
@@ -15,6 +15,7 @@ use EonX\EasyErrorHandler\Interfaces\FormatAwareInterface;
 use EonX\EasyErrorHandler\Interfaces\VerboseStrategyInterface;
 use EonX\EasyErrorHandler\Response\Data\ErrorResponseData;
 use EonX\EasyUtils\Helpers\CollectorHelper;
+use SplObjectStorage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
@@ -23,6 +24,8 @@ use Throwable;
 
 final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
 {
+    private SplObjectStorage $handledExceptions;
+
     /**
      * @var \EonX\EasyErrorHandler\Interfaces\ErrorResponseBuilderInterface[]
      */
@@ -40,6 +43,8 @@ final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
      */
     private array $reporters;
 
+    private bool $skipReportedExceptions;
+
     /**
      * @param class-string[]|null $ignoredExceptionsForReport
      */
@@ -50,11 +55,14 @@ final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
         private readonly VerboseStrategyInterface $verboseStrategy,
         ?array $ignoredExceptionsForReport = null,
         ?bool $reportRetryableExceptionAttempts = null,
+        ?bool $skipReportedExceptions = null,
     ) {
         $this->setBuilders($builderProviders);
         $this->setReporters($reporterProviders);
         $this->ignoredExceptionsForReport = $ignoredExceptionsForReport ?? [];
         $this->reportRetryableExceptionAttempts = $reportRetryableExceptionAttempts ?? false;
+        $this->skipReportedExceptions = $skipReportedExceptions ?? false;
+        $this->handledExceptions = new SplObjectStorage();
     }
 
     /**
@@ -96,6 +104,10 @@ final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
 
     public function report(Throwable $throwable): void
     {
+        if ($this->skipReportedExceptions && $this->handledExceptions->contains($throwable)) {
+            return;
+        }
+
         if ($throwable instanceof RetryableException) {
             if ($throwable->willRetry() && $this->reportRetryableExceptionAttempts === false) {
                 return;
@@ -137,6 +149,8 @@ final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
         foreach ($this->reporters as $reporter) {
             $reporter->report($throwable);
         }
+
+        $this->handledExceptions->attach($throwable);
     }
 
     public function supportsFormat(Request $request): bool

--- a/packages/EasyErrorHandler/tests/ErrorHandlerTest.php
+++ b/packages/EasyErrorHandler/tests/ErrorHandlerTest.php
@@ -76,6 +76,15 @@ final class ErrorHandlerTest extends AbstractTestCase
         ];
     }
 
+    /**
+     * @see testRepeatedExceptionReport
+     */
+    public static function providerTestRepeatedExceptionReport(): iterable
+    {
+        yield 'Skip reported exceptions' => [true, 1];
+        yield 'Report all exceptions' => [false, 2];
+    }
+
     #[DataProvider('providerTestReport')]
     public function testReport(
         Throwable $throwable,
@@ -96,5 +105,26 @@ final class ErrorHandlerTest extends AbstractTestCase
         $errorHandler->report($throwable);
 
         $assertions($reporter);
+    }
+
+    #[DataProvider('providerTestRepeatedExceptionReport')]
+    public function testRepeatedExceptionReport(bool $skipReportedExceptions, int $expectedReportedErrorsCount): void
+    {
+        $throwable = new Exception('message');
+        $reporter = new ErrorReporterStub();
+        $reporterProviders = [new FromIterableErrorReporterProvider([$reporter])];
+        $verboseStrategy = new ChainVerboseStrategy([], false);
+        $errorHandler = new ErrorHandler(
+            new ErrorResponseFactory(),
+            [],
+            $reporterProviders,
+            $verboseStrategy,
+            skipReportedExceptions: $skipReportedExceptions,
+        );
+
+        $errorHandler->report($throwable);
+        $errorHandler->report($throwable);
+
+        self::assertCount($expectedReportedErrorsCount, $reporter->getReportedErrors());
     }
 }

--- a/packages/EasyErrorHandler/tests/ErrorHandlerTest.php
+++ b/packages/EasyErrorHandler/tests/ErrorHandlerTest.php
@@ -19,6 +19,15 @@ use Throwable;
 final class ErrorHandlerTest extends AbstractTestCase
 {
     /**
+     * @see testRepeatedExceptionReport
+     */
+    public static function providerTestRepeatedExceptionReport(): iterable
+    {
+        yield 'Skip reported exceptions' => [true, 1];
+        yield 'Report all exceptions' => [false, 2];
+    }
+
+    /**
      * @see testReport
      */
     public static function providerTestReport(): iterable
@@ -76,13 +85,25 @@ final class ErrorHandlerTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * @see testRepeatedExceptionReport
-     */
-    public static function providerTestRepeatedExceptionReport(): iterable
+    #[DataProvider('providerTestRepeatedExceptionReport')]
+    public function testRepeatedExceptionReport(bool $skipReportedExceptions, int $expectedReportedErrorsCount): void
     {
-        yield 'Skip reported exceptions' => [true, 1];
-        yield 'Report all exceptions' => [false, 2];
+        $throwable = new Exception('message');
+        $reporter = new ErrorReporterStub();
+        $reporterProviders = [new FromIterableErrorReporterProvider([$reporter])];
+        $verboseStrategy = new ChainVerboseStrategy([], false);
+        $errorHandler = new ErrorHandler(
+            new ErrorResponseFactory(),
+            [],
+            $reporterProviders,
+            $verboseStrategy,
+            skipReportedExceptions: $skipReportedExceptions,
+        );
+
+        $errorHandler->report($throwable);
+        $errorHandler->report($throwable);
+
+        self::assertCount($expectedReportedErrorsCount, $reporter->getReportedErrors());
     }
 
     #[DataProvider('providerTestReport')]
@@ -105,26 +126,5 @@ final class ErrorHandlerTest extends AbstractTestCase
         $errorHandler->report($throwable);
 
         $assertions($reporter);
-    }
-
-    #[DataProvider('providerTestRepeatedExceptionReport')]
-    public function testRepeatedExceptionReport(bool $skipReportedExceptions, int $expectedReportedErrorsCount): void
-    {
-        $throwable = new Exception('message');
-        $reporter = new ErrorReporterStub();
-        $reporterProviders = [new FromIterableErrorReporterProvider([$reporter])];
-        $verboseStrategy = new ChainVerboseStrategy([], false);
-        $errorHandler = new ErrorHandler(
-            new ErrorResponseFactory(),
-            [],
-            $reporterProviders,
-            $verboseStrategy,
-            skipReportedExceptions: $skipReportedExceptions,
-        );
-
-        $errorHandler->report($throwable);
-        $errorHandler->report($throwable);
-
-        self::assertCount($expectedReportedErrorsCount, $reporter->getReportedErrors());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Sometimes the exception may be reported twice. This PR is a solution for this case.