### PR TITLE
[EasySwoole] Disable EasyEncryption in tests

### DIFF
--- a/packages/EasySwoole/tests/Fixture/config/default.php
+++ b/packages/EasySwoole/tests/Fixture/config/default.php
@@ -8,4 +8,7 @@ use Symfony\Config\EasySwooleConfig;
 return static function (EasySwooleConfig $easySwooleConfig): void {
     $easySwooleConfig->doctrine()
         ->enabled(false);
+
+    $easySwooleConfig->easyEncryption()
+        ->enabled(false);
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

EasySwooleBundleTest::testSanity fails when run inside the monorepo (shared autoloader), while passing in CI's isolated package tests.

EasySwoole does not depend on easy-encryption. The bundle guards the integration with interface_exists(EncryptorInterface::class). In an isolated install the interface is absent, so the integration is skipped. In the monorepo every package is autoloadable, so the guard passes and registers InitAwsCloudHsmEncryptorListener, which autowires EncryptorInterface — a service the test kernel never provides (it boots only EasySwooleBundle). Container compilation then fails.

Fix: disable the optional EasyEncryption integration in the test fixture, mirroring the existing doctrine → enabled(false). This makes the test deterministic across both environments; no production behaviour changes (a real app installing both packages gets the service from the EasyEncryption bundle).