### PR TITLE
[EasyTest] Remove deprecated EasyErrorHandler assertion methods

### DIFF
--- a/packages/EasyTest/src/EasyErrorHandler/Trait/EasyErrorHandlerAssertionTrait.php
+++ b/packages/EasyTest/src/EasyErrorHandler/Trait/EasyErrorHandlerAssertionTrait.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace EonX\EasyTest\EasyErrorHandler\Trait;
 
-use EonX\EasyErrorHandler\Common\ErrorHandler\ErrorHandlerInterface;
 use EonX\EasyTest\EasyErrorHandler\ErrorHandler\TraceableErrorHandlerStub;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
@@ -56,51 +55,6 @@ trait EasyErrorHandlerAssertionTrait
                 ? \sprintf(' Not reported errors: %s.', \implode(', ', self::getErrorHandlerReportedErrors()))
                 : ' No reported errors.')
         );
-    }
-
-    /**
-     * @deprecated
-     */
-    protected function assertEmptyReportedErrors(): void
-    {
-        self::assertCount(
-            0,
-            $this->getErrorHandlerReportedThrowables(),
-            'The list of reported errors is not empty.'
-        );
-    }
-
-    /**
-     * @deprecated
-     */
-    protected function assertErrorCodeExistsInReportedErrors(int $errorCode): void
-    {
-        $errorCodeExists = false;
-        foreach ($this->getErrorHandlerReportedThrowables() as $exception) {
-            if ($exception->getCode() === $errorCode) {
-                $errorCodeExists = true;
-
-                break;
-            }
-        }
-
-        self::assertTrue(
-            $errorCodeExists,
-            \sprintf('There is no error with the "%s" error code in reported errors.', $errorCode)
-        );
-    }
-
-    /**
-     * @return \Throwable[]
-     *
-     * @deprecated
-     */
-    protected function getErrorHandlerReportedThrowables(): array
-    {
-        /** @var \EonX\EasyErrorHandler\Common\ErrorHandler\TraceableErrorHandlerInterface $errorHandler */
-        $errorHandler = self::getService(ErrorHandlerInterface::class);
-
-        return $errorHandler->getReportedErrors();
     }
 
     private static function checkErrorHandlerReportedErrorsAsserted(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
