### PR TITLE
[EasyTest] Fix AbstactTestResponse data normalization

### DIFF
--- a/packages/EasyTest/src/HttpClient/Response/AbstractTestResponse.php
+++ b/packages/EasyTest/src/HttpClient/Response/AbstractTestResponse.php
@@ -44,7 +44,7 @@ abstract class AbstractTestResponse
     {
         foreach ($array as &$value) {
             if (\is_array($value)) {
-                self::normalizeData($value);
+                $value = self::normalizeData($value);
             }
 
             if (\is_string($value) === false) {

--- a/packages/EasyTest/src/HttpClient/Response/AbstractTestResponse.php
+++ b/packages/EasyTest/src/HttpClient/Response/AbstractTestResponse.php
@@ -44,10 +44,10 @@ abstract class AbstractTestResponse
     {
         foreach ($array as &$value) {
             if (\is_array($value)) {
-                $value = self::normalizeData($value);
+                self::normalizeData($value);
             }
 
-            if (\is_string($value) === false) {
+            if (\is_array($value) === false) {
                 if ($value instanceof BackedEnum) {
                     $value = $value->value;
 

--- a/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
+++ b/packages/EasyTest/tests/Unit/src/HttpClient/Response/StrictTestResponseTest.php
@@ -62,6 +62,9 @@ final class StrictTestResponseTest extends TestCase
             json: [
                 'enum' => $enum,
                 'uuid' => $uuid,
+                'some-data' => [
+                    'some-data' => 'some-value',
+                ],
             ],
         );
 
@@ -73,6 +76,9 @@ final class StrictTestResponseTest extends TestCase
                 'body' => \json_encode([
                     'enum' => $enum,
                     'uuid' => $uuid,
+                    'some-data' => [
+                        'some-data' => 'some-value',
+                    ],
                 ]),
             ]
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

To fix warnings in tests, array to string converstion.

