### PR TITLE
[EasyWebhook] Fix DoctrineDbalStore on PostgreSQL: tolerant send_after parsing + ORDER BY out of count query

### DIFF
--- a/packages/EasyWebhook/laravel/Commands/SendDueWebhooksCommand.php
+++ b/packages/EasyWebhook/laravel/Commands/SendDueWebhooksCommand.php
@@ -10,6 +10,7 @@ use EonX\EasyWebhook\Common\Exception\InvalidDateTimeException;
 use EonX\EasyWebhook\Common\Store\SendAfterStoreInterface;
 use EonX\EasyWebhook\Common\Store\StoreInterface;
 use Illuminate\Console\Command;
+use Throwable;
 
 final class SendDueWebhooksCommand extends Command
 {
@@ -49,10 +50,13 @@ final class SendDueWebhooksCommand extends Command
         $webhooksSent = 0;
 
         if ($sendAfterString !== null) {
-            $sendAfter = Carbon::createFromFormat(StoreInterface::DATETIME_FORMAT, $sendAfterString, $timezone);
-
-            if ($sendAfter instanceof Carbon === false) {
-                throw new InvalidDateTimeException(\sprintf('Invalid DateTime provided, "%s"', $sendAfterString));
+            try {
+                $sendAfter = Carbon::parse($sendAfterString, $timezone);
+            } catch (Throwable $throwable) {
+                throw new InvalidDateTimeException(
+                    \sprintf('Invalid DateTime provided, "%s"', $sendAfterString),
+                    previous: $throwable,
+                );
             }
         }
 

--- a/packages/EasyWebhook/src/Common/Command/SendDueWebhooksCommand.php
+++ b/packages/EasyWebhook/src/Common/Command/SendDueWebhooksCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
 
 #[AsCommand(
     name: 'easy-webhooks:send-due-webhooks',
@@ -70,10 +71,13 @@ final class SendDueWebhooksCommand extends Command
         $webhooksSent = 0;
 
         if ($sendAfterString !== null) {
-            $sendAfter = Carbon::createFromFormat(StoreInterface::DATETIME_FORMAT, $sendAfterString, $timezone);
-
-            if ($sendAfter instanceof Carbon === false) {
-                throw new InvalidDateTimeException(\sprintf('Invalid DateTime provided, "%s"', $sendAfterString));
+            try {
+                $sendAfter = Carbon::parse($sendAfterString, $timezone);
+            } catch (Throwable $throwable) {
+                throw new InvalidDateTimeException(
+                    \sprintf('Invalid DateTime provided, "%s"', $sendAfterString),
+                    previous: $throwable,
+                );
             }
         }
 

--- a/packages/EasyWebhook/src/Doctrine/Store/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Doctrine/Store/DoctrineDbalStore.php
@@ -15,7 +15,6 @@ use EonX\EasyWebhook\Common\Cleaner\DataCleanerInterface;
 use EonX\EasyWebhook\Common\Entity\Webhook;
 use EonX\EasyWebhook\Common\Entity\WebhookInterface;
 use EonX\EasyWebhook\Common\Enum\WebhookStatus;
-use EonX\EasyWebhook\Common\Exception\InvalidDateTimeException;
 use EonX\EasyWebhook\Common\Store\SendAfterStoreInterface;
 use EonX\EasyWebhook\Common\Store\StoreInterface;
 
@@ -49,16 +48,8 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
         ?string $timezone = null,
     ): LengthAwarePaginatorInterface {
         $sendAfter = $sendAfter !== null
-            ? Carbon::createFromFormat(self::DATETIME_FORMAT, $sendAfter->format(self::DATETIME_FORMAT), $timezone)
+            ? Carbon::parse($sendAfter->format(self::DATETIME_FORMAT), $timezone)
             : Carbon::now($timezone);
-
-        if ($sendAfter instanceof Carbon === false) {
-            throw new InvalidDateTimeException(\sprintf(
-                'Could not instantiate DateTime for %s::%s',
-                self::class,
-                __METHOD__
-            ));
-        }
 
         $paginator = new DoctrineDbalLengthAwarePaginator($pagination, $this->connection, $this->table);
 
@@ -69,8 +60,10 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
                     ->setParameters([
                         'sendAfter' => $sendAfter->format(self::DATETIME_FORMAT),
                         'status' => WebhookStatus::Pending->value,
-                    ])
-                    ->orderBy('created_at');
+                    ]);
+            })
+            ->setGetItemsCriteria(static function (QueryBuilder $queryBuilder): void {
+                $queryBuilder->orderBy('created_at');
             })
             ->setTransformer(fn (array $item): WebhookInterface => $this->instantiateWebhook($item)
                 ->bypassSendAfter(true));
