### PR TITLE
[EasyBankFiles] Fix cents corruption in NAI/BAI control totals

### DIFF
--- a/packages/EasyBankFiles/src/Parsing/Nai/ValueObject/ControlTotalTrait.php
+++ b/packages/EasyBankFiles/src/Parsing/Nai/ValueObject/ControlTotalTrait.php
@@ -6,14 +6,11 @@ namespace EonX\EasyBankFiles\Parsing\Nai\ValueObject;
 trait ControlTotalTrait
 {
     /**
-     * Format amount/total from string to float. The last two digits are the cents and are kept
-     * as-is, including a leading zero (%02d) — dropping it (%d) both corrupts cents 01-09 and
-     * makes different totals collide (e.g. 10001 and 10010).
+     * The on-file value is an integer number of implied cents that may carry a leading sign,
+     * so the amount is that value divided by 100.
      */
     private function formatAmount(string $amount): float
     {
-        $length = \strlen($amount) - 2;
-
-        return (float)\sprintf('%d.%02d', (int)\substr($amount, 0, $length), (int)\substr($amount, $length));
+        return (float)$amount / 100;
     }
 }

--- a/packages/EasyBankFiles/src/Parsing/Nai/ValueObject/ControlTotalTrait.php
+++ b/packages/EasyBankFiles/src/Parsing/Nai/ValueObject/ControlTotalTrait.php
@@ -6,12 +6,14 @@ namespace EonX\EasyBankFiles\Parsing\Nai\ValueObject;
 trait ControlTotalTrait
 {
     /**
-     * Format amount/total from string to float.
+     * Format amount/total from string to float. The last two digits are the cents and are kept
+     * as-is, including a leading zero (%02d) — dropping it (%d) both corrupts cents 01-09 and
+     * makes different totals collide (e.g. 10001 and 10010).
      */
     private function formatAmount(string $amount): float
     {
         $length = \strlen($amount) - 2;
 
-        return (float)\sprintf('%d.%d', (int)\substr($amount, 0, $length), (int)\substr($amount, $length));
+        return (float)\sprintf('%d.%02d', (int)\substr($amount, 0, $length), (int)\substr($amount, $length));
     }
 }

--- a/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/Parser/NaiParserTest.php
+++ b/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/Parser/NaiParserTest.php
@@ -12,6 +12,7 @@ use EonX\EasyBankFiles\Parsing\Nai\ValueObject\ResultsContext;
 use EonX\EasyBankFiles\Parsing\Nai\ValueObject\TransactionDetailCodesTrait;
 use EonX\EasyBankFiles\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(AccountSummaryCodesTrait::class)]
 #[CoversClass(ControlTotalTrait::class)]
@@ -20,6 +21,27 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(TransactionDetailCodesTrait::class)]
 final class NaiParserTest extends AbstractUnitTestCase
 {
+    /**
+     * Distinct expected values (10001 -> 100.01 vs 10010 -> 100.10) also pin down that two
+     * genuinely different control totals never collapse to the same value, which would defeat an
+     * equality-based reconciliation check.
+     *
+     * @see testControlTotalTraitReturnFormattedAmount
+     */
+    public static function provideControlTotals(): iterable
+    {
+        yield 'whole dollars' => ['amount' => '10000', 'expected' => 100.00];
+        yield 'one cent' => ['amount' => '10001', 'expected' => 100.01];
+        yield 'five cents' => ['amount' => '10005', 'expected' => 100.05];
+        yield 'nine cents' => ['amount' => '10009', 'expected' => 100.09];
+        yield 'ten cents' => ['amount' => '10010', 'expected' => 100.10];
+        yield 'ninety-nine cents' => ['amount' => '10099', 'expected' => 100.99];
+        yield 'implied cents only' => ['amount' => '1', 'expected' => 0.01];
+        yield 'negative' => ['amount' => '-13467', 'expected' => -134.67];
+        yield 'negative dollars and cents' => ['amount' => '-10001', 'expected' => -100.01];
+        yield 'small negative' => ['amount' => '-99', 'expected' => -0.99];
+    }
+
     public function testBai2FromUSSucceeds(): void
     {
         $parser = new NaiParser($this->getSampleFileContents('fundsTypesCases.BAI'), true);
@@ -31,14 +53,21 @@ final class NaiParserTest extends AbstractUnitTestCase
     }
 
     /**
-     * ControlTotal should format amount as expected.
+     * ControlTotal formats an on-file cents amount into a float, preserving leading-zero cents.
      */
-    public function testControlTotalTraitReturnFormattedAmount(): void
+    #[DataProvider('provideControlTotals')]
+    public function testControlTotalTraitReturnFormattedAmount(string $amount, float $expected): void
     {
-        $trait = $this->getObjectForTrait(ControlTotalTrait::class);
+        $trait = new class() {
+            use ControlTotalTrait;
 
-        self::assertIsFloat($this->callPrivateMethod($trait, 'formatAmount', '100000'));
-        self::assertSame(100.0, $this->callPrivateMethod($trait, 'formatAmount', '10000'));
+            public function format(string $amount): float
+            {
+                return $this->formatAmount($amount);
+            }
+        };
+
+        self::assertSame($expected, $trait->format($amount));
     }
 
     public function testParserCanParseBaiFile(): void

--- a/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/ValueObject/FileTrailerTest.php
+++ b/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/ValueObject/FileTrailerTest.php
@@ -25,6 +25,18 @@ final class FileTrailerTest extends AbstractUnitTestCase
     }
 
     /**
+     * Two genuinely different control totals (e.g. $100.01 vs $100.10) must not collapse to the
+     * same value, otherwise an equality-based reconciliation check cannot tell them apart.
+     */
+    public function testDistinctCentsDoNotCollide(): void
+    {
+        $oneCent = (new FileTrailer(['fileControlTotalA' => '10001']))->getFileControlTotalA();
+        $tenCents = (new FileTrailer(['fileControlTotalA' => '10010']))->getFileControlTotalA();
+
+        self::assertNotSame($oneCent, $tenCents);
+    }
+
+    /**
      * The last two digits of a control total are the cents and must be preserved exactly,
      * including a leading zero (cents 01-09).
      */
