### PR TITLE
[EasyServerless] Make SymfonyServicesAppStateResetter to be public

### DIFF
--- a/packages/EasyServerless/bundle/CompilerPass/SymfonyServicesResetCompilerPass.php
+++ b/packages/EasyServerless/bundle/CompilerPass/SymfonyServicesResetCompilerPass.php
@@ -21,6 +21,7 @@ final class SymfonyServicesResetCompilerPass implements CompilerPassInterface
 
             $symfonyServicesAppStateResetter->setArgument('$resettableServices', $servicesResetter->getArgument(0));
             $symfonyServicesAppStateResetter->setArgument('$resetMethods', $servicesResetter->getArgument(1));
+            $symfonyServicesAppStateResetter->setPublic(true);
 
             $container->setDefinition(self::SERVICES_RESETTER, $symfonyServicesAppStateResetter);
             $container->removeDefinition(SymfonyServicesAppStateResetter::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
