### PR TITLE
[EasySecurity] Make configurators stoppable

### DIFF
--- a/packages/EasySecurity/bundle/config/services.php
+++ b/packages/EasySecurity/bundle/config/services.php
@@ -3,13 +3,14 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use EonX\EasyLogging\Interfaces\LoggerFactoryInterface;
+use EonX\EasyLogging\Factory\LoggerFactoryInterface;
 use EonX\EasySecurity\Authorization\Factory\AuthorizationMatrixFactory;
 use EonX\EasySecurity\Authorization\Factory\AuthorizationMatrixFactoryInterface;
 use EonX\EasySecurity\Authorization\Factory\CachedAuthorizationMatrixFactory;
 use EonX\EasySecurity\Bundle\Enum\BundleParam;
 use EonX\EasySecurity\Bundle\Enum\ConfigServiceId;
 use EonX\EasySecurity\Bundle\Enum\ConfigTag;
+use EonX\EasySecurity\Common\Command\ListSecurityContextConfiguratorsCommand;
 use EonX\EasySecurity\Common\DataCollector\SecurityContextDataCollector;
 use EonX\EasySecurity\Common\Factory\SecurityContextFactory;
 use EonX\EasySecurity\Common\Factory\SecurityContextFactoryInterface;
@@ -63,6 +64,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $responseFactory = $services
         ->set(AuthenticationFailureResponseFactoryInterface::class, AuthenticationFailureResponseFactory::class);
     $services->set(SecurityContextAuthenticator::class);
