### PR TITLE
[EasyWebhook] Block SSRF via outgoing webhook requests

### DIFF
--- a/packages/EasyWebhook/bundle/EasyWebhookBundle.php
+++ b/packages/EasyWebhook/bundle/EasyWebhookBundle.php
@@ -41,6 +41,15 @@ final class EasyWebhookBundle extends AbstractBundle
         $container
             ->parameters()
             ->set(ConfigParam::Method->value, $config['method'])
+            ->set(ConfigParam::SsrfProtectionEnabled->value, $config['ssrf_protection']['enabled'])
+            ->set(
+                ConfigParam::SsrfProtectionExtraBlockedRanges->value,
+                $config['ssrf_protection']['extra_blocked_ranges']
+            )
+            ->set(
+                ConfigParam::SsrfProtectionAllowedRanges->value,
+                $config['ssrf_protection']['allowed_ranges']
+            )
             ->set(ConfigParam::RequestLimitsEnabled->value, $config['request_limits']['enabled'])
             ->set(ConfigParam::RequestTimeout->value, $config['request_limits']['timeout'])
             ->set(ConfigParam::RequestMaxDuration->value, $config['request_limits']['max_duration'])

--- a/packages/EasyWebhook/bundle/Enum/ConfigParam.php
+++ b/packages/EasyWebhook/bundle/Enum/ConfigParam.php
@@ -26,4 +26,10 @@ enum ConfigParam: string
     case Secret = 'easy_webhooks.secret';
 
     case SignatureHeader = 'easy_webhooks.signature_header';
+
+    case SsrfProtectionAllowedRanges = 'easy_webhooks.ssrf_protection.allowed_ranges';
+
+    case SsrfProtectionEnabled = 'easy_webhooks.ssrf_protection.enabled';
+
+    case SsrfProtectionExtraBlockedRanges = 'easy_webhooks.ssrf_protection.extra_blocked_ranges';
 }

--- a/packages/EasyWebhook/bundle/config/definition.php
+++ b/packages/EasyWebhook/bundle/config/definition.php
@@ -1,9 +1,11 @@
 <?php
 declare(strict_types=1);
 
