### PR TITLE
[EasyDoctrine] Remove deprecated ObjectCopier and $objectCopier argument

### DIFF
--- a/packages/EasyDoctrine/bundle/Factory/ObjectCopierFactory.php
+++ b/packages/EasyDoctrine/bundle/Factory/ObjectCopierFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace EonX\EasyDoctrine\Bundle\Factory;
 
 use DeepCopy\DeepCopy;
-use DeepCopy\Filter\Doctrine\DoctrineCollectionFilter;
 use DeepCopy\Matcher\PropertyTypeMatcher;
 use Doctrine\Common\Collections\Collection;
 use EonX\EasyDoctrine\DeepCopy\Filter\DoctrineInitializedCollectionDeepCopyFilter;
@@ -13,20 +12,6 @@ use EonX\EasyDoctrine\EntityEvent\Copier\ObjectCopierInterface;
 
 final class ObjectCopierFactory
 {
-    /**
-     * @deprecated since 6.0.3, will be removed in 7.0.0. Use createForDeletedEntity
-     */
-    public static function create(): ObjectCopierInterface
-    {
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(
-            new DoctrineCollectionFilter(),
-            new PropertyTypeMatcher(Collection::class)
-        );
-
-        return new ObjectCopier($deepCopy);
-    }
-
     public static function createForDeletedEntity(): ObjectCopierInterface
     {
         $deepCopy = new DeepCopy();

--- a/packages/EasyDoctrine/bundle/config/services.php
+++ b/packages/EasyDoctrine/bundle/config/services.php
@@ -20,16 +20,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(TimestampableListener::class);
 
     $services
-        ->set(ObjectCopierInterface::class)
-        ->deprecate(
-            'eonx_com/easy-doctrine',
-            '6.0.3',
-            '"%service_id%" service is deprecated and will be removed in 7.0.'
-            . ' Use ' . ConfigServiceId::DeletedEntityCopier->value . ' instead or register your own service.'
-        )
-        ->factory([ObjectCopierFactory::class, 'create']);
-
-    $services
         ->set(ConfigServiceId::DeletedEntityCopier->value, ObjectCopierInterface::class)
         ->factory([ObjectCopierFactory::class, 'createForDeletedEntity']);
 

--- a/packages/EasyDoctrine/src/EntityEvent/Dispatcher/DeferredEntityEventDispatcher.php
+++ b/packages/EasyDoctrine/src/EntityEvent/Dispatcher/DeferredEntityEventDispatcher.php
@@ -9,7 +9,6 @@ use EonX\EasyDoctrine\EntityEvent\Event\EntityCreatedEvent;
 use EonX\EasyDoctrine\EntityEvent\Event\EntityDeletedEvent;
 use EonX\EasyDoctrine\EntityEvent\Event\EntityUpdatedEvent;
 use EonX\EasyEventDispatcher\Dispatcher\EventDispatcherInterface;
-use JetBrains\PhpStorm\Deprecated;
 use LogicException;
 
 final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatcherInterface
@@ -26,9 +25,7 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
      */
     private array $deletedEntities = [];
 
-    private readonly ObjectCopierInterface $deletedEntityCopier;
-
-    private bool $enabled;
+    private bool $enabled = true;
 
     private array $entityChangeSets = [];
 
@@ -39,24 +36,8 @@ final class DeferredEntityEventDispatcher implements DeferredEntityEventDispatch
 
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
-        #[Deprecated('Will be removed in 7.0, use $deletedEntityCopier instead')]
-        ?ObjectCopierInterface $objectCopier = null,
-        ?ObjectCopierInterface $deletedEntityCopier = null,
+        private readonly ObjectCopierInterface $deletedEntityCopier,
     ) {
-        $this->enabled = true;
-
-        if ($objectCopier !== null) {
-            @\trigger_error(
-                'Argument $objectCopier is deprecated and will be removed in 7.0, use $deletedEntityCopier instead.',
-                \E_USER_DEPRECATED
-            );
-        }
-
-        if ($objectCopier === null && $deletedEntityCopier === null) {
-            throw new LogicException('At least one of $objectCopier or $deletedEntityCopier must be provided.');
-        }
-
-        $this->deletedEntityCopier = $deletedEntityCopier ?? $objectCopier;
     }
 
     public function clear(?int $transactionNestingLevel = null): void

--- a/packages/EasyDoctrine/src/EntityEvent/Dispatcher/DeferredEntityEventDispatcherInterface.php
+++ b/packages/EasyDoctrine/src/EntityEvent/Dispatcher/DeferredEntityEventDispatcherInterface.php
@@ -19,10 +19,7 @@ interface DeferredEntityEventDispatcherInterface
 
     public function deferInsert(int $transactionNestingLevel, object $entity, array $entityChangeSet): void;
 
-    /**
-     * @todo Rename $object to $entity in next major release
-     */
-    public function deferUpdate(int $transactionNestingLevel, object $object, array $entityChangeSet): void;
+    public function deferUpdate(int $transactionNestingLevel, object $entity, array $entityChangeSet): void;
 
     public function disable(): void;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
