### PR TITLE
[EasyTest] arrangeResponse with ignoreOrder PoC

### DIFF
--- a/packages/EasyTest/src/HttpClient/Factory/TestResponseFactory.php
+++ b/packages/EasyTest/src/HttpClient/Factory/TestResponseFactory.php
@@ -8,6 +8,7 @@ use EonX\EasyTest\HttpClient\Response\AbstractTestResponse;
 use Iterator;
 use RuntimeException;
 use Throwable;
+use UnexpectedValueException;
 
 /**
  * @implements \Iterator<int, \EonX\EasyTest\HttpClient\Response\AbstractTestResponse>
@@ -21,9 +22,19 @@ final class TestResponseFactory implements Iterator
      */
     private static array $responses = [];
 
-    public static function addResponse(AbstractTestResponse $request): void
+    /**
+     * @var array<\EonX\EasyTest\HttpClient\Response\AbstractTestResponse>
+     */
+    private static array $responsesWithIgnoreOrder = [];
+
+    public static function addResponse(AbstractTestResponse $response): void
     {
-        self::$responses[] = $request;
+        if ($response->isIgnoreOrder()) {
+            self::$responsesWithIgnoreOrder[] = $response;
+
+            return;
+        }
+        self::$responses[] = $response;
     }
 
     public static function areAllResponsesUsed(): bool
@@ -32,7 +43,7 @@ final class TestResponseFactory implements Iterator
             throw self::getException();
         }
 
-        return \count(self::$responses) === 0;
+        return \count(self::$responses) === 0 && \count(self::$responsesWithIgnoreOrder) === 0;
     }
 
     public static function getException(): ?Throwable
@@ -63,7 +74,7 @@ final class TestResponseFactory implements Iterator
             throw self::getException();
         }
 
-        if (\count(self::$responses) === 0) {
+        if (\count(self::$responses) === 0 && \count(self::$responsesWithIgnoreOrder) === 0) {
             return static function (string $method, string $url, ?array $options = null): void {
                 TestResponseFactory::throwException(new RuntimeException(\sprintf(
                     'You should add a response to the TestResponseFactory for the request: %s %s',
@@ -73,7 +84,23 @@ final class TestResponseFactory implements Iterator
             };
         }
 
-        return \array_shift(self::$responses);
+        $responsesWithIgnoreOrder = self::$responsesWithIgnoreOrder;
+
+        $factory = $this;
+
+        return static function ($method, $url, $options) use ($factory, $responsesWithIgnoreOrder) {
+            foreach ($responsesWithIgnoreOrder as $response) {
+                if ($response->isUrlMatched($url)) {
+                    $factory->unsetResponse($response);
+
+                    return $response($method, $url, $options);
+                }
+            }
+
+            $response = $factory->shiftResponse();
+
+            return $response($method, $url, $options);
+        };
     }
 
     public function key(): int
@@ -88,6 +115,21 @@ final class TestResponseFactory implements Iterator
     public function rewind(): void
     {
         throw new RuntimeException('Method is not supported');
+    }
+
+    public function shiftResponse(): AbstractTestResponse
+    {
+        if (\count(self::$responses) === 0) {
+            throw new UnexpectedValueException('Responses array is empty');
+        }
+
+        return \array_shift(self::$responses);
+    }
+
+    public function unsetResponse(AbstractTestResponse $response): void
+    {
+        $index = (int)\array_search($response, self::$responsesWithIgnoreOrder, true);
+        unset(self::$responsesWithIgnoreOrder[$index]);
     }
 
     public function valid(): bool

--- a/packages/EasyTest/src/HttpClient/Response/AbstractTestResponse.php
+++ b/packages/EasyTest/src/HttpClient/Response/AbstractTestResponse.php
@@ -25,6 +25,7 @@ abstract class AbstractTestResponse
         protected readonly array|string|TransportException|null $responseData = null,
         protected ?array $responseHeaders = null,
         protected ?int $responseCode = null,
+        protected ?bool $ignoreOrder = null,
     ) {
         $this->query ??= [];
         $this->responseHeaders ??= [];
@@ -38,6 +39,31 @@ abstract class AbstractTestResponse
         $this->checkParameters($method, $url, $options);
 
         return $this->createResponse($method, $url, $options);
+    }
+
+    public function isIgnoreOrder(): bool
+    {
+        return $this->ignoreOrder === true;
+    }
+
+    public function isUrlMatched(string $url): bool
+    {
+        $actualUrl = (array)\parse_url($url);
+        $expectedUrl = (array)\parse_url($this->url);
+
+        \parse_str($actualUrl['query'] ?? '', $actualQuery);
+        \parse_str($expectedUrl['query'] ?? '', $expectedQuery);
+
+        $actualUrl['query'] = $actualQuery;
+
+        $expectedQuery = [
+            ...$expectedQuery,
+            ...($this->query ?? []),
+        ];
+
+        $expectedUrl['query'] = $expectedQuery;
+
+        return $actualUrl === $expectedUrl;
     }
 
     protected static function normalizeData(array &$array): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Usage:

```
      self::arrangeHttpResponse(
          url: some-url,
          ....
          ignoreOrder: true
      );
```
        
        