### PR TITLE
[EasyErrorHandler] Type mismatch in EasyErrorHandler config and BugsnagErrorReporterProvider

### DIFF
--- a/packages/EasyErrorHandler/src/Bugsnag/Provider/BugsnagErrorReporterProvider.php
+++ b/packages/EasyErrorHandler/src/Bugsnag/Provider/BugsnagErrorReporterProvider.php
@@ -18,7 +18,7 @@ final readonly class BugsnagErrorReporterProvider implements ErrorReporterProvid
         private Client $bugsnag,
         private readonly iterable $exceptionIgnorers,
         private ErrorLogLevelResolverInterface $errorLogLevelResolver,
-        private ?int $threshold = null,
+        private ?Level $threshold = null,
     ) {
     }
 
@@ -31,7 +31,7 @@ final readonly class BugsnagErrorReporterProvider implements ErrorReporterProvid
             $this->bugsnag,
             $this->exceptionIgnorers,
             $this->errorLogLevelResolver,
-            $this->threshold ? Level::from($this->threshold) : null
+            $this->threshold
         );
     }
 }

--- a/packages/EasyErrorHandler/tests/Fixture/app/config/bundles.php
+++ b/packages/EasyErrorHandler/tests/Fixture/app/config/bundles.php
@@ -1,10 +1,14 @@
 <?php
 declare(strict_types=1);
 
+use EonX\EasyBugsnag\Bundle\EasyBugsnagBundle;
 use EonX\EasyErrorHandler\Bundle\EasyErrorHandlerBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 
 return [
+    EasyBugsnagBundle::class => [
+        'with_easy_bugsnag' => true,
+    ],
     EasyErrorHandlerBundle::class => [
         'all' => true,
     ],

--- a/packages/EasyErrorHandler/tests/Fixture/app/config/packages/with_easy_bugsnag/easy_bugsnag.php
+++ b/packages/EasyErrorHandler/tests/Fixture/app/config/packages/with_easy_bugsnag/easy_bugsnag.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Config\EasyBugsnagConfig;
+
+return static function (EasyBugsnagConfig $easyBugsnagConfig): void {
+    $easyBugsnagConfig->apiKey('some-key');
+
+    $easyBugsnagConfig->sensitiveDataSanitizer()
+        ->enabled(false);
+};

--- a/packages/EasyErrorHandler/tests/Fixture/app/config/packages/with_easy_bugsnag/easy_error_handler.php
+++ b/packages/EasyErrorHandler/tests/Fixture/app/config/packages/with_easy_bugsnag/easy_error_handler.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Monolog\Level;
+use Symfony\Config\EasyErrorHandlerConfig;
+
+return static function (EasyErrorHandlerConfig $easyErrorHandlerConfig): void {
+    $easyErrorHandlerConfig->bugsnag()
+        ->enabled(true)
+        ->threshold(Level::Debug);
+};

--- a/packages/EasyErrorHandler/tests/Unit/bundle/EasyErrorHandlerBundleTest.php
+++ b/packages/EasyErrorHandler/tests/Unit/bundle/EasyErrorHandlerBundleTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyErrorHandler\Tests\Unit\Bundle;
+
+use EonX\EasyErrorHandler\Bugsnag\Provider\BugsnagErrorReporterProvider;
+use EonX\EasyErrorHandler\Tests\Unit\AbstractUnitTestCase;
+
+final class EasyErrorHandlerBundleTest extends AbstractUnitTestCase
+{
+    public function testItSucceedsWithEasyBugsnag(): void
+    {
+        self::bootKernel(['environment' => 'with_easy_bugsnag']);
+
+        self::getService(BugsnagErrorReporterProvider::class);
+
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://eonx.atlassian.net/browse/MTCE-321
