### PR TITLE
[EasyErrorHandler] Use enums as exception's `code`, `subCode` and `statusCode`

### DIFF
--- a/packages/EasyErrorHandler/src/ApiPlatform/Builder/ApiPlatformValidationErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/ApiPlatform/Builder/ApiPlatformValidationErrorResponseBuilder.php
@@ -8,7 +8,7 @@ use ApiPlatform\State\Provider\DeserializeProvider;
 use ApiPlatform\Symfony\EventListener\DeserializeListener;
 use EonX\EasyErrorHandler\Common\Builder\AbstractErrorResponseBuilder;
 use EonX\EasyErrorHandler\Common\Translator\TranslatorInterface;
-use Symfony\Component\HttpFoundation\Response;
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
@@ -219,13 +219,13 @@ final class ApiPlatformValidationErrorResponseBuilder extends AbstractErrorRespo
         return parent::buildData($throwable, $data);
     }
 
-    public function buildStatusCode(Throwable $throwable, ?int $statusCode = null): ?int
+    public function buildStatusCode(Throwable $throwable, ?HttpStatusCode $statusCode = null): ?HttpStatusCode
     {
         if (self::supports($throwable) === false) {
             return parent::buildStatusCode($throwable, $statusCode);
         }
 
-        return Response::HTTP_BAD_REQUEST;
+        return HttpStatusCode::BadRequest;
     }
 
     private function getKey(string $name): string

--- a/packages/EasyErrorHandler/src/ApiPlatform/Builder/ApiPlatformValidationExceptionErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/ApiPlatform/Builder/ApiPlatformValidationExceptionErrorResponseBuilder.php
@@ -6,7 +6,7 @@ namespace EonX\EasyErrorHandler\ApiPlatform\Builder;
 use ApiPlatform\Symfony\Validator\Exception\ValidationException;
 use EonX\EasyErrorHandler\Common\Builder\AbstractErrorResponseBuilder;
 use EonX\EasyErrorHandler\Common\Translator\TranslatorInterface;
-use Symfony\Component\HttpFoundation\Response;
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use Throwable;
 
 final class ApiPlatformValidationExceptionErrorResponseBuilder extends AbstractErrorResponseBuilder
@@ -69,10 +69,10 @@ final class ApiPlatformValidationExceptionErrorResponseBuilder extends AbstractE
         return parent::buildData($throwable, $data);
     }
 
-    public function buildStatusCode(Throwable $throwable, ?int $statusCode = null): ?int
+    public function buildStatusCode(Throwable $throwable, ?HttpStatusCode $statusCode = null): ?HttpStatusCode
     {
         if ($throwable instanceof ValidationException) {
-            $statusCode = Response::HTTP_BAD_REQUEST;
+            $statusCode = HttpStatusCode::BadRequest;
         }
 
         return parent::buildStatusCode($throwable, $statusCode);

--- a/packages/EasyErrorHandler/src/Common/Builder/AbstractErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Common/Builder/AbstractErrorResponseBuilder.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Builder;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use EonX\EasyUtils\Common\Helper\HasPriorityTrait;
 use Throwable;
 
@@ -25,7 +26,7 @@ abstract class AbstractErrorResponseBuilder implements ErrorResponseBuilderInter
         return $headers;
     }
 
-    public function buildStatusCode(Throwable $throwable, ?int $statusCode = null): ?int
+    public function buildStatusCode(Throwable $throwable, ?HttpStatusCode $statusCode = null): ?HttpStatusCode
     {
         return $statusCode;
     }

--- a/packages/EasyErrorHandler/src/Common/Builder/ErrorResponseBuilderInterface.php
+++ b/packages/EasyErrorHandler/src/Common/Builder/ErrorResponseBuilderInterface.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Builder;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use EonX\EasyUtils\Common\Helper\HasPriorityInterface;
 use Throwable;
 
