### PR TITLE
[EasyTest] Fix MessengerAssertionsTrait::consumeAsyncMessages() annotation

### DIFF
--- a/packages/EasyTest/src/Common/Trait/MessengerAssertionsTrait.php
+++ b/packages/EasyTest/src/Common/Trait/MessengerAssertionsTrait.php
@@ -116,7 +116,7 @@ trait MessengerAssertionsTrait
 
     /**
      * @param array<int, class-string<\Throwable>|array<class-string<\Throwable>, int|string>> $expectedExceptions
-     * @param array<int> $expectedDelays Expected delays in seconds between worker runs
+     * @param array<int|float> $expectedDelays Expected delays in seconds between worker runs
      */
     public static function consumeAsyncMessages(array $expectedExceptions = [], array $expectedDelays = []): void
     {


### PR DESCRIPTION
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
