### PR TITLE
[EasyLock] Expose LockFactory as a service

### DIFF
--- a/packages/EasyLock/bundle/config/services.php
+++ b/packages/EasyLock/bundle/config/services.php
@@ -8,6 +8,7 @@ use EonX\EasyLock\Bundle\Enum\ConfigServiceId;
 use EonX\EasyLock\Common\Locker\Locker;
 use EonX\EasyLock\Common\Locker\LockerInterface;
 use EonX\EasyLock\Doctrine\Listener\EasyLockDoctrineSchemaListener;
+use Symfony\Component\Lock\LockFactory;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -17,8 +18,15 @@ return static function (ContainerConfigurator $container): void {
         ->autoconfigure();
 
     $services
+        ->set(LockFactory::class)
+        ->arg('$store', service(ConfigServiceId::Store->value))
+        ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+        ->tag('monolog.logger', ['channel' => BundleParam::LogChannel->value]);
+
+    $services
         ->set(LockerInterface::class, Locker::class)
         ->arg('$store', service(ConfigServiceId::Store->value))
+        ->arg('$lockFactory', service(LockFactory::class))
         ->tag('monolog.logger', ['channel' => BundleParam::LogChannel->value]);
 
     $services

--- a/packages/EasyLock/laravel/EasyLockServiceProvider.php
+++ b/packages/EasyLock/laravel/EasyLockServiceProvider.php
@@ -22,7 +22,7 @@ final class EasyLockServiceProvider extends ServiceProvider
     public function register(): void
     {
         $loggerParams = \enum_exists(EasyLoggingBundleParam::class)
-            ? [EasyLoggingBundleParam::KeyChannel->value => BundleParam::LogChannel]
+            ? [EasyLoggingBundleParam::KeyChannel->value => BundleParam::LogChannel->value]
             : [];
 
         $this->app->singleton(

--- a/packages/EasyLock/laravel/EasyLockServiceProvider.php
+++ b/packages/EasyLock/laravel/EasyLockServiceProvider.php
@@ -11,6 +11,7 @@ use EonX\EasyLogging\Bundle\Enum\BundleParam as EasyLoggingBundleParam;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\StoreFactory;
 
@@ -33,6 +34,20 @@ final class EasyLockServiceProvider extends ServiceProvider
         );
 
         $this->app->singleton(
+            LockFactory::class,
+            static function (Container $app): LockFactory {
+                $loggerParams = \enum_exists(EasyLoggingBundleParam::class)
+                    ? [EasyLoggingBundleParam::KeyChannel->value => BundleParam::LogChannel]
+                    : [];
+
+                $lockFactory = new LockFactory($app->make(ConfigServiceId::Store->value));
+                $lockFactory->setLogger($app->make(LoggerInterface::class, $loggerParams));
+
+                return $lockFactory;
+            }
+        );
+
+        $this->app->singleton(
             LockerInterface::class,
             static function (Container $app): LockerInterface {
                 $loggerParams = \enum_exists(EasyLoggingBundleParam::class)
@@ -41,7 +56,8 @@ final class EasyLockServiceProvider extends ServiceProvider
 
                 return new Locker(
                     $app->make(ConfigServiceId::Store->value),
-                    $app->make(LoggerInterface::class, $loggerParams)
+                    $app->make(LoggerInterface::class, $loggerParams),
+                    $app->make(LockFactory::class)
                 );
             }
         );

--- a/packages/EasyLock/laravel/EasyLockServiceProvider.php
+++ b/packages/EasyLock/laravel/EasyLockServiceProvider.php
@@ -21,6 +21,10 @@ final class EasyLockServiceProvider extends ServiceProvider
 
     public function register(): void
     {
+        $loggerParams = \enum_exists(EasyLoggingBundleParam::class)
+            ? [EasyLoggingBundleParam::KeyChannel->value => BundleParam::LogChannel]
+            : [];
+
         $this->app->singleton(
             ConfigServiceId::Store->value,
             static function (Container $app): PersistingStoreInterface {
@@ -35,11 +39,7 @@ final class EasyLockServiceProvider extends ServiceProvider
 
         $this->app->singleton(
             LockFactory::class,
-            static function (Container $app): LockFactory {
-                $loggerParams = \enum_exists(EasyLoggingBundleParam::class)
-                    ? [EasyLoggingBundleParam::KeyChannel->value => BundleParam::LogChannel]
-                    : [];
-
+            static function (Container $app) use ($loggerParams): LockFactory {
                 $lockFactory = new LockFactory($app->make(ConfigServiceId::Store->value));
                 $lockFactory->setLogger($app->make(LoggerInterface::class, $loggerParams));
 
@@ -49,17 +49,11 @@ final class EasyLockServiceProvider extends ServiceProvider
 
         $this->app->singleton(
             LockerInterface::class,
-            static function (Container $app): LockerInterface {
-                $loggerParams = \enum_exists(EasyLoggingBundleParam::class)
-                    ? [EasyLoggingBundleParam::KeyChannel->value => BundleParam::LogChannel]
-                    : [];
-
-                return new Locker(
-                    $app->make(ConfigServiceId::Store->value),
-                    $app->make(LoggerInterface::class, $loggerParams),
-                    $app->make(LockFactory::class)
-                );
-            }
+            static fn (Container $app): LockerInterface => new Locker(
+                $app->make(ConfigServiceId::Store->value),
+                $app->make(LoggerInterface::class, $loggerParams),
+                $app->make(LockFactory::class)
+            )
         );
     }
 }

--- a/packages/EasyLock/readme.md
+++ b/packages/EasyLock/readme.md
@@ -32,6 +32,33 @@ supported by the Lock component.
 If defining the connection doesn't work for you, you can override the store instance within the service container under
 the `easy_lock.store` id.
 
+###### Lock factory
+
+The package registers `Symfony\Component\Lock\LockFactory` as a service, configured with the package's store and
+logger, so there is no need to create your own instance of the lock factory. You can simply inject it into your
+services:
+
+```php
+use Symfony\Component\Lock\LockFactory;
+
+final readonly class MyService
+{
+    public function __construct(
+        private LockFactory $lockFactory,
+    ) {
+    }
+
+    public function doSomething(): void
+    {
+        $lock = $this->lockFactory->createLock('my-resource');
+
+        // ...
+    }
+}
+```
+
+The same lock factory instance is used by `EonX\EasyLock\Common\Locker\LockerInterface` internally.
+
 [1]: https://getcomposer.org/
 [2]: https://symfony.com/doc/current/components/lock.html
 [3]: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Lock/Store/StoreFactory.php

--- a/packages/EasyLock/src/Common/Locker/Locker.php
+++ b/packages/EasyLock/src/Common/Locker/Locker.php
@@ -69,6 +69,7 @@ final class Locker implements LockerInterface
         }
     }
 
+    // @todo in 7.0 make $lockFactory constructor argument required and remove this fallback
     private function getFactory(): LockFactory
     {
         if ($this->lockFactory !== null) {

--- a/packages/EasyLock/src/Common/Locker/Locker.php
+++ b/packages/EasyLock/src/Common/Locker/Locker.php
@@ -18,11 +18,10 @@ use Symfony\Component\Lock\PersistingStoreInterface;
 
 final class Locker implements LockerInterface
 {
-    private ?LockFactory $factory = null;
-
     public function __construct(
         private readonly PersistingStoreInterface $store,
         private readonly LoggerInterface $logger = new NullLogger(),
+        private ?LockFactory $lockFactory = null,
     ) {
     }
 
@@ -72,13 +71,13 @@ final class Locker implements LockerInterface
 
     private function getFactory(): LockFactory
     {
-        if ($this->factory !== null) {
-            return $this->factory;
+        if ($this->lockFactory !== null) {
+            return $this->lockFactory;
         }
 
-        $this->factory = new LockFactory($this->store);
-        $this->factory->setLogger($this->logger);
+        $this->lockFactory = new LockFactory($this->store);
+        $this->lockFactory->setLogger($this->logger);
 
-        return $this->factory;
+        return $this->lockFactory;
     }
 }

--- a/packages/EasyLock/tests/Stub/Factory/LockFactoryStub.php
+++ b/packages/EasyLock/tests/Stub/Factory/LockFactoryStub.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyLock\Tests\Stub\Factory;
+
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+
+final class LockFactoryStub extends LockFactory
+{
+    private int $createLockCallCount = 0;
+
+    public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true): SharedLockInterface
+    {
+        ++$this->createLockCallCount;
+
+        return parent::createLock($resource, $ttl, $autoRelease);
+    }
+
+    public function getCreateLockCallCount(): int
+    {
+        return $this->createLockCallCount;
+    }
+}

--- a/packages/EasyLock/tests/Unit/bundle/EasyLockBundleTest.php
+++ b/packages/EasyLock/tests/Unit/bundle/EasyLockBundleTest.php
@@ -6,6 +6,8 @@ namespace EonX\EasyLock\Tests\Unit\Bundle;
 use EonX\EasyLock\Common\Locker\Locker;
 use EonX\EasyLock\Common\Locker\LockerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionProperty;
+use Symfony\Component\Lock\LockFactory;
 
 final class EasyLockBundleTest extends AbstractSymfonyTestCase
 {
@@ -17,6 +19,18 @@ final class EasyLockBundleTest extends AbstractSymfonyTestCase
         yield 'default config, no connection' => [null];
 
         yield 'in memory connection' => [[__DIR__ . '/../../Fixture/config/in_memory_connection.php']];
+    }
+
+    public function testLockFactoryIsRegisteredAndSharedWithLocker(): void
+    {
+        $container = $this->getKernel()
+            ->getContainer();
+
+        $lockFactory = $container->get(LockFactory::class);
+        $locker = $container->get(LockerInterface::class);
+
+        self::assertInstanceOf(LockFactory::class, $lockFactory);
+        self::assertSame($lockFactory, (new ReflectionProperty(Locker::class, 'lockFactory'))->getValue($locker));
     }
 
     /**

--- a/packages/EasyLock/tests/Unit/laravel/EasyLockServiceProviderTest.php
+++ b/packages/EasyLock/tests/Unit/laravel/EasyLockServiceProviderTest.php
@@ -5,6 +5,8 @@ namespace EonX\EasyLock\Tests\Unit\Laravel;
 
 use EonX\EasyLock\Common\Locker\Locker;
 use EonX\EasyLock\Common\Locker\LockerInterface;
+use ReflectionProperty;
+use Symfony\Component\Lock\LockFactory;
 
 final class EasyLockServiceProviderTest extends AbstractLaravelTestCase
 {
@@ -13,5 +15,16 @@ final class EasyLockServiceProviderTest extends AbstractLaravelTestCase
         $app = $this->getApp();
 
         self::assertInstanceOf(Locker::class, $app->get(LockerInterface::class));
+    }
+
+    public function testLockFactoryIsRegisteredAndSharedWithLocker(): void
+    {
+        $app = $this->getApp();
+
+        $lockFactory = $app->get(LockFactory::class);
+        $locker = $app->get(LockerInterface::class);
+
+        self::assertInstanceOf(LockFactory::class, $lockFactory);
+        self::assertSame($lockFactory, (new ReflectionProperty(Locker::class, 'lockFactory'))->getValue($locker));
     }
 }

--- a/packages/EasyLock/tests/Unit/src/Common/Locker/LockerTest.php
+++ b/packages/EasyLock/tests/Unit/src/Common/Locker/LockerTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyLock\Tests\Unit\Common\Locker;
+
+use EonX\EasyLock\Common\Locker\Locker;
+use EonX\EasyLock\Tests\Stub\Factory\LockFactoryStub;
+use EonX\EasyLock\Tests\Unit\AbstractUnitTestCase;
+use Symfony\Component\Lock\Store\InMemoryStore;
+
+final class LockerTest extends AbstractUnitTestCase
+{
+    public function testCreateLockCreatesFactoryWhenNoLockFactoryGiven(): void
+    {
+        $locker = new Locker(new InMemoryStore());
+
+        $lock = $locker->createLock('some-resource');
+
+        self::assertTrue($lock->acquire());
+
+        $lock->release();
+    }
+
+    public function testCreateLockUsesGivenLockFactory(): void
+    {
+        $store = new InMemoryStore();
+        $lockFactory = new LockFactoryStub($store);
+        $locker = new Locker($store, lockFactory: $lockFactory);
+
+        $lock = $locker->createLock('some-resource');
+
+        self::assertSame(1, $lockFactory->getCreateLockCallCount());
+        self::assertTrue($lock->acquire());
+
+        $lock->release();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

EasyLock configures a shared persisting store for locks, but the Symfony `LockFactory` built
on it is private to `Locker`. Projects that need the factory itself (rate limiter
`->lockFactory()`, `LockableTrait`, etc.) had to wire their own from `easy_lock.store` — or
accidentally autowire Symfony's default flock-based factory, which doesn't lock across
multiple app instances.

Now the bundle (and the Laravel provider) registers `LockFactory` as a service on the same
store and logger, so it can simply be autowired. `Locker` reuses it as the single creation
point. No BC breaks — the new `Locker` constructor argument is optional.
