### PR TITLE
[EasyApiPlatform] EasyErrorHandler now cares about the IRI with an invalid UUID passed in the request payload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-openssl": "*",
         "ext-pdo": "*",
         "ext-sodium": "*",
-        "api-platform/core": "^3.4.17 || ^4.1.12",
+        "api-platform/core": "^3.4.17 || ^4.1.18",
         "async-aws/secrets-manager": "^2.5",
         "aws/aws-sdk-php": "^3.288.1",
         "bugsnag/bugsnag": "^3.29",

--- a/packages/EasyApiPlatform/composer.json
+++ b/packages/EasyApiPlatform/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "api-platform/core": "^3.4.17 || ^4.1.12",
+        "api-platform/core": "^3.4.17 || ^4.1.18",
         "doctrine/collections": "^1.7.2 || ^2.1",
         "doctrine/dbal": "^3.8",
         "doctrine/orm": "^2.20",

--- a/packages/EasyApiPlatform/tests/Application/src/EasyErrorHandler/Provider/ApiPlatformErrorResponseBuilderProviderTest.php
+++ b/packages/EasyApiPlatform/tests/Application/src/EasyErrorHandler/Provider/ApiPlatformErrorResponseBuilderProviderTest.php
@@ -378,11 +378,25 @@ final class ApiPlatformErrorResponseBuilderProviderTest extends AbstractApplicat
         yield 'item not found by IRI type when input dto' => [
             'url' => '/invoices',
             'json' => [
+                'payment' => '/payments/435411d5-72cb-4169-ae44-4e0deb742d9a',
+            ],
+            'violations' => [
+                'payment' => [
+                    'Item not found for "/payments/435411d5-72cb-4169-ae44-4e0deb742d9a".',
+                ],
+            ],
+            'exceptionMessage' => 'payment: This value should be of type Payment.',
+            'version' => 4,
+        ];
+
+        yield 'invalid IRI when input dto' => [
+            'url' => '/invoices',
+            'json' => [
                 'payment' => '/payments/123',
             ],
             'violations' => [
                 'payment' => [
-                    'Item not found for "/payments/123".',
+                    'Invalid IRI "/payments/123".',
                 ],
             ],
             'exceptionMessage' => 'payment: This value should be of type Payment.',
@@ -868,6 +882,7 @@ final class ApiPlatformErrorResponseBuilderProviderTest extends AbstractApplicat
         $response = self::$client->request('POST', $url, ['json' => $json]);
 
         $responseData = $response->toArray(false);
+        dump($responseData);
         self::assertSame(400, $response->getStatusCode());
         self::assertArrayStructure(
             [

--- a/packages/EasyApiPlatform/tests/Application/src/EasyErrorHandler/Provider/ApiPlatformErrorResponseBuilderProviderTest.php
+++ b/packages/EasyApiPlatform/tests/Application/src/EasyErrorHandler/Provider/ApiPlatformErrorResponseBuilderProviderTest.php
@@ -882,7 +882,6 @@ final class ApiPlatformErrorResponseBuilderProviderTest extends AbstractApplicat
         $response = self::$client->request('POST', $url, ['json' => $json]);
 
         $responseData = $response->toArray(false);
-        dump($responseData);
         self::assertSame(400, $response->getStatusCode());
         self::assertArrayStructure(
             [

--- a/packages/EasyApiPlatform/tests/Fixture/app/src/EasyErrorHandler/ApiResource/Payment.php
+++ b/packages/EasyApiPlatform/tests/Fixture/app/src/EasyErrorHandler/ApiResource/Payment.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Post;
 use EonX\EasyApiPlatform\Tests\Fixture\App\EasyErrorHandler\DataTransferObject\PaymentInputDtoWithConstructor;
 use EonX\EasyApiPlatform\Tests\Fixture\App\EasyErrorHandler\StateProvider\PaymentStateProvider;
 use Symfony\Component\Serializer\Attribute\SerializedName;
+use Symfony\Component\Uid\Uuid;
 
 #[ApiResource(
     operations: [
@@ -27,7 +28,7 @@ use Symfony\Component\Serializer\Attribute\SerializedName;
 final class Payment
 {
     #[ApiProperty(identifier: true)]
-    public int $id;
+    public Uuid $id;
 
     #[SerializedName('type')]
     public string $paymentType;

--- a/packages/EasyApiPlatform/tests/Fixture/app/src/EasyErrorHandler/StateProvider/PaymentStateProvider.php
+++ b/packages/EasyApiPlatform/tests/Fixture/app/src/EasyErrorHandler/StateProvider/PaymentStateProvider.php
@@ -6,7 +6,6 @@ namespace EonX\EasyApiPlatform\Tests\Fixture\App\EasyErrorHandler\StateProvider;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
-use EonX\EasyApiPlatform\Tests\Fixture\App\EasyErrorHandler\ApiResource\Payment;
 use LogicException;
 
 final class PaymentStateProvider implements ProviderInterface
@@ -14,13 +13,6 @@ final class PaymentStateProvider implements ProviderInterface
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         if ($operation instanceof Get) {
-            if ($uriVariables['id'] === 1) {
-                $payment = new Payment('Some type');
-                $payment->id = 1;
-
-                return $payment;
-            }
-
             return null;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
