### PR TITLE
[EasyUtils] Change type for carbon immutable denormalization.

### DIFF
--- a/packages/EasyUtils/src/Common/Normalizer/CarbonImmutableNormalizer.php
+++ b/packages/EasyUtils/src/Common/Normalizer/CarbonImmutableNormalizer.php
@@ -33,7 +33,9 @@ final readonly class CarbonImmutableNormalizer implements NormalizerInterface, D
         ?string $format = null,
         ?array $context = null,
     ): CarbonImmutable {
-        return new CarbonImmutable($this->dateTimeNormalizer->denormalize($data, $type, $format, $context ?? []));
+        return new CarbonImmutable(
+            $this->dateTimeNormalizer->denormalize($data, DateTimeInterface::class, $format, $context ?? [])
+        );
     }
 
     public function getSupportedTypes(?string $format): array

--- a/packages/EasyUtils/src/Common/Normalizer/CarbonImmutableNormalizer.php
+++ b/packages/EasyUtils/src/Common/Normalizer/CarbonImmutableNormalizer.php
@@ -34,7 +34,7 @@ final readonly class CarbonImmutableNormalizer implements NormalizerInterface, D
         ?array $context = null,
     ): CarbonImmutable {
         return new CarbonImmutable(
-            $this->dateTimeNormalizer->denormalize($data, DateTimeInterface::class, $format, $context ?? [])
+            $this->dateTimeNormalizer->denormalize($data, DateTimeImmutable::class, $format, $context ?? [])
         );
     }
 

--- a/packages/EasyUtils/tests/Unit/src/Common/Normalizer/CarbonImmutableNormalizerTest.php
+++ b/packages/EasyUtils/tests/Unit/src/Common/Normalizer/CarbonImmutableNormalizerTest.php
@@ -6,18 +6,29 @@ namespace EonX\EasyUtils\Tests\Unit\Common\Normalizer;
 use Carbon\CarbonImmutable;
 use EonX\EasyUtils\Common\Normalizer\CarbonImmutableNormalizer;
 use EonX\EasyUtils\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 final class CarbonImmutableNormalizerTest extends AbstractUnitTestCase
 {
-    public function testDenormalizeSucceeds(): void
+    /**
+     * @see testDenormalizeSucceeds
+     */
+    public static function provideDateTimeFormats(): iterable
     {
-        $data = '2021-12-16T17:00:00+07:00';
+        yield 'Y-m-d H:i:s' => ['dateTime' => '2021-12-16 17:00:00'];
+
+        yield 'Y-m-d\TH:i:sP' => ['dateTime' => '2021-12-16T17:00:00+07:00'];
+    }
+
+    #[DataProvider('provideDateTimeFormats')]
+    public function testDenormalizeSucceeds(string $dateTime): void
+    {
         $normalizer = new CarbonImmutableNormalizer(new DateTimeNormalizer());
 
-        $result = $normalizer->denormalize($data, CarbonImmutable::class);
+        $result = $normalizer->denormalize($dateTime, CarbonImmutable::class);
 
-        self::assertEquals(new CarbonImmutable($data), $result);
+        self::assertEquals(new CarbonImmutable($dateTime), $result);
     }
 
     public function testHasCacheableSupportsMethodSucceeds(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes  

Change type to `DateTimeInterface` to instantiate objects using `DateTimeImmutable` class
