### PR TITLE
[Monorepo] Fail security check if package abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -196,9 +196,6 @@
             "php-http/discovery": true,
             "symfony/runtime": true
         },
-        "audit": {
-            "abandoned": "report"
-        },
         "platform": {
             "ext-openswoole": "22.0"
         },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

It is better to have red CI than abandoned deps.
