### PR TITLE
[EasyTest] Create EasyTestBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -168,6 +168,7 @@
             "EonX\\EasyTemplatingBlock\\": "packages/EasyTemplatingBlock/src",
             "EonX\\EasyTemplatingBlock\\Bundle\\": "packages/EasyTemplatingBlock/bundle",
             "EonX\\EasyTest\\": "packages/EasyTest/src",
+            "EonX\\EasyTest\\Bundle\\": "packages/EasyTest/bundle",
             "EonX\\EasyUtils\\": "packages/EasyUtils/src",
             "EonX\\EasyUtils\\Bundle\\": "packages/EasyUtils/bundle",
             "EonX\\EasyUtils\\Laravel\\": "packages/EasyUtils/laravel",

--- a/packages/EasyErrorHandler/bundle/CompilerPass/RegisterTraceableErrorHandlerCompilerPass.php
+++ b/packages/EasyErrorHandler/bundle/CompilerPass/RegisterTraceableErrorHandlerCompilerPass.php
@@ -14,7 +14,7 @@ final class RegisterTraceableErrorHandlerCompilerPass implements CompilerPassInt
 {
     public function process(ContainerBuilder $container): void
     {
-        if (($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug'))) {
+        if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
             $container
                 ->register(TraceableErrorHandlerInterface::class, TraceableErrorHandler::class)
                 ->setDecoratedService(ErrorHandlerInterface::class)

--- a/packages/EasyTest/bundle/CompilerPass/RegisterTraceableErrorHandlerStubCompilerPass.php
+++ b/packages/EasyTest/bundle/CompilerPass/RegisterTraceableErrorHandlerStubCompilerPass.php
@@ -1,24 +1,30 @@
 <?php
 declare(strict_types=1);
 
-namespace EonX\EasyErrorHandler\Bundle\CompilerPass;
+namespace EonX\EasyTest\Bundle\CompilerPass;
 
 use EonX\EasyErrorHandler\Common\ErrorHandler\ErrorHandlerInterface;
 use EonX\EasyErrorHandler\Common\ErrorHandler\TraceableErrorHandler;
 use EonX\EasyErrorHandler\Common\ErrorHandler\TraceableErrorHandlerInterface;
+use EonX\EasyTest\EasyErrorHandler\ErrorHandler\TraceableErrorHandlerStub;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-final class RegisterTraceableErrorHandlerCompilerPass implements CompilerPassInterface
+final class RegisterTraceableErrorHandlerStubCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug'))) {
+        if ($container->hasDefinition(TraceableErrorHandlerInterface::class) === false) {
             $container
                 ->register(TraceableErrorHandlerInterface::class, TraceableErrorHandler::class)
                 ->setDecoratedService(ErrorHandlerInterface::class)
                 ->addArgument(new Reference(\sprintf('%s.inner', TraceableErrorHandlerInterface::class)));
         }
+
+        $container
+            ->register(TraceableErrorHandlerStub::class, TraceableErrorHandlerStub::class)
+            ->setDecoratedService(TraceableErrorHandlerInterface::class)
+            ->addArgument(new Reference(\sprintf('%s.inner', TraceableErrorHandlerStub::class)));
     }
 }

--- a/packages/EasyTest/bundle/EasyTestBundle.php
+++ b/packages/EasyTest/bundle/EasyTestBundle.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyTest\Bundle;
+
+use EonX\EasyTest\Bundle\CompilerPass\RegisterTraceableErrorHandlerStubCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+
+final class EasyTestBundle extends AbstractBundle
+{
+    public function __construct()
+    {
+        $this->path = \realpath(__DIR__);
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        $container
+            ->addCompilerPass(new RegisterTraceableErrorHandlerStubCompilerPass());
+    }
+}

--- a/packages/EasyTest/composer.json
+++ b/packages/EasyTest/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": {
-            "EonX\\EasyTest\\": "src"
+            "EonX\\EasyTest\\": "src",
+            "EonX\\EasyTest\\Bundle\\": "bundle"
         }
     },
     "autoload-dev": {

--- a/packages/EasyTest/src/EasyErrorHandler/Trait/EasyErrorHandlerAssertionTrait.php
+++ b/packages/EasyTest/src/EasyErrorHandler/Trait/EasyErrorHandlerAssertionTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace EonX\EasyTest\EasyErrorHandler\Trait;
 
 use EonX\EasyErrorHandler\Common\ErrorHandler\ErrorHandlerInterface;
+use EonX\EasyTest\EasyErrorHandler\ErrorHandler\TraceableErrorHandlerStub;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 
@@ -22,6 +23,7 @@ trait EasyErrorHandlerAssertionTrait
     public function setUpEasyErrorHandler(): void
     {
         self::$errorHandlerReportedErrors = null;
+        TraceableErrorHandlerStub::reset();
     }
 
     #[After]
@@ -118,11 +120,9 @@ trait EasyErrorHandlerAssertionTrait
             return self::$errorHandlerReportedErrors;
         }
 
-        /** @var \EonX\EasyErrorHandler\Common\ErrorHandler\TraceableErrorHandlerInterface $errorHandler */
-        $errorHandler = self::getService(ErrorHandlerInterface::class);
         self::$errorHandlerReportedErrors = [];
 
-        foreach ($errorHandler->getReportedErrors() as $exception) {
+        foreach (TraceableErrorHandlerStub::getAllReportedErrors() as $exception) {
             if (\is_int($exception->getCode()) && $exception->getCode() !== 0) {
                 self::$errorHandlerReportedErrors[] = $exception->getCode();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

We use `\PHPUnit\Framework\Attributes\After` to automatically check reported errors.
With `After `, our methods called after test `tearDown`, which always resets the container.
We need to use `TraceableErrorHandlerStub` as it stores reported errors in static property to not depend on the container.