+
+    // Command
+    $services
+        ->set(ListSecurityContextConfiguratorsCommand::class)
+        ->arg('$configurators', tagged_iterator(ConfigTag::ContextConfigurator->value));
 
     // Logger
     if (\interface_exists(LoggerFactoryInterface::class)) {

--- a/packages/EasySecurity/src/Common/Command/ListSecurityContextConfiguratorsCommand.php
+++ b/packages/EasySecurity/src/Common/Command/ListSecurityContextConfiguratorsCommand.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasySecurity\Common\Command;
+
+use EonX\EasySecurity\Common\Configurator\SecurityContextConfiguratorInterface;
+use EonX\EasyUtils\Common\Helper\CollectorHelper;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'easy-security:configurators:list',
+    description: 'List registered security context configurators with their priority ' .
+    '(execution order = lower priority first).'
+)]
+final class ListSecurityContextConfiguratorsCommand extends Command
+{
+    /**
+     * @param iterable<\EonX\EasySecurity\Common\Configurator\SecurityContextConfiguratorInterface> $configurators
+     */
+    public function __construct(
+        private readonly iterable $configurators,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $configurators = CollectorHelper::filterByClassAsArray(
+            $this->configurators,
+            SecurityContextConfiguratorInterface::class
+        );
+
+        if ($configurators === []) {
+            $output->writeln('<info>No security context configurator registered.</info>');
+
+            return self::SUCCESS;
+        }
+
+        // Execution order matches FromRequestConfigurator: lower priority first
+        $ordered = CollectorHelper::orderLowerPriorityFirstAsArray($configurators);
+
+        $table = new Table($output);
+        $table->setHeaders(['Order', 'Priority', 'Class']);
+
+        $order = 1;
+        foreach ($ordered as $configurator) {
+            $priority = $configurator->getPriority();
+            $table->addRow([$order, $priority, $configurator::class]);
+            ++$order;
+        }
+
+        $output->writeln('<comment>Execution order = lower priority first. Higher priority runs last.</comment>');
+        $table->render();
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/EasySecurity/src/Common/Configurator/AbstractSecurityContextConfigurator.php
+++ b/packages/EasySecurity/src/Common/Configurator/AbstractSecurityContextConfigurator.php
@@ -9,8 +9,20 @@ abstract class AbstractSecurityContextConfigurator implements SecurityContextCon
 {
     use HasPriorityTrait;
 
+    private bool $propagationStopped = false;
+
     public function __construct(?int $priority = null)
     {
         $this->doSetPriority($priority);
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        return $this->propagationStopped;
+    }
+
+    public function stopPropagation(): void
+    {
+        $this->propagationStopped = true;
     }
 }

--- a/packages/EasySecurity/src/Common/Configurator/FromRequestConfigurator.php
+++ b/packages/EasySecurity/src/Common/Configurator/FromRequestConfigurator.php
@@ -30,6 +30,10 @@ final readonly class FromRequestConfigurator
     {
         foreach ($this->configurators as $configurator) {
             $configurator->configure($securityContext, $this->request);
+
+            if ($configurator->isPropagationStopped()) {
+                break;
+            }
         }
 
         return $securityContext;

--- a/packages/EasySecurity/tests/Stub/Configurator/StopPropagationConfiguratorStub.php
+++ b/packages/EasySecurity/tests/Stub/Configurator/StopPropagationConfiguratorStub.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasySecurity\Tests\Stub\Configurator;
+
+use EonX\EasySecurity\Common\Configurator\AbstractSecurityContextConfigurator;
+use EonX\EasySecurity\Common\Context\SecurityContextInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class StopPropagationConfiguratorStub extends AbstractSecurityContextConfigurator
+{
+    public function __construct(?int $priority = null)
+    {
+        parent::__construct($priority);
+    }
+
+    public function configure(SecurityContextInterface $context, Request $request): void
+    {
+        $context->addPermissions('stop');
+        $this->stopPropagation();
+    }
+}

--- a/packages/EasySecurity/tests/Unit/src/Common/Command/ListSecurityContextConfiguratorsCommandTest.php
+++ b/packages/EasySecurity/tests/Unit/src/Common/Command/ListSecurityContextConfiguratorsCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasySecurity\Tests\Unit\Common\Command;
+
+use EonX\EasySecurity\Common\Command\ListSecurityContextConfiguratorsCommand;
+use EonX\EasySecurity\Tests\Stub\Configurator\PermissionFromApiKeyConfiguratorStub;
+use EonX\EasySecurity\Tests\Stub\Configurator\PermissionFromHashedApiKeyConfiguratorStub;
+use EonX\EasySecurity\Tests\Stub\Configurator\PermissionFromHeaderConfiguratorStub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ListSecurityContextConfiguratorsCommandTest extends TestCase
+{
+    public function testExecuteListsConfiguratorsInExecutionOrder(): void
+    {
+        // Priorities chosen so ordering (lower first) is: -10, 0, 50
+        $cHigh = new PermissionFromHashedApiKeyConfiguratorStub('perm_high', 50);
+        $cDefault = new PermissionFromApiKeyConfiguratorStub('perm_default', 0);
+        $cLow = new PermissionFromHeaderConfiguratorStub('perm_low', [], -10);
+        // Provide in random order to ensure command sorts them
+        $command = new ListSecurityContextConfiguratorsCommand([
+            $cDefault,
+            $cHigh,
+            $cLow,
+        ]);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        $posLow = \strpos($output, PermissionFromHeaderConfiguratorStub::class);
+        // Find occurrences; first occurrence should be low priority configurator (-10)
+        $posDefault = \strpos($output, PermissionFromApiKeyConfiguratorStub::class, $posLow + 1);
+        $posHigh = \strpos($output, PermissionFromHashedApiKeyConfiguratorStub::class, $posDefault + 1);
+        self::assertNotFalse($posLow, 'Low priority configurator not found in output');
+        self::assertNotFalse($posDefault, 'Default priority configurator not found in output');
+        self::assertNotFalse($posHigh, 'High priority configurator not found in output');
+        self::assertTrue($posLow < $posDefault && $posDefault < $posHigh, 'Configurators not listed in expected order');
+        self::assertStringContainsString('Execution order = lower priority first. Higher priority runs last.', $output);
+    }
+
+    public function testExecuteWithNoConfigurators(): void
+    {
+        $command = new ListSecurityContextConfiguratorsCommand([]);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        self::assertSame("No security context configurator registered.\n", $output);
+    }
+}

--- a/packages/EasySecurity/tests/Unit/src/Common/Configurator/FromRequestConfiguratorTest.php
+++ b/packages/EasySecurity/tests/Unit/src/Common/Configurator/FromRequestConfiguratorTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasySecurity\Tests\Unit\Common\Configurator;
+
+use EonX\EasySecurity\Common\Configurator\FromRequestConfigurator;
+use EonX\EasySecurity\Common\Context\SecurityContext;
+use EonX\EasySecurity\Tests\Stub\Configurator\PermissionFromApiKeyConfiguratorStub;
+use EonX\EasySecurity\Tests\Stub\Configurator\StopPropagationConfiguratorStub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class FromRequestConfiguratorTest extends TestCase
+{
+    public function testStopPropagationPreventsLaterConfigurators(): void
+    {
+        $request = new Request();
+        // Priorities: lower first -> stop(-10) runs, then 0 would be skipped because stopPropagation called
+        $stop = new StopPropagationConfiguratorStub(-10);
+        $second = new PermissionFromApiKeyConfiguratorStub('should_not_be_added', 0);
+        $fromRequest = new FromRequestConfigurator($request, [$second, $stop]); // Out of order to ensure sorting
+        $context = new SecurityContext();
+
+        $fromRequest($context);
+
+        self::assertTrue($context->hasPermission('stop'), 'First configurator should add permission');
+        self::assertFalse($context->hasPermission('should_not_be_added'), 'Second configurator should not execute');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
