### PR TITLE
[EasySwoole] Fix double AWS RDS resolve dropping cross-account assume-role ARN

### DIFF
--- a/packages/EasySwoole/src/Doctrine/Factory/CoroutineConnectionFactory.php
+++ b/packages/EasySwoole/src/Doctrine/Factory/CoroutineConnectionFactory.php
@@ -7,6 +7,7 @@ use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use EonX\EasyDoctrine\AwsRds\Middleware\AwsRdsMiddleware;
 use EonX\EasyDoctrine\AwsRds\Resolver\AwsRdsConnectionParamsResolver;
 use EonX\EasySwoole\Doctrine\Driver\DbalDriver;
 use Psr\Log\LoggerInterface;
@@ -53,6 +54,15 @@ final class CoroutineConnectionFactory extends ConnectionFactory
         );
 
         foreach ($config?->getMiddlewares() ?? [] as $middleware) {
+            // The Coroutine PDO pool (DbalDriver) already resolves AWS RDS connection params
+            // (IAM auth token + SSL) on the original params via the injected resolver. Re-wrapping
+            // with AwsRdsMiddleware would resolve a second time on already-stripped params, dropping
+            // driver options such as the cross-account assume-role ARN from the pooled connection's
+            // token. Skip it when the pool can resolve params itself.
+            if ($this->connectionParamsResolver !== null && $middleware instanceof AwsRdsMiddleware) {
+                continue;
+            }
+
             $driver = $middleware->wrap($driver);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no dedicated test yet — verified on a live deployment
| Fixed tickets | n/a (internal Jira: PBAO-1080)

## Problem

When the `EasySwoole` Coroutine PDO pool is active, AWS RDS connection params are resolved **twice** per connection.

`CoroutineConnectionFactory::createConnection()` builds a `DbalDriver` (the pool driver), which already resolves params (IAM auth token + SSL) on the original params via the injected `AwsRdsConnectionParamsResolver`. It then re-wraps that driver with **all** configured Doctrine middlewares — including `EasyDoctrine`'s `AwsRdsMiddleware`. The chain becomes `AwsRdsDriver → DbalDriver → real driver`, so `resolve()` runs on both layers.

The second `resolve()` runs on params that the first call already **stripped** of the AWS RDS driver options (`AwsRdsConnectionParamsResolver` removes every `AwsRdsOption::*` from `driverOptions` before returning). The token actually used by the pooled connection comes from this second resolve — where the cross-account **assume-role ARN** is already gone — so the IAM auth token is signed with the task's own credentials instead of the assumed role.

In a single-account / non-assume-role setup this is harmless (both resolves yield an equivalent token, and the token cache usually masks it). For **cross-account RDS IAM** (STS assume-role) it breaks: the token is signed by the wrong principal and RDS rejects it with `FATAL: password authentication failed`.

## Root cause

`AwsRdsMiddleware` is designed to add RDS resolution to a vanilla Doctrine driver. But `DbalDriver` already owns resolution for the coroutine pool (it has its own injected resolver and resolves in both its swoole and non-swoole branches). Re-applying `AwsRdsMiddleware` on top duplicates the work, and the second pass loses driver options the first pass stripped.

## Fix

Skip `AwsRdsMiddleware` in the middleware loop when `DbalDriver` already has a resolver, so resolution happens exactly once, on intact params. The `$this->connectionParamsResolver !== null` guard preserves existing behaviour when the pool has no resolver of its own.

## Verification

Reproduced and fixed on a live deployment — a Symfony/OpenSwoole app connecting cross-account to an Aurora PostgreSQL cluster via RDS IAM + STS assume-role:

- **Before:** two resolves logged; the second (used) token generated **without** the assume-role; `password authentication failed`.
- **After:** a single resolve, assume-role applied, connection succeeds.

A/B confirmed by toggling the equivalent change as a composer patch: works → revert → fails again → re-apply → works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
