### PR TITLE
[EasyErrorHandler] Rollback error-handler UnrecoverableMessageInterface check

### DIFF
--- a/packages/EasyErrorHandler/src/Common/ErrorHandler/ErrorHandler.php
+++ b/packages/EasyErrorHandler/src/Common/ErrorHandler/ErrorHandler.php
@@ -15,7 +15,7 @@ use EonX\EasyUtils\Common\Helper\CollectorHelper;
 use SplObjectStorage;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Exception\WrappedExceptionsInterface;
 use Throwable;
 
@@ -124,7 +124,11 @@ final class ErrorHandler implements ErrorHandlerInterface, FormatAwareInterface
             return;
         }
 
-        if ($throwable instanceof UnrecoverableExceptionInterface) {
+        // We especially want to check UnrecoverableMessageHandlingException, not UnrecoverableExceptionInterface
+        if (\class_exists(UnrecoverableMessageHandlingException::class)
+            && $throwable instanceof UnrecoverableMessageHandlingException
+            && $throwable->getPrevious() instanceof Throwable
+        ) {
             $throwable = $throwable->getPrevious();
         }
 

--- a/packages/EasyErrorHandler/tests/Stub/Client/BugsnagClientStub.php
+++ b/packages/EasyErrorHandler/tests/Stub/Client/BugsnagClientStub.php
@@ -20,7 +20,7 @@ final class BugsnagClientStub extends Client
         return $this->calls;
     }
 
-    public function notifyException(mixed $throwable, ?callable $callback = null): void
+    public function notifyException(mixed $throwable, $callback = null): void
     {
         $this->calls[] = [$throwable, $callback];
     }

--- a/packages/EasyErrorHandler/tests/Unit/src/Common/ErrorHandler/ErrorHandlerTest.php
+++ b/packages/EasyErrorHandler/tests/Unit/src/Common/ErrorHandler/ErrorHandlerTest.php
@@ -99,7 +99,7 @@ final class ErrorHandlerTest extends AbstractUnitTestCase
             'throwable' => new UnrecoverableWebhookMessageException(previous: new Exception()),
             'assertions' => static function (ErrorReporterStub $reporter): void {
                 self::assertCount(1, $reporter->getReportedErrors());
-                self::assertSame(Exception::class, $reporter->getReportedErrors()[0]::class);
+                self::assertSame(UnrecoverableWebhookMessageException::class, $reporter->getReportedErrors()[0]::class);
             },
         ];
     }

--- a/quality/phpstan.neon
+++ b/quality/phpstan.neon
@@ -76,9 +76,6 @@ parameters:
         - message: '#Dead catch \- ReflectionException is never thrown in the try block#'
           path: %currentWorkingDirectory%/packages/EasyErrorHandler/src/ErrorCodes/Provider/ErrorCodesFromInterfaceProvider.php
 
-        - message: '#Parameter \#2 \$callback \(\(callable\)\|null\) of method EonX\\EasyErrorHandler\\Tests\\Stub\\Client\\BugsnagClientStub\:\:notifyException\(\) is not contravariant with parameter \#2 \$callback \(mixed\) of method Bugsnag\\Client\:\:notifyException\(\)#'
-          path: %currentWorkingDirectory%/packages/EasyErrorHandler/tests/Stub/Client/BugsnagClientStub.php
-
         # ---- EasyEventDispatcher ----
         # ---- EasyHttpClient ----
         # ---- EasyLock ----

--- a/quality/phpstan.neon
+++ b/quality/phpstan.neon
@@ -76,6 +76,9 @@ parameters:
         - message: '#Dead catch \- ReflectionException is never thrown in the try block#'
           path: %currentWorkingDirectory%/packages/EasyErrorHandler/src/ErrorCodes/Provider/ErrorCodesFromInterfaceProvider.php
 
+        - message: '#Parameter \#2 \$callback \(\(callable\)\|null\) of method EonX\\EasyErrorHandler\\Tests\\Stub\\Client\\BugsnagClientStub\:\:notifyException\(\) is not contravariant with parameter \#2 \$callback \(mixed\) of method Bugsnag\\Client\:\:notifyException\(\)#'
+          path: %currentWorkingDirectory%/packages/EasyErrorHandler/tests/Stub/Client/BugsnagClientStub.php
+
         # ---- EasyEventDispatcher ----
         # ---- EasyHttpClient ----
         # ---- EasyLock ----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Rollback changes from monorepo 5.x