### PR TITLE
[EasyTest] Fix an infinite loop in StrictTestResponse

### DIFF
--- a/packages/EasyTest/composer.json
+++ b/packages/EasyTest/composer.json
@@ -12,6 +12,7 @@
         "symfony/console": "^7.0",
         "symfony/contracts": "^3.5",
         "symfony/dependency-injection": "^7.0",
+        "symfony/http-client": "^7.0",
         "symfony/http-kernel": "^7.0"
     },
     "autoload": {

--- a/packages/EasyTest/src/HttpClient/Response/StrictTestResponse.php
+++ b/packages/EasyTest/src/HttpClient/Response/StrictTestResponse.php
@@ -115,6 +115,6 @@ final class StrictTestResponse extends AbstractTestResponse
             }
         }
 
-        $this->sortArray($array);
+        unset($value);
     }
 }

--- a/packages/EasyTest/src/HttpClient/Response/StrictTestResponse.php
+++ b/packages/EasyTest/src/HttpClient/Response/StrictTestResponse.php
@@ -116,6 +116,6 @@ final class StrictTestResponse extends AbstractTestResponse
         }
         unset($value);
 
-        array_is_list($array) ? sort($array) : ksort($array);
+        \array_is_list($array) ? \sort($array) : \ksort($array);
     }
 }

--- a/packages/EasyTest/src/HttpClient/Response/StrictTestResponse.php
+++ b/packages/EasyTest/src/HttpClient/Response/StrictTestResponse.php
@@ -114,7 +114,8 @@ final class StrictTestResponse extends AbstractTestResponse
                 $this->sortArray($value);
             }
         }
-
         unset($value);
+
+        array_is_list($array) ? sort($array) : ksort($array);
     }
 }

--- a/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
+++ b/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
@@ -5,7 +5,6 @@ namespace EonX\EasyTest\Tests\Unit\HttpClient\Response;
 
 use EonX\EasyTest\HttpClient\Response\StrictTestResponse;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class StrictTestResponseTest extends TestCase
 {
@@ -29,7 +28,7 @@ final class StrictTestResponseTest extends TestCase
             responseCode: 200,
         );
 
-       $mockResponse =  $sut(
+        $mockResponse = $sut(
             method: 'GET',
             url: 'https://example.com',
             options: [
@@ -39,9 +38,9 @@ final class StrictTestResponseTest extends TestCase
                     ],
                     'x-request-id' => [
                         'X-Request-Id: 123',
-                    ]
+                    ],
                 ],
-                'body' => json_encode([
+                'body' => \json_encode([
                     'bar' => 'baz',
                     'foo' => 'bar',
                     'tags' => ['foo', 'bar'],
@@ -49,7 +48,6 @@ final class StrictTestResponseTest extends TestCase
             ]
         );
 
-        self::assertInstanceOf(MockResponse::class, $mockResponse);
         self::assertSame(200, $mockResponse->getInfo()['http_code']);
     }
 }

--- a/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
+++ b/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
@@ -5,6 +5,7 @@ namespace EonX\EasyTest\Tests\Unit\HttpClient\Response;
 
 use EonX\EasyTest\HttpClient\Response\StrictTestResponse;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class StrictTestResponseTest extends TestCase
 {
@@ -48,6 +49,7 @@ final class StrictTestResponseTest extends TestCase
             ]
         );
 
+        self::assertInstanceOf(MockResponse::class, $mockResponse);
         self::assertSame(200, $mockResponse->getInfo()['http_code']);
     }
 }

--- a/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
+++ b/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyTest\Tests\Unit\HttpClient\Response;
+
+use EonX\EasyTest\HttpClient\Response\StrictTestResponse;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class StrictTestResponseTest extends TestCase
+{
+    public function testItSucceedsWithUnsortedRequestData(): void
+    {
+        $sut = new StrictTestResponse(
+            method: 'GET',
+            url: 'https://example.com',
+            json: [
+                'foo' => 'bar',
+                'bar' => 'baz',
+                'tags' => ['foo', 'bar'],
+            ],
+            headers: [
+                'X-Request-Id' => '123',
+                'Content-Type' => 'application/json',
+            ],
+            responseData: [
+                'some' => 'data',
+            ],
+            responseCode: 200,
+        );
+
+       $mockResponse =  $sut(
+            method: 'GET',
+            url: 'https://example.com',
+            options: [
+                'normalized_headers' => [
+                    'content-type' => [
+                        'Content-Type: application/json',
+                    ],
+                    'x-request-id' => [
+                        'X-Request-Id: 123',
+                    ]
+                ],
+                'body' => json_encode([
+                    'bar' => 'baz',
+                    'foo' => 'bar',
+                    'tags' => ['foo', 'bar'],
+                ]),
+            ]
+        );
+
+        self::assertInstanceOf(MockResponse::class, $mockResponse);
+        self::assertSame(200, $mockResponse->getInfo()['http_code']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | 