@@ -133,7 +126,7 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
         }
 
         if (\is_string($data['send_after'] ?? null)) {
-            $data['send_after'] = Carbon::createFromFormat(self::DATETIME_FORMAT, $data['send_after']);
+            $data['send_after'] = Carbon::parse($data['send_after']);
         }
 
         // Recover extra

--- a/packages/EasyWebhook/src/Doctrine/Store/DoctrineDbalStore.php
+++ b/packages/EasyWebhook/src/Doctrine/Store/DoctrineDbalStore.php
@@ -47,9 +47,11 @@ final class DoctrineDbalStore extends AbstractDoctrineDbalStore implements Store
         ?DateTimeInterface $sendAfter = null,
         ?string $timezone = null,
     ): LengthAwarePaginatorInterface {
-        $sendAfter = $sendAfter !== null
-            ? Carbon::parse($sendAfter->format(self::DATETIME_FORMAT), $timezone)
-            : Carbon::now($timezone);
+        $sendAfter = $sendAfter !== null ? Carbon::instance($sendAfter) : Carbon::now($timezone);
+
+        if ($timezone !== null) {
+            $sendAfter = $sendAfter->shiftTimezone($timezone);
+        }
 
         $paginator = new DoctrineDbalLengthAwarePaginator($pagination, $this->connection, $this->table);
 

--- a/packages/EasyWebhook/src/DynamoDb/Store/DynamoDbStore.php
+++ b/packages/EasyWebhook/src/DynamoDb/Store/DynamoDbStore.php
@@ -97,7 +97,7 @@ final class DynamoDbStore extends AbstractDynamoDbStore implements StoreInterfac
         }
 
         if (\is_string($data['send_after'] ?? null)) {
-            $data['send_after'] = CarbonImmutable::createFromFormat(self::DATETIME_FORMAT, $data['send_after']);
+            $data['send_after'] = CarbonImmutable::parse($data['send_after']);
         }
 
         if (\is_string($data['extra'] ?? null)) {

--- a/packages/EasyWebhook/tests/Unit/src/Doctrine/Store/DoctrineDbalStoreTest.php
+++ b/packages/EasyWebhook/tests/Unit/src/Doctrine/Store/DoctrineDbalStoreTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace EonX\EasyWebhook\Tests\Unit\Doctrine\Store;
 
 use Carbon\Carbon;
+use DateTimeInterface;
 use EonX\EasyPagination\Pagination\Pagination;
 use EonX\EasyWebhook\Common\Entity\Webhook;
 use EonX\EasyWebhook\Common\Entity\WebhookInterface;
@@ -39,6 +40,67 @@ final class DoctrineDbalStoreTest extends AbstractDoctrineDbalStoreTestCase
     }
 
     /**
+     * @see testFindDueWebhooksWithTimezone
+     */
+    public static function provideFindDueWebhooksWithTimezoneData(): iterable
+    {
+        // Pacific/Kiritimati is UTC+14: "now" there are 14 hours ahead of the UTC wall-clock
+        $sendAfter = Carbon::parse('2026-06-02 12:00:00', 'UTC');
+
+        yield 'now in UTC, send_after just ahead, not due' => [
+            self::createWebhookForSendAfter(Carbon::now('UTC')->addMinute()),
+            null,
+            'UTC',
+            0,
+        ];
+
+        yield 'now in UTC+14, send_after just ahead of UTC, due' => [
+            self::createWebhookForSendAfter(Carbon::now('UTC')->addMinute()),
+            null,
+            'Pacific/Kiritimati',
+            1,
+        ];
+
+        yield 'now in UTC+14, send_after just inside the window, due' => [
+            self::createWebhookForSendAfter(Carbon::now('UTC')->addHours(14)->subMinute()),
+            null,
+            'Pacific/Kiritimati',
+            1,
+        ];
+
+        yield 'now in UTC+14, send_after just past the window, not due' => [
+            self::createWebhookForSendAfter(Carbon::now('UTC')->addHours(14)->addMinute()),
+            null,
+            'Pacific/Kiritimati',
+            0,
+        ];
+
+        // Explicit $sendAfter: $timezone must not affect the result
+        yield 'explicit sendAfter after send_after, due' => [
+            self::createWebhookForSendAfter($sendAfter),
+            $sendAfter->copy()
+->addSecond(),
+            'Pacific/Kiritimati',
+            1,
+        ];
+
+        yield 'explicit sendAfter equal to send_after, not due' => [
+            self::createWebhookForSendAfter($sendAfter),
+            $sendAfter->copy(),
+            'Pacific/Kiritimati',
+            0,
+        ];
+
+        yield 'explicit sendAfter before send_after, not due' => [
+            self::createWebhookForSendAfter($sendAfter),
+            $sendAfter->copy()
+->subSecond(),
+            'Pacific/Kiritimati',
+            0,
+        ];
+    }
+
+    /**
      * @param \EonX\EasyWebhook\Common\Entity\WebhookInterface[] $webhooks
      */
     #[DataProvider('provideFindDueWebhooksData')]
