### PR TITLE
[EasyTest] Make HttpClientStub::forRequest(queryParams) work correctly with an array type of value

### DIFF
--- a/packages/EasyTest/src/Stub/HttpClient/HttpClientStub.php
+++ b/packages/EasyTest/src/Stub/HttpClient/HttpClientStub.php
@@ -64,7 +64,7 @@ final class HttpClientStub extends MockHttpClient
         }
 
         if ($queryParams !== null) {
-            $url = \sprintf('%s?%s', $url, \http_build_query($queryParams));
+            $url = \sprintf('%s?%s', $url, \urldecode(\http_build_query($queryParams)));
         }
 
         return new HttpClientRequestStub(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 