@@ -12,5 +13,5 @@ interface ErrorResponseBuilderInterface extends HasPriorityInterface
 
     public function buildHeaders(Throwable $throwable, ?array $headers = null): ?array;
 
-    public function buildStatusCode(Throwable $throwable, ?int $statusCode = null): ?int;
+    public function buildStatusCode(Throwable $throwable, ?HttpStatusCode $statusCode = null): ?HttpStatusCode;
 }

--- a/packages/EasyErrorHandler/src/Common/Builder/HttpExceptionErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Common/Builder/HttpExceptionErrorResponseBuilder.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Builder;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
@@ -31,10 +32,10 @@ final class HttpExceptionErrorResponseBuilder extends AbstractErrorResponseBuild
         return parent::buildData($throwable, $data);
     }
 
-    public function buildStatusCode(Throwable $throwable, ?int $statusCode = null): ?int
+    public function buildStatusCode(Throwable $throwable, ?HttpStatusCode $statusCode = null): ?HttpStatusCode
     {
         if ($throwable instanceof HttpExceptionInterface) {
-            $statusCode = $throwable->getStatusCode();
+            $statusCode = HttpStatusCode::from($throwable->getStatusCode());
         }
 
         return parent::buildStatusCode($throwable, $statusCode);

--- a/packages/EasyErrorHandler/src/Common/Builder/StatusCodeErrorResponseBuilder.php
+++ b/packages/EasyErrorHandler/src/Common/Builder/StatusCodeErrorResponseBuilder.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 namespace EonX\EasyErrorHandler\Common\Builder;
 
 use EonX\EasyErrorHandler\Common\Exception\StatusCodeAwareExceptionInterface;
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use Throwable;
 
 final class StatusCodeErrorResponseBuilder extends AbstractErrorResponseBuilder
 {
     /**
-     * @var array<class-string, int>
+     * @var array<class-string, \EonX\EasyUtils\Common\Enum\HttpStatusCode>
      */
     private readonly array $exceptionToStatusCode;
 
     /**
-     * @param array<class-string, int>|null $exceptionToStatusCode
+     * @param array<class-string, \EonX\EasyUtils\Common\Enum\HttpStatusCode>|null $exceptionToStatusCode
      */
     public function __construct(
         ?array $exceptionToStatusCode = null,
@@ -25,7 +26,7 @@ final class StatusCodeErrorResponseBuilder extends AbstractErrorResponseBuilder
         parent::__construct($priority);
     }
 
-    public function buildStatusCode(Throwable $throwable, ?int $statusCode = null): ?int
+    public function buildStatusCode(Throwable $throwable, ?HttpStatusCode $statusCode = null): ?HttpStatusCode
     {
         if ($throwable instanceof StatusCodeAwareExceptionInterface) {
             $statusCode = $throwable->getStatusCode();

--- a/packages/EasyErrorHandler/src/Common/Exception/BadRequestException.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/BadRequestException.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 abstract class BadRequestException extends BaseException
 {
-    protected int $statusCode = 400;
+    protected HttpStatusCode $statusCode = HttpStatusCode::BadRequest;
 
     protected string $userMessage = self::USER_MESSAGE_BAD_REQUEST;
 }

--- a/packages/EasyErrorHandler/src/Common/Exception/BaseException.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/BaseException.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use BackedEnum;
 use Exception;
+use InvalidArgumentException;
+use Throwable;
 
 abstract class BaseException extends Exception implements
     TranslatableExceptionInterface,
@@ -15,4 +18,27 @@ abstract class BaseException extends Exception implements
     use StatusCodeAwareExceptionTrait;
     use SubCodeAwareExceptionTrait;
     use TranslatableExceptionTrait;
+
+    public function __construct(?string $message = null, null|int|BackedEnum $code = null, ?Throwable $previous = null)
+    {
+        $codeValue = null;
+
+        if ($code !== null) {
+            if ($code instanceof BackedEnum && \is_int($code->value) === false) {
+                throw new InvalidArgumentException(
+                    \sprintf('The backed case of the "%s" backed enum has to be an integer.', $code::class)
+                );
+            }
+
+            if ($code instanceof BackedEnum && \is_int($code->value)) {
+                $codeValue = $code->value;
+            }
+
+            if (\is_int($code)) {
+                $codeValue = $code;
+            }
+        }
+
+        parent::__construct($message ?? '', $codeValue ?? 0, $previous);
+    }
 }

--- a/packages/EasyErrorHandler/src/Common/Exception/ConflictException.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/ConflictException.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 abstract class ConflictException extends BaseException
 {
-    protected int $statusCode = 409;
+    protected HttpStatusCode $statusCode = HttpStatusCode::Conflict;
 
     protected string $userMessage = self::USER_MESSAGE_CONFLICT;
 }

--- a/packages/EasyErrorHandler/src/Common/Exception/ForbiddenException.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/ForbiddenException.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 abstract class ForbiddenException extends BaseException
 {
-    protected int $statusCode = 403;
+    protected HttpStatusCode $statusCode = HttpStatusCode::Forbidden;
 
     protected string $userMessage = self::USER_MESSAGE_FORBIDDEN;
 }

--- a/packages/EasyErrorHandler/src/Common/Exception/NotFoundException.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/NotFoundException.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 abstract class NotFoundException extends BaseException
 {
-    protected int $statusCode = 404;
+    protected HttpStatusCode $statusCode = HttpStatusCode::NotFound;
 
     protected string $userMessage = self::USER_MESSAGE_NOT_FOUND;
 }

--- a/packages/EasyErrorHandler/src/Common/Exception/StatusCodeAwareExceptionInterface.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/StatusCodeAwareExceptionInterface.php
@@ -3,10 +3,12 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 interface StatusCodeAwareExceptionInterface
 {
     /**
      * Returns the HTTP response status code of an exception.
      */
-    public function getStatusCode(): int;
+    public function getStatusCode(): HttpStatusCode;
 }

--- a/packages/EasyErrorHandler/src/Common/Exception/StatusCodeAwareExceptionTrait.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/StatusCodeAwareExceptionTrait.php
@@ -19,7 +19,7 @@ trait StatusCodeAwareExceptionTrait
      */
     public function setStatusCode(int|HttpStatusCode $statusCode): self
     {
-        $this->statusCode = $statusCode instanceof HttpStatusCode ? $statusCode : HttpStatusCode::from($statusCode);
+        $this->statusCode = \is_int($statusCode) ? HttpStatusCode::from($statusCode) : $statusCode;
 
         return $this;
     }

--- a/packages/EasyErrorHandler/src/Common/Exception/StatusCodeAwareExceptionTrait.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/StatusCodeAwareExceptionTrait.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 trait StatusCodeAwareExceptionTrait
 {
-    protected int $statusCode = 500;
+    protected HttpStatusCode $statusCode = HttpStatusCode::InternalServerError;
 
-    public function getStatusCode(): int
+    public function getStatusCode(): HttpStatusCode
     {
         return $this->statusCode;
     }
@@ -15,9 +17,9 @@ trait StatusCodeAwareExceptionTrait
     /**
      * Sets the HTTP response status code for an exception.
      */
-    public function setStatusCode(int $statusCode): self
+    public function setStatusCode(int|HttpStatusCode $statusCode): self
     {
-        $this->statusCode = $statusCode;
+        $this->statusCode = $statusCode instanceof HttpStatusCode ? $statusCode : HttpStatusCode::from($statusCode);
 
         return $this;
     }

--- a/packages/EasyErrorHandler/src/Common/Exception/SubCodeAwareExceptionTrait.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/SubCodeAwareExceptionTrait.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use BackedEnum;
+use InvalidArgumentException;
+
 trait SubCodeAwareExceptionTrait
 {
     protected int $subCode = 0;
@@ -15,9 +18,23 @@ trait SubCodeAwareExceptionTrait
     /**
      * Sets the sub code for an exception.
      */
-    public function setSubCode(int $subCode): self
+    public function setSubCode(int|BackedEnum $subCode): self
     {
-        $this->subCode = $subCode;
+        if ($subCode instanceof BackedEnum && \is_int($subCode->value) === false) {
+            throw new InvalidArgumentException(
+                \sprintf('The backed case of the "%s" backed enum has to be an integer.', $subCode::class)
+            );
+        }
+
+        if ($subCode instanceof BackedEnum && \is_int($subCode->value)) {
+            $this->subCode = $subCode->value;
+
+            return $this;
+        }
+
+        if (\is_int($subCode)) {
+            $this->subCode = $subCode;
+        }
 
         return $this;
     }

--- a/packages/EasyErrorHandler/src/Common/Exception/UnauthorizedException.php
+++ b/packages/EasyErrorHandler/src/Common/Exception/UnauthorizedException.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\Exception;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 abstract class UnauthorizedException extends BaseException
 {
-    protected int $statusCode = 401;
+    protected HttpStatusCode $statusCode = HttpStatusCode::Unauthorized;
 
     protected string $userMessage = self::USER_MESSAGE_UNAUTHORIZED;
 }

--- a/packages/EasyErrorHandler/src/Common/Factory/ErrorResponseFactory.php
+++ b/packages/EasyErrorHandler/src/Common/Factory/ErrorResponseFactory.php
@@ -15,7 +15,7 @@ final class ErrorResponseFactory implements ErrorResponseFactoryInterface, Forma
 
     public function create(Request $request, ErrorResponseDataInterface $data): Response
     {
-        return new JsonResponse($data->getRawData(), $data->getStatusCode(), $data->getHeaders());
+        return new JsonResponse($data->getRawData(), $data->getStatusCode()->value, $data->getHeaders());
     }
 
     public function supportsFormat(Request $request): bool

--- a/packages/EasyErrorHandler/src/Common/Factory/SymfonySerializerErrorResponseFactory.php
+++ b/packages/EasyErrorHandler/src/Common/Factory/SymfonySerializerErrorResponseFactory.php
@@ -29,7 +29,8 @@ final class SymfonySerializerErrorResponseFactory implements ErrorResponseFactor
         $headers['X-Content-Type-Options'] = 'nosniff';
         $headers['X-Frame-Options'] = 'deny';
 
-        $statusCode = $data->getStatusCode();
+        $statusCode = $data->getStatusCode()
+            ->value;
 
         $content = $this->serializer->serialize(
             $data->getRawData(),

--- a/packages/EasyErrorHandler/src/Common/Resolver/ErrorDetailsResolver.php
+++ b/packages/EasyErrorHandler/src/Common/Resolver/ErrorDetailsResolver.php
@@ -99,7 +99,7 @@ final class ErrorDetailsResolver implements ErrorDetailsResolverInterface
         }
 
         if ($throwable instanceof StatusCodeAwareExceptionInterface) {
-            $details['status_code'] = $throwable->getStatusCode();
+            $details['status_code'] = $throwable->getStatusCode()->value;
         }
 
         if ($throwable instanceof TranslatableExceptionInterface) {

--- a/packages/EasyErrorHandler/src/Common/ValueObject/ErrorResponseData.php
+++ b/packages/EasyErrorHandler/src/Common/ValueObject/ErrorResponseData.php
@@ -3,24 +3,24 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\ValueObject;
 
-use Symfony\Component\HttpFoundation\Response;
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 
 final class ErrorResponseData implements ErrorResponseDataInterface
 {
     private readonly array $headers;
 
-    private readonly int $statusCode;
+    private readonly HttpStatusCode $statusCode;
 
     public function __construct(
         private readonly array $rawData,
-        ?int $statusCode = null,
+        ?HttpStatusCode $statusCode = null,
         ?array $headers = null,
     ) {
-        $this->statusCode = $statusCode ?? Response::HTTP_INTERNAL_SERVER_ERROR;
+        $this->statusCode = $statusCode ?? HttpStatusCode::InternalServerError;
         $this->headers = $headers ?? [];
     }
 
-    public static function create(array $rawData, ?int $statusCode = null, ?array $headers = null): self
+    public static function create(array $rawData, ?HttpStatusCode $statusCode = null, ?array $headers = null): self
     {
         return new self($rawData, $statusCode, $headers);
     }
@@ -35,7 +35,7 @@ final class ErrorResponseData implements ErrorResponseDataInterface
         return $this->rawData;
     }
 
-    public function getStatusCode(): int
+    public function getStatusCode(): HttpStatusCode
     {
         return $this->statusCode;
     }

--- a/packages/EasyErrorHandler/src/Common/ValueObject/ErrorResponseDataInterface.php
+++ b/packages/EasyErrorHandler/src/Common/ValueObject/ErrorResponseDataInterface.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Common\ValueObject;
 
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
+
 interface ErrorResponseDataInterface
 {
     public function getHeaders(): array;
 
     public function getRawData(): array;
 
-    public function getStatusCode(): int;
+    public function getStatusCode(): HttpStatusCode;
 }

--- a/packages/EasyErrorHandler/tests/Fixture/app/src/Enum/ErrorCode.php
+++ b/packages/EasyErrorHandler/tests/Fixture/app/src/Enum/ErrorCode.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyErrorHandler\Tests\Fixture\App\Enum;
+
+use EonX\EasyErrorHandler\ErrorCodes\Attribute\AsErrorCodes;
+
+#[AsErrorCodes]
+enum ErrorCode: int
+{
+    case Code1 = 1;
+}

--- a/packages/EasyErrorHandler/tests/Unit/src/Common/Builder/TestRenderWithDefaultBuildersDataProvider.php
+++ b/packages/EasyErrorHandler/tests/Unit/src/Common/Builder/TestRenderWithDefaultBuildersDataProvider.php
@@ -5,6 +5,7 @@ namespace EonX\EasyErrorHandler\Tests\Unit\Common\Builder;
 
 use EonX\EasyErrorHandler\Tests\Stub\Exception\BaseExceptionStub;
 use EonX\EasyErrorHandler\Tests\Stub\Exception\ValidationExceptionStub;
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use Exception;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
@@ -48,9 +49,9 @@ final class TestRenderWithDefaultBuildersDataProvider
 
         yield 'Response with status code of code aware exception interface' => [
             'request' => new Request(),
-            'exception' => (new BaseExceptionStub())->setStatusCode(123),
+            'exception' => (new BaseExceptionStub())->setStatusCode(HttpStatusCode::IamTeapot),
             'assertResponse' => static function (Response $response): void {
-                TestCase::assertSame(123, $response->getStatusCode());
+                TestCase::assertSame(418, $response->getStatusCode());
             },
             'translations' => null,
         ];

--- a/packages/EasyErrorHandler/tests/Unit/src/Common/Exception/BaseExceptionTest.php
+++ b/packages/EasyErrorHandler/tests/Unit/src/Common/Exception/BaseExceptionTest.php
@@ -60,6 +60,22 @@ final class BaseExceptionTest extends AbstractUnitTestCase
     }
 
     /**
+     * @see testSetStatusCode
+     */
+    public static function provideStatusCodes(): iterable
+    {
+        yield 'integer' => [
+            'statusCode' => 418,
+            'expectedStatusCode' => HttpStatusCode::IamTeapot,
+        ];
+
+        yield 'enum' => [
+            'statusCode' => HttpStatusCode::IamTeapot,
+            'expectedStatusCode' => HttpStatusCode::IamTeapot,
+        ];
+    }
+
+    /**
      * @see testSetSubCode
      */
     public static function provideSubCodes(): iterable
@@ -188,15 +204,15 @@ final class BaseExceptionTest extends AbstractUnitTestCase
         self::assertSame($messageParams, self::getPrivatePropertyValue($result, 'messageParams'));
     }
 
-    public function testSetStatusCode(): void
+    #[DataProvider('provideStatusCodes')]
+    public function testSetStatusCode(int|HttpStatusCode $statusCode, HttpStatusCode $expectedStatusCode): void
     {
-        $statusCode = HttpStatusCode::IamTeapot;
         $exception = new BaseExceptionStub();
 
         $result = $exception->setStatusCode($statusCode);
 
         self::assertSame($exception, $result);
-        self::assertSame($statusCode, self::getPrivatePropertyValue($result, 'statusCode'));
+        self::assertSame($expectedStatusCode, self::getPrivatePropertyValue($result, 'statusCode'));
     }
 
     #[DataProvider('provideSubCodes')]

--- a/packages/EasyErrorHandler/tests/Unit/src/Common/Exception/BaseExceptionTest.php
+++ b/packages/EasyErrorHandler/tests/Unit/src/Common/Exception/BaseExceptionTest.php
@@ -3,13 +3,31 @@ declare(strict_types=1);
 
 namespace EonX\EasyErrorHandler\Tests\Unit\Common\Exception;
 
+use EonX\EasyErrorHandler\Tests\Fixture\App\Enum\ErrorCode;
 use EonX\EasyErrorHandler\Tests\Stub\Exception\BaseExceptionStub;
 use EonX\EasyErrorHandler\Tests\Unit\AbstractUnitTestCase;
+use EonX\EasyUtils\Common\Enum\HttpStatusCode;
 use Monolog\Logger;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 final class BaseExceptionTest extends AbstractUnitTestCase
 {
+    /**
+     * @see testSetCode
+     */
+    public static function provideCodes(): iterable
+    {
+        yield 'integer' => [
+            'code' => 1,
+            'expectedCode' => 1,
+        ];
+
+        yield 'enum' => [
+            'code' => ErrorCode::Code1,
+            'expectedCode' => 1,
+        ];
+    }
+
     /**
      * @see testLogLevelConvenientMethods
      */
@@ -41,6 +59,22 @@ final class BaseExceptionTest extends AbstractUnitTestCase
         ];
     }
 
+    /**
+     * @see testSetSubCode
+     */
+    public static function provideSubCodes(): iterable
+    {
+        yield 'integer' => [
+            'subCode' => 1,
+            'expectedSubCode' => 1,
+        ];
+
+        yield 'enum' => [
+            'subCode' => ErrorCode::Code1,
+            'expectedSubCode' => 1,
+        ];
+    }
+
     public function testGetLogLevel(): void
     {
         $logLevel = Logger::CRITICAL;
@@ -67,7 +101,7 @@ final class BaseExceptionTest extends AbstractUnitTestCase
 
     public function testGetStatusCode(): void
     {
-        $statusCode = 123;
+        $statusCode = HttpStatusCode::IamTeapot;
         $exception = new BaseExceptionStub();
         self::setPrivatePropertyValue($exception, 'statusCode', $statusCode);
 
@@ -122,6 +156,14 @@ final class BaseExceptionTest extends AbstractUnitTestCase
         self::assertSame($expectedLogLevel, self::getPrivatePropertyValue($result, 'logLevel'));
     }
 
+    #[DataProvider('provideCodes')]
+    public function testSetCode(int|ErrorCode $code, int $expectedCode): void
+    {
+        $result = new BaseExceptionStub(code: $code);
+
+        self::assertSame($expectedCode, self::getPrivatePropertyValue($result, 'code'));
+    }
+
     public function testSetLogLevel(): void
     {
         $logLevel = Logger::CRITICAL;
@@ -148,7 +190,7 @@ final class BaseExceptionTest extends AbstractUnitTestCase
 
     public function testSetStatusCode(): void
     {
-        $statusCode = 123;
+        $statusCode = HttpStatusCode::IamTeapot;
         $exception = new BaseExceptionStub();
 
         $result = $exception->setStatusCode($statusCode);
@@ -157,15 +199,15 @@ final class BaseExceptionTest extends AbstractUnitTestCase
         self::assertSame($statusCode, self::getPrivatePropertyValue($result, 'statusCode'));
     }
 
-    public function testSetSubCode(): void
+    #[DataProvider('provideSubCodes')]
+    public function testSetSubCode(int|ErrorCode $subCode, int $expectedSubCode): void
     {
-        $subCode = 123;
         $exception = new BaseExceptionStub();
 
         $result = $exception->setSubCode($subCode);
 
         self::assertSame($exception, $result);
-        self::assertSame($subCode, self::getPrivatePropertyValue($result, 'subCode'));
+        self::assertSame($expectedSubCode, self::getPrivatePropertyValue($result, 'subCode'));
     }
 
     public function testSetUserMessage(): void

--- a/packages/EasyUtils/src/Common/Enum/HttpStatusCode.php
+++ b/packages/EasyUtils/src/Common/Enum/HttpStatusCode.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyUtils\Common\Enum;
+
+enum HttpStatusCode: int
+{
+    case Accepted = 202;
+
+    case AlreadyReported = 208;
+
+    case BadGateway = 502;
+
+    case BadRequest = 400;
+
+    case Conflict = 409;
+
+    case Continue = 100;
+
+    case Created = 201;
+
+    case EarlyHints = 103;
+
+    case ExpectationFailed = 417;
+
+    case FailedDependency = 424;
+
+    case Forbidden = 403;
+
+    case Found = 302;
+
+    case GatewayTimeout = 504;
+
+    case Gone = 410;
+
+    case IamTeapot = 418;
+
+    case ImUsed = 226;
+
+    case InsufficientStorage = 507;
+
+    case InternalServerError = 500;
+
+    case LengthRequired = 411;
+
+    case Locked = 423;
+
+    case LoopDetected = 508;
+
+    case MethodNotAllowed = 405;
+
+    case MisdirectedRequest = 421;
+
+    case MovedPermanently = 301;
+
+    case MultiStatus = 207;
+
+    case MultipleChoices = 300;
+
+    case NetworkAuthenticationRequired = 511;
+
+    case NoContent = 204;
+
+    case NonAuthoritativeInformation = 203;
+
+    case NotAcceptable = 406;
+
+    case NotExtended = 510;
+
+    case NotFound = 404;
+
+    case NotImplemented = 501;
+
+    case NotModified = 304;
+
+    case Ok = 200;
+
+    case PartialContent = 206;
+
+    case PaymentRequired = 402;
+
+    case PermanentlyRedirect = 308;
+
+    case PreconditionFailed = 412;
+
+    case PreconditionRequired = 428;
+
+    case Processing = 102;
+
+    case ProxyAuthenticationRequired = 407;
+
+    case RequestEntityTooLarge = 413;
+
+    case RequestHeaderFieldsTooLarge = 431;
+
+    case RequestTimeout = 408;
+
+    case RequestUriTooLong = 414;
+
+    case RequestedRangeNotSatisfiable = 416;
+
+    case Reserved = 306;
+
+    case ResetContent = 205;
+
+    case SeeOther = 303;
+
+    case ServiceUnavailable = 503;
+
+    case SwitchingProtocols = 101;
+
+    case TemporaryRedirect = 307;
+
+    case TooEarly = 425;
+
+    case TooManyRequests = 429;
+
+    case Unauthorized = 401;
+
+    case UnavailableForLegalReasons = 451;
+
+    case UnprocessableEntity = 422;
+
+    case UnsupportedMediaType = 415;
+
+    case UpgradeRequired = 426;
+
+    case UseProxy = 305;
+
+    case VariantAlsoNegotiatesExperimental = 506;
+
+    case VersionNotSupported = 505;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://eonx.atlassian.net/browse/MTCE-251
