### PR TITLE
[EasyEncryption] Fix an issue in the `AwsCloudHsmSdkConfigurator` service

### DIFF
--- a/packages/EasyEncryption/src/Configurator/AwsCloudHsmSdkConfigurator.php
+++ b/packages/EasyEncryption/src/Configurator/AwsCloudHsmSdkConfigurator.php
@@ -65,13 +65,20 @@ final class AwsCloudHsmSdkConfigurator
     private function configureAwsCloudHsmSdkUsingAwsSdk(array $options): void
     {
         $cluster = [
-            'client_cert_path' => $options['--server-client-cert-file'],
-            'client_key_path' => $options['--server-client-key-file'],
             'hsm_ca_file' => $options['--hsm-ca-cert'],
             'options' => [
                 'disable_key_availability_check' => $options['--disable-key-availability-check'],
             ],
         ];
+
+        if (
+            \array_key_exists('--server-client-cert-file', $options) &&
+            \array_key_exists('--server-client-key-file', $options)
+        ) {
+            $cluster['client_cert_path'] = $options['--server-client-cert-file'];
+            $cluster['client_key_path'] = $options['--server-client-key-file'];
+        }
+
         $servers = [];
 
         if (\array_key_exists('-a', $options)) {

--- a/packages/EasyEncryption/src/Configurator/AwsCloudHsmSdkConfigurator.php
+++ b/packages/EasyEncryption/src/Configurator/AwsCloudHsmSdkConfigurator.php
@@ -71,17 +71,14 @@ final class AwsCloudHsmSdkConfigurator
             ],
         ];
 
-        if (
-            \array_key_exists('--server-client-cert-file', $options) &&
-            \array_key_exists('--server-client-key-file', $options)
-        ) {
+        if (isset($options['--server-client-cert-file']) && isset($options['--server-client-key-file'])) {
             $cluster['client_cert_path'] = $options['--server-client-cert-file'];
             $cluster['client_key_path'] = $options['--server-client-key-file'];
         }
 
         $servers = [];
 
-        if (\array_key_exists('-a', $options)) {
+        if (isset($options['-a'])) {
             $hsmIpAddresses = \explode(' ', (string)$options['-a']);
 
             foreach ($hsmIpAddresses as $hsmIpAddress) {
@@ -93,7 +90,7 @@ final class AwsCloudHsmSdkConfigurator
             }
         }
 
-        if (\array_key_exists('--cluster-id', $options)) {
+        if (isset($options['--cluster-id'])) {
             $awsCredentials = null;
             if ($this->awsRoleArn !== null) {
                 $stsClient = new StsClient([


### PR DESCRIPTION
[EasyEncryption] Make the `--server-client-cert-file` and the `--server-client-key-file` options optional in the `AwsCloudHsmSdkConfigurator` service.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
