### PR TITLE
[EasyApiPlatform] Fix serializer context builder interface usage

### DIFF
--- a/packages/EasyApiPlatform/src/Common/SerializerContextBuilder/SerializerContextBuilder.php
+++ b/packages/EasyApiPlatform/src/Common/SerializerContextBuilder/SerializerContextBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace EonX\EasyApiPlatform\Common\SerializerContextBuilder;
 
 use ApiPlatform\Metadata\GetCollection;
-use ApiPlatform\State\SerializerContextBuilderInterface;
+use ApiPlatform\Serializer\SerializerContextBuilderInterface;
 use EonX\EasyApiPlatform\Common\Paginator\CustomPaginatorInterface;
 use Symfony\Component\HttpFoundation\Request;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Fix `lint:container` error:

```
  Invalid alias definition: alias "ApiPlatform\Serializer\SerializerContextBu  
  ilderInterface" is referencing class "EonX\EasyApiPlatform\Common\Serialize  
  rContextBuilder\SerializerContextBuilder" but this class does not implement  
   "ApiPlatform\Serializer\SerializerContextBuilderInterface". Because this a  
  lias is an interface, "EonX\EasyApiPlatform\Common\SerializerContextBuilder  
  \SerializerContextBuilder" must implement "ApiPlatform\Serializer\Serialize  
  rContextBuilderInterface".   
```

https://github.com/api-platform/core/issues/6411
https://github.com/api-platform/core/pull/6412/files
