### PR TITLE
[EasyServerless] Skip state checkers on `kernel.terminate` in non-Lambda environment

### DIFF
--- a/packages/EasyServerless/src/State/Listener/CheckStateListener.php
+++ b/packages/EasyServerless/src/State/Listener/CheckStateListener.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyServerless\State\Listener;
 
+use EonX\EasyServerless\Aws\Helper\LambdaContextHelper;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 final readonly class CheckStateListener
@@ -17,6 +18,10 @@ final readonly class CheckStateListener
 
     public function __invoke(TerminateEvent $event): void
     {
+        if (LambdaContextHelper::inLambda() === false) {
+            return;
+        }
+        
         foreach ($this->stateCheckers as $stateChecker) {
             $stateChecker->check();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Skip state checkers on `kernel.terminate` in non-Lambda environment