### PR TITLE
[Monorepo] Fix stale composer vendor prefix and auth0 version in docs

### DIFF
--- a/packages/EasyApiToken/docs/decoders.md
+++ b/packages/EasyApiToken/docs/decoders.md
@@ -50,7 +50,7 @@ By default, this package comes with 3 built-in drivers:
     - `composer require firebase/php-jwt:^7.0`
     - `composer require phpseclib/phpseclib:^3.0`
 - Auth0: Allows you to decode JWT from [Auth0][2]. The following dependencies are required and need to be installed:
-    - `composer require auth0/auth0-php:^8.17`
+    - `composer require auth0/auth0-php:^8.19`
 - Firebase: Allows you to decode JWT using the [Firebase PHP package][3]. The following dependencies are required and need to be installed:
     - `composer require firebase/php-jwt:^7.0`
 

--- a/packages/EasyPagination/docs/install_laravel.md
+++ b/packages/EasyPagination/docs/install_laravel.md
@@ -12,7 +12,7 @@ This document describes the steps to install this package into a [Laravel][1] ap
 Laravel uses [Composer][2] to manage its dependencies. You can require this package as following:
 
 ```bash
-$ composer require eonx/easy-pagination
+$ composer require eonx-com/easy-pagination
 ```
 
 # Service Providers

--- a/packages/EasyPipeline/docs/laravel_install.md
+++ b/packages/EasyPipeline/docs/laravel_install.md
@@ -10,7 +10,7 @@ This document describes the steps to install this package into a [Laravel][1] ap
 Laravel uses [Composer][2] to manage its dependencies. You can require this package as following:
 
 ```bash
-$ composer require eonx/easy-pipeline
+$ composer require eonx-com/easy-pipeline
 ```
 
 <br>

--- a/packages/EasyRepository/readme.md
+++ b/packages/EasyRepository/readme.md
@@ -12,7 +12,7 @@ Provides an easy way to implement the Repository Design Pattern in your applicat
 Laravel uses [Composer][1] to manage its dependencies. You can require this package as following:
 
 ```bash
-$ composer require eonx/easy-repository
+$ composer require eonx-com/easy-repository
 ```
 
 [1]: https://getcomposer.org/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
