### PR TITLE
[EasyDoctrine] Do not decorate WithEventsEntityManager when default EM not exists

### DIFF
--- a/packages/EasyDoctrine/bundle/config/deferred_dispatcher.php
+++ b/packages/EasyDoctrine/bundle/config/deferred_dispatcher.php
@@ -11,6 +11,7 @@ use EonX\EasyDoctrine\EntityEvent\Dispatcher\DeferredEntityEventDispatcher;
 use EonX\EasyDoctrine\EntityEvent\Dispatcher\DeferredEntityEventDispatcherInterface;
 use EonX\EasyDoctrine\EntityEvent\EntityManager\WithEventsEntityManager;
 use EonX\EasyDoctrine\EntityEvent\Listener\EntityEventListener;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -38,7 +39,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(WithEventsEntityManager::class)
         ->arg('$decorated', service('.inner'))
-        ->decorate('doctrine.orm.default_entity_manager');
+        ->decorate(
+            'doctrine.orm.default_entity_manager',
+            invalidBehavior: ContainerInterface::IGNORE_ON_INVALID_REFERENCE
+        );
 
     $services
         ->set(EntityEventListener::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