@@ -51,6 +113,22 @@ final class DoctrineDbalStoreTest extends AbstractDoctrineDbalStoreTestCase
         }
 
         $dueWebhooks = $store->findDueWebhooks(new Pagination(1, 15));
+
+        self::assertSame($expectedDue, $dueWebhooks->getTotalItems());
+        self::assertCount($expectedDue, $dueWebhooks->getItems());
+    }
+
+    #[DataProvider('provideFindDueWebhooksWithTimezoneData')]
+    public function testFindDueWebhooksWithTimezone(
+        WebhookInterface $webhook,
+        ?DateTimeInterface $sendAfter,
+        string $timezone,
+        int $expectedDue,
+    ): void {
+        $store = $this->getStore();
+        $store->store($webhook);
+
+        $dueWebhooks = $store->findDueWebhooks(new Pagination(1, 15), $sendAfter, $timezone);
 
         self::assertSame($expectedDue, $dueWebhooks->getTotalItems());
         self::assertCount($expectedDue, $dueWebhooks->getItems());

--- a/packages/EasyWebhook/tests/Unit/src/Doctrine/Store/DoctrineDbalStoreTest.php
+++ b/packages/EasyWebhook/tests/Unit/src/Doctrine/Store/DoctrineDbalStoreTest.php
@@ -162,6 +162,24 @@ final class DoctrineDbalStoreTest extends AbstractDoctrineDbalStoreTestCase
         }
     }
 
+    public function testFindWebhookWithSendAfterContainingMicroseconds(): void
+    {
+        $store = $this->getStore();
+        $webhook = self::createWebhookForSendAfter(Carbon::now('UTC'));
+        $store->store($webhook);
+        $connection = $this->getDoctrineDbalConnection();
+        $connection->update(
+            DoctrineDbalStore::DEFAULT_TABLE,
+            ['send_after' => '2026-06-02 12:00:00.123456'],
+            ['id' => $webhook->getId()]
+        );
+
+        $found = $store->find((string)$webhook->getId());
+
+        self::assertInstanceOf(WebhookInterface::class, $found);
+        self::assertSame('2026-06-02 12:00:00.123456', $found->getSendAfter()?->format('Y-m-d H:i:s.u'));
+    }
+
     public function testStore(): void
     {
         $id = 'my-id';

--- a/packages/EasyWebhook/tests/Unit/src/Doctrine/Store/DoctrineDbalStoreTest.php
+++ b/packages/EasyWebhook/tests/Unit/src/Doctrine/Store/DoctrineDbalStoreTest.php
@@ -40,8 +40,6 @@ final class DoctrineDbalStoreTest extends AbstractDoctrineDbalStoreTestCase
 
     /**
      * @param \EonX\EasyWebhook\Common\Entity\WebhookInterface[] $webhooks
-     *
-     * @throws \Doctrine\DBAL\Exception
      */
     #[DataProvider('provideFindDueWebhooksData')]
     public function testFindDueWebhooks(array $webhooks, int $expectedDue): void
@@ -54,6 +52,7 @@ final class DoctrineDbalStoreTest extends AbstractDoctrineDbalStoreTestCase
 
         $dueWebhooks = $store->findDueWebhooks(new Pagination(1, 15));
 
+        self::assertSame($expectedDue, $dueWebhooks->getTotalItems());
         self::assertCount($expectedDue, $dueWebhooks->getItems());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