+use EonX\EasyWebhook\Common\Exception\InvalidSsrfProtectionConfigException;
 use EonX\EasyWebhook\Common\Factory\HttpClientFactory;
 use EonX\EasyWebhook\Common\Signer\Rs256WebhookSigner;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 return static function (DefinitionConfigurator $definition) {
     $definition->rootNode()
@@ -33,6 +35,52 @@ return static function (DefinitionConfigurator $definition) {
                     ->stringNode('header')->defaultNull()->end()
                     ->stringNode('signer')->defaultValue(Rs256WebhookSigner::class)->end()
                     ->stringNode('secret')->defaultNull()->end()
+                ->end()
+            ->end()
+            ->arrayNode('ssrf_protection')
+                ->canBeDisabled()
+                ->validate()
+                    ->always(static function (array $v): array {
+                        // Disabled means allowed_ranges is inert, so don't fail the build on it
+                        if ($v['enabled'] === false) {
+                            return $v;
+                        }
+
+                        // Fail at container build on an allowed_ranges entry that would do nothing
+                        try {
+                            HttpClientFactory::validateAllowedRanges(
+                                $v['extra_blocked_ranges'],
+                                $v['allowed_ranges']
+                            );
+                        } catch (InvalidSsrfProtectionConfigException $exception) {
+                            throw new InvalidConfigurationException($exception->getMessage(), previous: $exception);
+                        }
+
+                        return $v;
+                    })
+                ->end()
+                ->children()
+                    ->arrayNode('extra_blocked_ranges')
+                        ->info(
+                            'Additional CIDR ranges to reject as SSRF targets, on top of the standard '
+                            . 'private + reserved defaults (which include the link-local 169.254.0.0/16 '
+                            . 'used by cloud metadata endpoints). Checked against the resolved IP of every '
+                            . 'request and redirect hop.'
+                        )
+                        ->defaultValue([])
+                        ->stringPrototype()->end()
+                    ->end()
+                    ->arrayNode('allowed_ranges')
+                        ->info(
+                            'CIDR ranges to unblock by REMOVING a matching entry from the default block '
+                            . 'list (e.g. "127.0.0.0/8" to reach IPv4 localhost). Each entry must match a '
+                            . 'default range verbatim and must not be covered by another default (e.g. '
+                            . '"::1/128" is inside "::/96"), otherwise it is rejected at startup. To reach '
+                            . 'hosts this cannot express, use "enabled: false".'
+                        )
+                        ->defaultValue([])
+                        ->stringPrototype()->end()
+                    ->end()
                 ->end()
             ->end()
             ->arrayNode('request_limits')

--- a/packages/EasyWebhook/bundle/config/services.php
+++ b/packages/EasyWebhook/bundle/config/services.php
@@ -49,6 +49,9 @@ return static function (ContainerConfigurator $container): void {
     $services
         // Factory
         ->set(HttpClientFactoryInterface::class, HttpClientFactory::class)
+        ->arg('$blockPrivateNetworks', param(ConfigParam::SsrfProtectionEnabled->value))
+        ->arg('$extraBlockedRanges', param(ConfigParam::SsrfProtectionExtraBlockedRanges->value))
+        ->arg('$allowedRanges', param(ConfigParam::SsrfProtectionAllowedRanges->value))
         ->arg('$requestLimitsEnabled', param(ConfigParam::RequestLimitsEnabled->value))
         ->arg('$timeout', param(ConfigParam::RequestTimeout->value))
         ->arg('$maxDuration', param(ConfigParam::RequestMaxDuration->value))

--- a/packages/EasyWebhook/docs/config.md
+++ b/packages/EasyWebhook/docs/config.md
@@ -31,6 +31,9 @@ The common configuration options for Laravel and Symfony are as follows:
 | `signature.header`       | `X-Webhook-Signature` | Name of the Signature header                                                                           |
 | `signature.signer`       | `Rs256Signer:class`   | Class to use for signing the webhook HTTP request body                                                 |
 | `signature.secret`       | N/A                   | Secret to use when signing the webhook HTTP request body                                               |
+| `ssrf_protection.enabled`        | `true`        | Whether outgoing webhook requests are blocked from reaching private/reserved IP ranges (SSRF protection) |
+| `ssrf_protection.extra_blocked_ranges` | `[]`    | Additional CIDR ranges to reject **on top of** the standard private + reserved defaults (incl. link-local `169.254.0.0/16`) |
+| `ssrf_protection.allowed_ranges` | `[]`          | CIDR ranges to unblock by **removing a matching entry** from the default block list (e.g. `127.0.0.0/8` for IPv4 localhost). Must match a default verbatim and not be covered by another default (e.g. `::1/128` is inside `::/96`), else rejected at startup |
 | `request_limits.enabled`            | `false`    | Enable the DoS request limits below (opt-in; the default will flip to `true` in a future major) |
 | `request_limits.timeout`            | `10`       | Idle timeout in seconds — abort when the target stops sending data. `0` keeps PHP's `default_socket_timeout` |
 | `request_limits.max_duration`       | `30`       | Total request-duration cap in seconds, regardless of activity. `0` = unlimited                          |
@@ -80,6 +83,42 @@ Retry behaviour differs by limit type, and neither is a crash:
   configured retry strategy — the target may simply have been slow.
 - A **size**-limit abort (`max_response_bytes`) is a failed webhook that is **not retried** —
   retrying would only re-download the same oversized body.
+
+## SSRF protection
+
+Webhook URLs are frequently supplied by external parties (for example, tenant-registered
+subscription URLs). Without egress control, an attacker can point a webhook at an internal
+address — the cloud metadata endpoint (`169.254.169.254`), loopback, or another private host
+— and have your server fetch it (Server-Side Request Forgery).
+
+A URL-string check cannot catch DNS-rebinding (a public hostname that resolves to a private
+IP) or a redirect to an internal target, so EasyWebhook enforces the block on the **resolved
+IP of every request and every redirect hop**, using Symfony's `NoPrivateNetworkHttpClient`.
+
+This protection is **enabled by default**. It exposes two narrowing knobs, plus an all-or-nothing
+switch (`ssrf_protection.enabled: false`) to turn it off entirely. Both knobs build on the full
+defaults, so the cloud-metadata endpoint and every IPv6 range stay covered, and the two can be
+combined.
+
+Use `ssrf_protection.extra_blocked_ranges` to reject ranges *on top of* the defaults. This exists
+because the one thing the library cannot know is your project's own **publicly routable** internal
+ranges: those are not private or reserved, so the built-in defaults do not cover them. For example,
+if an internal-only admin service sits behind the public range `203.0.113.0/24` that no webhook
+should ever reach, block it with `extra_blocked_ranges: ['203.0.113.0/24']`.
+
+Use `ssrf_protection.allowed_ranges` to reach specific addresses by **removing a matching entry from
+the default block list** — it is a list edit, not a general "allow this address". Each entry must be
+one of the default ranges written verbatim; the usual case is reaching IPv4 localhost with
+`allowed_ranges: ['127.0.0.0/8']`. Because it only removes the entry you name, it can unblock an
+address only when no other default range also covers it — for example `::1/128` sits inside the
+`::/96` default, so IPv6 loopback cannot be carved out this way. Anything that would have no effect
+(an entry that is not a default, or one still covered by a broader default) is **rejected at
+startup** rather than silently ignored. To reach hosts this cannot express, turn the protection off
+with `ssrf_protection.enabled: false`.
+
+> Note: enabling this by default is a behavioural change — webhooks whose URL resolves to a
+> private or reserved IP are now rejected out of the box (surfaced as a failed webhook, not a
+> crash). Set `ssrf_protection.enabled` to `false` to restore the previous behaviour.
 
 ## Example configuration files
 

--- a/packages/EasyWebhook/laravel/EasyWebhookServiceProvider.php
+++ b/packages/EasyWebhook/laravel/EasyWebhookServiceProvider.php
@@ -196,6 +196,9 @@ final class EasyWebhookServiceProvider extends ServiceProvider
         $this->app->singleton(
             HttpClientFactoryInterface::class,
             static fn (): HttpClientFactoryInterface => new HttpClientFactory(
+                (bool)\config('easy-webhook.ssrf_protection.enabled', true),
+                (array)\config('easy-webhook.ssrf_protection.extra_blocked_ranges', []),
+                (array)\config('easy-webhook.ssrf_protection.allowed_ranges', []),
                 (bool)\config('easy-webhook.request_limits.enabled', false),
                 // ?? keeps a present-but-null value (e.g. an unset env() override) falling back to
                 // the intended default instead of casting to 0, which would silently disable the limit

--- a/packages/EasyWebhook/laravel/config/easy-webhook.php
+++ b/packages/EasyWebhook/laravel/config/easy-webhook.php
@@ -21,6 +21,22 @@ return [
         'header' => 'X-Webhook-Signature',
         'signer' => Rs256WebhookSigner::class,
     ],
+    'ssrf_protection' => [
+        'enabled' => true,
+
+        /**
+         * Additional CIDR ranges to reject on top of the private + reserved defaults.
+         */
+        'extra_blocked_ranges' => [],
+
+        /**
+         * CIDR ranges to unblock by REMOVING a matching entry from the default block list (e.g.
+         * "127.0.0.0/8" to reach IPv4 localhost). Each entry must match a default range verbatim
+         * and must not be covered by another default (e.g. "::1/128" is inside "::/96"), otherwise
+         * it is rejected at startup. To reach hosts this cannot express, use "enabled" => false.
+         */
+        'allowed_ranges' => [],
+    ],
     'request_limits' => [
         'enabled' => false,
         'timeout' => HttpClientFactory::DEFAULT_TIMEOUT,

--- a/packages/EasyWebhook/src/Common/Exception/InvalidSsrfProtectionConfigException.php
+++ b/packages/EasyWebhook/src/Common/Exception/InvalidSsrfProtectionConfigException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyWebhook\Common\Exception;
+
+/**
+ * Thrown when the SSRF-protection configuration is invalid — for example an "allowed_ranges" entry
+ * that would not actually unblock anything (it is not a default range, or it stays covered by a
+ * broader default).
+ */
+final class InvalidSsrfProtectionConfigException extends AbstractEasyWebhookException
+{
+    // No body needed
+}

--- a/packages/EasyWebhook/src/Common/Factory/HttpClientFactory.php
+++ b/packages/EasyWebhook/src/Common/Factory/HttpClientFactory.php
@@ -3,8 +3,11 @@ declare(strict_types=1);
 
 namespace EonX\EasyWebhook\Common\Factory;
 
+use EonX\EasyWebhook\Common\Exception\InvalidSsrfProtectionConfigException;
 use EonX\EasyWebhook\Common\HttpClient\RequestLimitsHttpClient;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final readonly class HttpClientFactory implements HttpClientFactoryInterface
@@ -15,12 +18,66 @@ final readonly class HttpClientFactory implements HttpClientFactoryInterface
 
     public const DEFAULT_TIMEOUT = 10;
 
+    /**
+     * @param string[] $extraBlockedRanges
+     * @param string[] $allowedRanges
+     */
     public function __construct(
+        private bool $blockPrivateNetworks = true,
+        private array $extraBlockedRanges = [],
+        private array $allowedRanges = [],
         private bool $requestLimitsEnabled = false,
         private int $timeout = self::DEFAULT_TIMEOUT,
         private int $maxDuration = self::DEFAULT_MAX_DURATION,
         private int $maxResponseBytes = self::DEFAULT_MAX_RESPONSE_BYTES,
     ) {
+        // Only when protection is on; disabled means allowed_ranges is inert, so don't reject it
+        if ($blockPrivateNetworks) {
+            self::validateAllowedRanges($extraBlockedRanges, $allowedRanges);
+        }
+    }
+
+    /**
+     * Rejects an "allowed_ranges" entry that would silently do nothing, so a broken config fails at
+     * startup instead of leaving a host the operator believes is reachable still blocked. Called
+     * from the Symfony config validator (fails at container build) and from the constructor
+     * (Laravel / direct instantiation).
+     *
+     * @param string[] $extraBlockedRanges
+     * @param string[] $allowedRanges
+     */
+    public static function validateAllowedRanges(array $extraBlockedRanges, array $allowedRanges): void
+    {
+        if ($allowedRanges === []) {
+            return;
+        }
+
+        $blockSource = [...IpUtils::PRIVATE_SUBNETS, ...$extraBlockedRanges];
+        $subnets = \array_values(\array_diff($blockSource, $allowedRanges));
+
+        foreach ($allowedRanges as $range) {
+            if (\in_array($range, $blockSource, true) === false) {
+                throw new InvalidSsrfProtectionConfigException(\sprintf(
+                    'SSRF "allowed_ranges" entry "%s" does not match any blocked range, so it has no '
+                    . 'effect. It must be one of the default private/reserved ranges (or an '
+                    . '"extra_blocked_ranges" entry) written exactly as listed.',
+                    $range
+                ));
+            }
+
+            // The allowed_ranges option removes a matching entry from the block list, so it can
+            // only reach an address that entry is the sole cover for. If a broader default still
+            // covers it (e.g. "::1/128" sits inside "::/96"), removing the exact string leaves the
+            // address blocked; removing the broader range instead would be far too permissive
+            if (IpUtils::checkIp(\explode('/', $range)[0], $subnets)) {
+                throw new InvalidSsrfProtectionConfigException(\sprintf(
+                    'SSRF "allowed_ranges" entry "%s" cannot be carved out: a broader default range '
+                    . 'still covers it (for example "::1/128" is covered by "::/96"). This is not '
+                    . 'supported; use "ssrf_protection.enabled: false" to reach such hosts.',
+                    $range
+                ));
+            }
+        }
     }
 
     public function create(): HttpClientInterface
@@ -29,22 +86,38 @@ final readonly class HttpClientFactory implements HttpClientFactoryInterface
             'http_version' => '1.1',
         ]);
 
-        // @todo Change the default to enabled (on) in 7.x
-        // Opt-in: with the guards off, hand back the bare client
-        if ($this->requestLimitsEnabled === false) {
-            return $httpClient;
+        // SSRF guard (enabled by default): reject any request whose resolved peer IP falls in a
+        // blocked range, re-checked on every redirect hop. This defeats both DNS-rebinding (the
+        // resolved IP is inspected, not the hostname) and redirect-to-internal, neither of which a
+        // URL-string check can catch. Range selection:
+        // - both empty -> null, i.e. the full standard private + reserved defaults (incl. link-local
+        // 169.254.0.0/16 used by cloud metadata endpoints); null gets the widest coverage
+        // - otherwise -> the defaults PLUS extraBlockedRanges, MINUS allowedRanges. Building on the
+        // defaults keeps IPv6 entries in the list, which NoPrivateNetworkHttpClient needs to check
+        // IPv6 peers at all; validateAllowedRanges() has already rejected a no-op allowedRanges entry
+        if ($this->blockPrivateNetworks) {
+            $subnets = $this->extraBlockedRanges === [] && $this->allowedRanges === []
+                ? null
+                : \array_values(\array_diff(
+                    [...IpUtils::PRIVATE_SUBNETS, ...$this->extraBlockedRanges],
+                    $this->allowedRanges
+                ));
+
+            $httpClient = new NoPrivateNetworkHttpClient($httpClient, $subnets);
         }
 
-        // Every limit is enforced inside the decorator, not as a client-default option: a webhook's
-        // own http client options are merged per request and win over client defaults, so a
-        // client-default timeout/max_duration could be silently overridden (or disabled with 0) by
-        // the webhook. RequestLimitsHttpClient clamps them per request instead. Each limit is
-        // no-op'd by the decorator when its value is 0
-        return new RequestLimitsHttpClient(
-            $httpClient,
-            $this->timeout,
-            $this->maxDuration,
-            $this->maxResponseBytes,
-        );
+        // DoS request limits (opt-in): enforced inside the decorator, not as client-default options,
+        // so a per-webhook http client option cannot silently raise or disable them.
+        // @todo Change the default to enabled (on) in 7.x
+        if ($this->requestLimitsEnabled) {
+            $httpClient = new RequestLimitsHttpClient(
+                $httpClient,
+                $this->timeout,
+                $this->maxDuration,
+                $this->maxResponseBytes,
+            );
+        }
+
+        return $httpClient;
     }
 }

--- a/packages/EasyWebhook/tests/Unit/src/Common/Factory/HttpClientFactoryTest.php
+++ b/packages/EasyWebhook/tests/Unit/src/Common/Factory/HttpClientFactoryTest.php
@@ -3,22 +3,55 @@ declare(strict_types=1);
 
 namespace EonX\EasyWebhook\Tests\Unit\Common\Factory;
 
+use EonX\EasyWebhook\Common\Exception\InvalidSsrfProtectionConfigException;
 use EonX\EasyWebhook\Common\Factory\HttpClientFactory;
 use EonX\EasyWebhook\Common\HttpClient\RequestLimitsHttpClient;
 use EonX\EasyWebhook\Tests\Unit\AbstractUnitTestCase;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class HttpClientFactoryTest extends AbstractUnitTestCase
 {
+    /**
+     * allowed_ranges must carve out only the range it removes: after allowing IPv4 localhost, a
+     * loopback request passes the SSRF gate while the cloud metadata endpoint stays blocked. The
+     * gate runs synchronously in request(), which is otherwise lazy, so no network call is made
+     */
+    public function testAllowedRangesCarveOutMatchingDefaultButKeepOthersBlocked(): void
+    {
+        $httpClient = (new HttpClientFactory(allowedRanges: ['127.0.0.0/8']))->create();
+
+        $response = $httpClient->request('GET', 'http://127.0.0.1/');
+        $response->cancel();
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertRequestBlocked($httpClient, 'http://169.254.169.254/latest/meta-data/');
+    }
+
     public function testCreate(): void
     {
         self::assertInstanceOf(HttpClientInterface::class, (new HttpClientFactory())->create());
     }
 
-    public function testCreateAppliesNoLimitsWhenDisabledByDefault(): void
+    public function testCreateAppliesNoRequestLimitsWhenDisabledByDefault(): void
     {
-        // Opt-in: disabled by default, so the request limits are not enforced at all
+        // Request limits are opt-in, so by default the client is not wrapped by RequestLimitsHttpClient
         self::assertNotInstanceOf(RequestLimitsHttpClient::class, (new HttpClientFactory())->create());
+    }
+
+    public function testCreateBlocksExtraRanges(): void
+    {
+        self::assertInstanceOf(
+            NoPrivateNetworkHttpClient::class,
+            (new HttpClientFactory(extraBlockedRanges: ['8.8.8.8/32']))->create()
+        );
+    }
+
+    public function testCreateBlocksPrivateNetworksByDefault(): void
+    {
+        self::assertInstanceOf(NoPrivateNetworkHttpClient::class, (new HttpClientFactory())->create());
     }
 
     public function testCreateEnforcesRequestLimitsWhenEnabled(): void
@@ -27,5 +60,108 @@ final class HttpClientFactoryTest extends AbstractUnitTestCase
             RequestLimitsHttpClient::class,
             (new HttpClientFactory(requestLimitsEnabled: true))->create()
         );
+    }
+
+    public function testCreateReturnsPlainClientWhenProtectionDisabled(): void
+    {
+        $httpClient = (new HttpClientFactory(blockPrivateNetworks: false))->create();
+
+        self::assertInstanceOf(HttpClientInterface::class, $httpClient);
+        self::assertNotInstanceOf(NoPrivateNetworkHttpClient::class, $httpClient);
+    }
+
+    public function testCreateWithAllowedRanges(): void
+    {
+        self::assertInstanceOf(
+            NoPrivateNetworkHttpClient::class,
+            (new HttpClientFactory(allowedRanges: ['127.0.0.0/8']))->create()
+        );
+    }
+
+    public function testDoesNotValidateAllowedRangesWhenProtectionDisabled(): void
+    {
+        // Protection off -> allowed_ranges is inert, so an otherwise-invalid entry must not throw
+        $httpClient = (new HttpClientFactory(blockPrivateNetworks: false, allowedRanges: ['8.8.8.8/32']))
+            ->create();
+
+        self::assertNotInstanceOf(NoPrivateNetworkHttpClient::class, $httpClient);
+    }
+
+    /**
+     * extra_blocked_ranges must be added to the defaults, not replace them: the extra range and
+     * the standard private/reserved ranges are both blocked
+     */
+    public function testExtraBlockedRangesAddToDefaultsWithoutReplacing(): void
+    {
+        $httpClient = (new HttpClientFactory(extraBlockedRanges: ['8.8.8.8/32']))->create();
+
+        $this->assertRequestBlocked($httpClient, 'http://8.8.8.8/');
+        $this->assertRequestBlocked($httpClient, 'http://169.254.169.254/latest/meta-data/');
+    }
+
+    public function testRejectsAllowedRangeCoveredByBroaderRange(): void
+    {
+        // Build the overlap from our own ranges so it does not depend on Symfony's version-specific
+        // defaults (e.g. ::/96 only exists from http-foundation 7.4.13). Removing 203.0.113.5/32
+        // leaves it covered by the broader 203.0.113.0/24, so the address stays blocked; this must
+        // fail loudly, not silently do nothing
+        $this->expectException(InvalidSsrfProtectionConfigException::class);
+
+        new HttpClientFactory(
+            extraBlockedRanges: ['203.0.113.0/24', '203.0.113.5/32'],
+            allowedRanges: ['203.0.113.5/32']
+        );
+    }
+
+    public function testRejectsAllowedRangeThatIsNotADefault(): void
+    {
+        // A non-default range (typo, non-canonical CIDR, or public IP) would carve out nothing
+        $this->expectException(InvalidSsrfProtectionConfigException::class);
+
+        new HttpClientFactory(allowedRanges: ['8.8.8.8/32']);
+    }
+
+    /**
+     * A request whose resolved IP falls in a blocked range is rejected up-front, before any
+     * connection is attempted, so this is deterministic and needs no network. The link-local
+     * 169.254.0.0/16 range covers the cloud metadata endpoint that SSRF payloads target
+     */
+    public function testRequestToCloudMetadataEndpointIsBlocked(): void
+    {
+        $httpClient = (new HttpClientFactory())->create();
+
+        $this->expectException(TransportExceptionInterface::class);
+
+        $httpClient->request('GET', 'http://169.254.169.254/latest/meta-data/');
+    }
+
+    /**
+     * DNS-rebinding: a public hostname pinned (via the resolve option, so no real lookup) to the
+     * cloud metadata IP. This is the case a URL-string check cannot catch and is what this guard
+     * really buys — the block is enforced on the RESOLVED IP, which NoPrivateNetworkHttpClient
+     * inspects before any connection
+     */
+    public function testRequestToPublicHostResolvingToPrivateIpIsBlocked(): void
+    {
+        $httpClient = (new HttpClientFactory())->create();
+
+        $this->expectException(TransportExceptionInterface::class);
+
+        $httpClient->request('GET', 'http://evil.example.com/', [
+            'resolve' => ['evil.example.com' => '169.254.169.254'],
+        ]);
+    }
+
+    private function assertRequestBlocked(HttpClientInterface $httpClient, string $url): void
+    {
+        $blocked = false;
+
+        try {
+            $httpClient->request('GET', $url);
+        } catch (TransportExceptionInterface) {
+            $blocked = true;
+        }
+
+        self::assertTrue($blocked, "Expected request to {$url} to be blocked");
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Webhook URLs are often supplied by external parties (tenant subscriptions), and we sent
requests to any URL with no egress control — an attacker could hit the cloud metadata endpoint
(`169.254.169.254`), loopback, or internal hosts (SSRF). A URL-string check (`Assert\Url`)
can't stop this: it misses DNS-rebinding and redirects to internal targets.

`HttpClientFactory` now wraps the client in Symfony's `NoPrivateNetworkHttpClient`, which checks
the **resolved IP of every request and redirect hop** and rejects blocked ranges. Blocked
requests surface as failed webhooks, not crashes. Secure-by-default even without DI.

New `ssrf_protection` config (Symfony + Laravel):
- `enabled` (default `true`)
- `blocked_ranges` (default `[]` = standard private + reserved set, incl. `169.254.0.0/16`); a custom list **OVERRIDES** the default (replaces, not merged), so it can only narrow protection.

⚠️ **BC:** on by default — webhooks resolving to private/reserved IPs are now rejected.