### PR TITLE
[EasyTest] Fix http client stub debug output

### DIFF
--- a/packages/EasyTest/src/PHPUnit/Subscriber/HttpClientTestFailedSubscriber.php
+++ b/packages/EasyTest/src/PHPUnit/Subscriber/HttpClientTestFailedSubscriber.php
@@ -19,8 +19,8 @@ final class HttpClientTestFailedSubscriber implements FailedSubscriber
         ) {
             echo \PHP_EOL;
             echo Color::colorize('fg-red', 'HTTP client reported the following exception:');
-
-            throw TestResponseFactory::getException();
+            echo \PHP_EOL;
+            echo TestResponseFactory::getException()->getMessage();
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

It was found out that PHPUnit catches all exceptions thrown in subscribers.
