### PR TITLE
[EasySwoole] fixed mapping types initialization

### DIFF
--- a/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/CoroutineConnectionFactory.php
+++ b/packages/EasySwoole/src/Bridge/Doctrine/Coroutine/PDO/CoroutineConnectionFactory.php
@@ -57,11 +57,20 @@ final class CoroutineConnectionFactory extends ConnectionFactory
 
         $connectionClass = $connection::class;
 
-        return new $connectionClass(
+        $coroutineConnection = new $connectionClass(
             $connection->getParams(),
             $driver,
             $connection->getConfiguration(),
             $connection->getEventManager()
         );
+
+        if (\count($mappingTypes ?? []) > 0) {
+            $platform = $coroutineConnection->getDatabasePlatform();
+            foreach ($mappingTypes as $dbType => $doctrineType) {
+                $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
+            }
+        }
+
+        return $coroutineConnection;
     }
 }


### PR DESCRIPTION
This fixes excessive DB migrations creation when using swoole coroutines and our custom `\EonX\EasyDoctrine\DBAL\Types\JsonbType` for some entities columns.

When coroutines are enabled, mapped types are not injected into the connection.

![image](https://github.com/eonx-com/easy-monorepo/assets/13471770/0538d45a-4c10-4d7a-a597-9e47bb47d1a3)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | <!-- #-prefixed issue number(s), if any -->
