### PR TITLE
[EasyPagination] Fix easy admin search bug

### DIFF
--- a/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
+++ b/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
@@ -187,7 +187,8 @@ trait DoctrineCommonPaginatorTrait
                 $paramTypesMap[$param->getName()] = $param->getType();
             }
 
-            $paramMappings = (new Parser($query))->parse()->getParameterMappings();
+            $paramMappings = (new Parser($query))->parse()
+->getParameterMappings();
             foreach ($paramMappings as $paramName => $positions) {
                 if (\array_key_exists($paramName, $parametersMap) === false) {
                     continue;

--- a/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
+++ b/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
@@ -186,7 +186,7 @@ trait DoctrineCommonPaginatorTrait
                 $paramTypesMap[$param->getName()] = $param->getType();
             }
 
-            \preg_match_all('/:([a-zA-Z_][a-zA-Z0-9_]*)/', $queryBuilder->getDQL(), $dqlParamMatches);
+            \preg_match_all('/:([a-zA-Z_][a-zA-Z0-9_]*)/', $queryBuilder->getDQL() ?? '', $dqlParamMatches);
             foreach ($dqlParamMatches[1] as $paramName) {
                 if (\array_key_exists($paramName, $parametersMap)) {
                     $params[] = $parametersMap[$paramName];

--- a/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
+++ b/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Query\QueryBuilder as DbalQueryBuilder;
+use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\QueryBuilder as OrmQueryBuilder;
 
 use function Symfony\Component\String\u;
@@ -176,8 +177,8 @@ trait DoctrineCommonPaginatorTrait
         $paramTypes = [];
 
         if ($queryBuilder instanceof OrmQueryBuilder) {
-            $sql = $queryBuilder->getQuery()
-                ->getSQL();
+            $query = $queryBuilder->getQuery();
+            $sql = $query->getSQL();
 
             $parametersMap = [];
             $paramTypesMap = [];
@@ -186,16 +187,20 @@ trait DoctrineCommonPaginatorTrait
                 $paramTypesMap[$param->getName()] = $param->getType();
             }
 
-            $matched = \preg_match_all('/:([a-zA-Z_][a-zA-Z0-9_]*)/', $queryBuilder->getDQL(), $dqlParamMatches);
-
-            if ($matched !== false) {
-                foreach ($dqlParamMatches[1] as $paramName) {
-                    if (\array_key_exists($paramName, $parametersMap)) {
-                        $params[] = $parametersMap[$paramName];
-                        $paramTypes[] = $paramTypesMap[$paramName];
-                    }
+            $paramMappings = (new Parser($query))->parse()->getParameterMappings();
+            foreach ($paramMappings as $paramName => $positions) {
+                if (\array_key_exists($paramName, $parametersMap) === false) {
+                    continue;
+                }
+                foreach ($positions as $position) {
+                    $params[$position] = $parametersMap[$paramName];
+                    $paramTypes[$position] = $paramTypesMap[$paramName];
                 }
             }
+            \ksort($params);
+            \ksort($paramTypes);
+            $params = \array_values($params);
+            $paramTypes = \array_values($paramTypes);
         }
 
         if ($queryBuilder instanceof DbalQueryBuilder) {

--- a/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
+++ b/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
@@ -179,9 +179,19 @@ trait DoctrineCommonPaginatorTrait
             $sql = $queryBuilder->getQuery()
                 ->getSQL();
 
+            $parametersMap = [];
+            $paramTypesMap = [];
             foreach ($queryBuilder->getParameters() as $param) {
-                $params[] = $param->getValue();
-                $paramTypes[] = $param->getType();
+                $parametersMap[$param->getName()] = $param->getValue();
+                $paramTypesMap[$param->getName()] = $param->getType();
+            }
+
+            \preg_match_all('/:([a-zA-Z_][a-zA-Z0-9_]*)/', $queryBuilder->getDQL(), $dqlParamMatches);
+            foreach ($dqlParamMatches[1] as $paramName) {
+                if (\array_key_exists($paramName, $parametersMap)) {
+                    $params[] = $parametersMap[$paramName];
+                    $paramTypes[] = $paramTypesMap[$paramName];
+                }
             }
         }
 

--- a/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
+++ b/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
@@ -186,11 +186,14 @@ trait DoctrineCommonPaginatorTrait
                 $paramTypesMap[$param->getName()] = $param->getType();
             }
 
-            \preg_match_all('/:([a-zA-Z_][a-zA-Z0-9_]*)/', $queryBuilder->getDQL() ?? '', $dqlParamMatches);
-            foreach ($dqlParamMatches[1] as $paramName) {
-                if (\array_key_exists($paramName, $parametersMap)) {
-                    $params[] = $parametersMap[$paramName];
-                    $paramTypes[] = $paramTypesMap[$paramName];
+            $matched = \preg_match_all('/:([a-zA-Z_][a-zA-Z0-9_]*)/', $queryBuilder->getDQL(), $dqlParamMatches);
+
+            if ($matched !== false) {
+                foreach ($dqlParamMatches[1] as $paramName) {
+                    if (\array_key_exists($paramName, $parametersMap)) {
+                        $params[] = $parametersMap[$paramName];
+                        $paramTypes[] = $paramTypesMap[$paramName];
+                    }
                 }
             }
         }

--- a/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
+++ b/packages/EasyPagination/src/Paginator/DoctrineCommonPaginatorTrait.php
@@ -188,7 +188,7 @@ trait DoctrineCommonPaginatorTrait
             }
 
             $paramMappings = (new Parser($query))->parse()
-->getParameterMappings();
+                ->getParameterMappings();
             foreach ($paramMappings as $paramName => $positions) {
                 if (\array_key_exists($paramName, $parametersMap) === false) {
                     continue;

--- a/packages/EasyPagination/tests/Unit/src/Paginator/DoctrineOrmLengthAwarePaginatorTest.php
+++ b/packages/EasyPagination/tests/Unit/src/Paginator/DoctrineOrmLengthAwarePaginatorTest.php
@@ -321,9 +321,22 @@ final class DoctrineOrmLengthAwarePaginatorTest extends AbstractDoctrineOrmPagin
         $queryBuilder
             ->getParameters()
             ->willReturn([new Parameter('baz', 'test', ParameterType::STRING)]);
-        $queryBuilder
-            ->getDQL()
-            ->willReturn('SELECT * FROM foo WHERE bar = :baz || fizz = :baz');
+        $query->getParameter('baz')
+            ->willReturn(new Parameter('baz', 'test', ParameterType::STRING));
+        $query->getDQL()
+            ->willReturn('SELECT i FROM ' . Item::class . ' i WHERE i.title LIKE :baz OR i.title LIKE :baz');
+        $query->getEntityManager()
+            ->willReturn($this->getEntityManager());
+        $query->getHints()
+            ->willReturn([]);
+        $query->hasHint(Argument::any())
+            ->willReturn(false);
+        $query->getHint(Argument::any())
+            ->willReturn(false);
+        $query->getHydrationMode()
+            ->willReturn(Query::HYDRATE_OBJECT);
+        $query->setResultSetMapping(Argument::any())
+            ->willReturn(null);
         $entityManager
             ->getConnection()
             ->willReturn($connection->reveal());

--- a/packages/EasyPagination/tests/Unit/src/Paginator/DoctrineOrmLengthAwarePaginatorTest.php
+++ b/packages/EasyPagination/tests/Unit/src/Paginator/DoctrineOrmLengthAwarePaginatorTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 namespace EonX\EasyPagination\Tests\Unit\Paginator;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\QueryBuilder;
 use EonX\EasyPagination\Pagination\Pagination;
 use EonX\EasyPagination\Pagination\PaginationInterface;
@@ -318,7 +320,10 @@ final class DoctrineOrmLengthAwarePaginatorTest extends AbstractDoctrineOrmPagin
             ->willReturn('some sql');
         $queryBuilder
             ->getParameters()
-            ->willReturn([]);
+            ->willReturn([new Parameter('baz', 'test', ParameterType::STRING)]);
+        $queryBuilder
+            ->getDQL()
+            ->willReturn('SELECT * FROM foo WHERE bar = :baz || fizz = :baz');
         $entityManager
             ->getConnection()
             ->willReturn($connection->reveal());
@@ -327,7 +332,7 @@ final class DoctrineOrmLengthAwarePaginatorTest extends AbstractDoctrineOrmPagin
             ->willReturn(new PostgreSQLPlatform());
         $result = $this->prophesize(Result::class);
         $connection
-            ->executeQuery(Argument::any(), [], [])
+            ->executeQuery(Argument::any(), ['test', 'test'], [ParameterType::STRING, ParameterType::STRING])
             ->willReturn($result->reveal());
         $result
             ->fetchAssociative()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Fixed a bug in DoctrineCommonPaginatorTrait::getTotalItemsForLargeDataset() where ORM named parameters repeated across multiple search fields caused a PostgreSQL bind error. The fix expands named params by scanning their occurrences in DQL before building the positional params array passed to DBAL.