@@ -60,17 +72,5 @@ final class FileTrailerTest extends AbstractUnitTestCase
         self::assertSame((float)100, $trailer->getFileControlTotalB());
         self::assertSame($data['numberOfGroups'], $trailer->getNumberOfGroups());
         self::assertSame($data['numberOfRecords'], $trailer->getNumberOfRecords());
-    }
-
-    /**
-     * Two genuinely different control totals (e.g. $100.01 vs $100.10) must not collapse to the
-     * same value, otherwise an equality-based reconciliation check cannot tell them apart.
-     */
-    public function testDistinctCentsDoNotCollide(): void
-    {
-        $oneCent = (new FileTrailer(['fileControlTotalA' => '10001']))->getFileControlTotalA();
-        $tenCents = (new FileTrailer(['fileControlTotalA' => '10010']))->getFileControlTotalA();
-
-        self::assertNotSame($oneCent, $tenCents);
     }
 }

--- a/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/ValueObject/FileTrailerTest.php
+++ b/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/ValueObject/FileTrailerTest.php
@@ -6,52 +6,10 @@ namespace EonX\EasyBankFiles\Tests\Unit\Parsing\Nai\ValueObject;
 use EonX\EasyBankFiles\Parsing\Nai\ValueObject\FileTrailer;
 use EonX\EasyBankFiles\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(FileTrailer::class)]
 final class FileTrailerTest extends AbstractUnitTestCase
 {
-    /**
-     * @see testFormatsControlTotalCents
-     */
-    public static function provideControlTotalCents(): iterable
-    {
-        yield 'zero cents' => ['onFile' => '10000', 'expected' => 100.00];
-        yield 'one cent' => ['onFile' => '10001', 'expected' => 100.01];
-        yield 'five cents' => ['onFile' => '10005', 'expected' => 100.05];
-        yield 'nine cents' => ['onFile' => '10009', 'expected' => 100.09];
-        yield 'ten cents' => ['onFile' => '10010', 'expected' => 100.10];
-        yield 'ninety-nine cents' => ['onFile' => '10099', 'expected' => 100.99];
-    }
-
-    /**
-     * Two genuinely different control totals (e.g. $100.01 vs $100.10) must not collapse to the
-     * same value, otherwise an equality-based reconciliation check cannot tell them apart.
-     */
-    public function testDistinctCentsDoNotCollide(): void
-    {
-        $oneCent = (new FileTrailer(['fileControlTotalA' => '10001']))->getFileControlTotalA();
-        $tenCents = (new FileTrailer(['fileControlTotalA' => '10010']))->getFileControlTotalA();
-
-        self::assertNotSame($oneCent, $tenCents);
-    }
-
-    /**
-     * The last two digits of a control total are the cents and must be preserved exactly,
-     * including a leading zero (cents 01-09).
-     */
-    #[DataProvider('provideControlTotalCents')]
-    public function testFormatsControlTotalCents(string $onFile, float $expected): void
-    {
-        $trailer = new FileTrailer([
-            'fileControlTotalA' => $onFile,
-            'fileControlTotalB' => $onFile,
-        ]);
-
-        self::assertSame($expected, $trailer->getFileControlTotalA());
-        self::assertSame($expected, $trailer->getFileControlTotalB());
-    }
-
     /**
      * Result should return data as expected.
      */

--- a/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/ValueObject/FileTrailerTest.php
+++ b/packages/EasyBankFiles/tests/Unit/src/Parsing/Nai/ValueObject/FileTrailerTest.php
@@ -6,10 +6,40 @@ namespace EonX\EasyBankFiles\Tests\Unit\Parsing\Nai\ValueObject;
 use EonX\EasyBankFiles\Parsing\Nai\ValueObject\FileTrailer;
 use EonX\EasyBankFiles\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(FileTrailer::class)]
 final class FileTrailerTest extends AbstractUnitTestCase
 {
+    /**
+     * @see testFormatsControlTotalCents
+     */
+    public static function provideControlTotalCents(): iterable
+    {
+        yield 'zero cents' => ['onFile' => '10000', 'expected' => 100.00];
+        yield 'one cent' => ['onFile' => '10001', 'expected' => 100.01];
+        yield 'five cents' => ['onFile' => '10005', 'expected' => 100.05];
+        yield 'nine cents' => ['onFile' => '10009', 'expected' => 100.09];
+        yield 'ten cents' => ['onFile' => '10010', 'expected' => 100.10];
+        yield 'ninety-nine cents' => ['onFile' => '10099', 'expected' => 100.99];
+    }
+
+    /**
+     * The last two digits of a control total are the cents and must be preserved exactly,
+     * including a leading zero (cents 01-09).
+     */
+    #[DataProvider('provideControlTotalCents')]
+    public function testFormatsControlTotalCents(string $onFile, float $expected): void
+    {
+        $trailer = new FileTrailer([
+            'fileControlTotalA' => $onFile,
+            'fileControlTotalB' => $onFile,
+        ]);
+
+        self::assertSame($expected, $trailer->getFileControlTotalA());
+        self::assertSame($expected, $trailer->getFileControlTotalB());
+    }
+
     /**
      * Result should return data as expected.
      */
@@ -30,5 +60,17 @@ final class FileTrailerTest extends AbstractUnitTestCase
         self::assertSame((float)100, $trailer->getFileControlTotalB());
         self::assertSame($data['numberOfGroups'], $trailer->getNumberOfGroups());
         self::assertSame($data['numberOfRecords'], $trailer->getNumberOfRecords());
+    }
+
+    /**
+     * Two genuinely different control totals (e.g. $100.01 vs $100.10) must not collapse to the
+     * same value, otherwise an equality-based reconciliation check cannot tell them apart.
+     */
+    public function testDistinctCentsDoNotCollide(): void
+    {
+        $oneCent = (new FileTrailer(['fileControlTotalA' => '10001']))->getFileControlTotalA();
+        $tenCents = (new FileTrailer(['fileControlTotalA' => '10010']))->getFileControlTotalA();
+
+        self::assertNotSame($oneCent, $tenCents);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

### Problem
`ControlTotalTrait::formatAmount()` reassembles a control total's cents with `%d`:
`return (float)\sprintf('%d.%d', (int)\substr($amount, 0, $length), (int)\substr($amount, $length));`
(int) + %d strip a leading zero from the two-digit cents field, so:
- Cents 01–09 are corrupted: 10001 ($100.01) → 100.1 ($100.10), 10005 → 100.5, etc.
- The mapping is non-injective: 10001 and 10010 both produce 100.1.

Control totals are the reconciliation anchor of a (potentially untrusted) bank file. An
equality-based check keyed on getFileControlTotalA() / getGroupControlTotal… /
getAccountControlTotal… can therefore both reject legitimate small-cent totals and fail to
distinguish two genuinely different totals.

Fix (BC-safe)

Preserve the two-digit cents with %02d:
`return (float)\sprintf('%d.%02d', (int)\substr($amount, 0, $length), (int)\substr($amount, $length));`
Return type stays float — only the previously-wrong values change, so no BC break.

Tests

Added a data provider to FileTrailerTest covering cents 00, 01, 05, 09, 10, 99 plus a
collision test (10001 vs 10010). These fail on the old code (4 failures) and pass with the
fix; the existing 10000 → 100.0 case still passes.

Known limitation (out of scope, candidate for a major)

Money is still returned as float, so very large totals lose precision
(123456789012345601 → …3456.0). A precision-safe fix would return an exact decimal string or
integer cents, which changes the accessor return type (BC break) — left for a major version.