### PR TITLE
[EasyDoctrine] Clear deferred entity events on flush exceptions

### DIFF
--- a/packages/EasyDoctrine/src/EntityEvent/Dispatcher/DeferredEntityEventDispatcher.php
+++ b/packages/EasyDoctrine/src/EntityEvent/Dispatcher/DeferredEntityEventDispatcher.php
@@ -100,6 +100,12 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
                 }
             }
 
+            foreach ($this->deletedEntities as $entityHash => $value) {
+                if (isset($activeEntityHashes[$entityHash]) === false) {
+                    unset($this->deletedEntities[$entityHash]);
+                }
+            }
+
             return;
         }
 

--- a/packages/EasyDoctrine/src/EntityEvent/EntityManager/WithEventsEntityManager.php
+++ b/packages/EasyDoctrine/src/EntityEvent/EntityManager/WithEventsEntityManager.php
@@ -32,7 +32,7 @@ class WithEventsEntityManager extends EntityManagerDecorator
     }
 
     /**
-     * @param object|array<mixed>|null $entity
+     * @param object|array|null $entity
      */
     public function flush($entity = null): void
     {

--- a/packages/EasyDoctrine/src/EntityEvent/EntityManager/WithEventsEntityManager.php
+++ b/packages/EasyDoctrine/src/EntityEvent/EntityManager/WithEventsEntityManager.php
@@ -31,14 +31,18 @@ class WithEventsEntityManager extends EntityManagerDecorator
         }
     }
 
+    /**
+     * @param object|array<mixed>|null $entity
+     */
     public function flush($entity = null): void
     {
+        $transactionNestingLevel = $this->getConnection()
+            ->getTransactionNestingLevel();
+
         try {
             parent::flush($entity);
         } catch (Throwable $throwable) {
-            $this->deferredEntityEventDispatcher->clear(
-                $this->getConnection()->getTransactionNestingLevel()
-            );
+            $this->deferredEntityEventDispatcher->clear($transactionNestingLevel);
 
             throw $throwable;
         }

--- a/packages/EasyDoctrine/src/EntityEvent/EntityManager/WithEventsEntityManager.php
+++ b/packages/EasyDoctrine/src/EntityEvent/EntityManager/WithEventsEntityManager.php
@@ -31,6 +31,19 @@ class WithEventsEntityManager extends EntityManagerDecorator
         }
     }
 
+    public function flush($entity = null): void
+    {
+        try {
+            parent::flush($entity);
+        } catch (Throwable $throwable) {
+            $this->deferredEntityEventDispatcher->clear(
+                $this->getConnection()->getTransactionNestingLevel()
+            );
+
+            throw $throwable;
+        }
+    }
+
     public function rollback(): void
     {
         $transactionNestingLevel = $this->getConnection()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This change prevents deferred entity events from surviving a failed Doctrine `flush()`.
Without it, long-running workers could dispatch stale events from a previous failed message during a later successful `flush()`. The fix ensures deferred state is cleared on `flush()` exceptions.
