### PR TITLE
[EasySwoole] Fix comment style flagged by Rector (SingleLineCommentRector)

### DIFF
--- a/packages/EasySwoole/src/Doctrine/Factory/CoroutineConnectionFactory.php
+++ b/packages/EasySwoole/src/Doctrine/Factory/CoroutineConnectionFactory.php
@@ -58,7 +58,7 @@ final class CoroutineConnectionFactory extends ConnectionFactory
             // (IAM auth token + SSL) on the original params via the injected resolver. Re-wrapping
             // with AwsRdsMiddleware would resolve a second time on already-stripped params, dropping
             // driver options such as the cross-account assume-role ARN from the pooled connection's
-            // token. Skip it when the pool can resolve params itself.
+            // token. Skip it when the pool can resolve params itself
             if ($this->connectionParamsResolver !== null && $middleware instanceof AwsRdsMiddleware) {
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no (code-style follow-up)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (comment-only change)
| Fixed tickets | n/a (internal Jira: PBAO-1080)

Follow-up to #1805. Rector's `SingleLineCommentRector` flags the trailing period at the end of the comment block added in that PR, leaving `master` red on `check-rector`. This drops the trailing `.`. Comment-only change, no behaviour impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
