### PR TITLE
[EasyErrorHandler] Align translations with http status texts

### DIFF
--- a/packages/EasyErrorHandler/bundle/translations/EasyErrorHandlerBundle.en.php
+++ b/packages/EasyErrorHandler/bundle/translations/EasyErrorHandlerBundle.en.php
@@ -2,15 +2,14 @@
 declare(strict_types=1);
 
 return [
-    // @todo Make translations consistent with \Symfony\Component\HttpFoundation\Response::$statusTexts and \GuzzleHttp\Psr7\Response::PHRASES in 7.0
     'exceptions' => [
-        'bad_request' => 'Bad request.',
-        'conflict' => 'Conflict.',
+        'bad_request' => 'Bad Request',
+        'conflict' => 'Conflict',
         'default_user_message' => 'Oops, something went wrong.',
-        'forbidden' => 'Forbidden.',
-        'not_found' => 'Not found.',
+        'forbidden' => 'Forbidden',
+        'not_found' => 'Not Found',
         'not_valid' => 'Validation failed.',
-        'unauthorized' => 'Unauthorized.',
+        'unauthorized' => 'Unauthorized',
     ],
     'violations' => [
         'invalid_datetime' => 'This value is not a valid date/time.',

--- a/packages/EasyErrorHandler/laravel/translations/en/exceptions.php
+++ b/packages/EasyErrorHandler/laravel/translations/en/exceptions.php
@@ -2,12 +2,11 @@
 declare(strict_types=1);
 
 return [
-    // @todo Make translations consistent with \Symfony\Component\HttpFoundation\Response::$statusTexts and \GuzzleHttp\Psr7\Response::PHRASES in 7.0
-    'bad_request' => 'Bad request.',
-    'conflict' => 'Conflict.',
+    'bad_request' => 'Bad Request',
+    'conflict' => 'Conflict',
     'default_user_message' => 'Oops, something went wrong.',
-    'forbidden' => 'Forbidden.',
-    'not_found' => 'Not found.',
+    'forbidden' => 'Forbidden',
+    'not_found' => 'Not Found',
     'not_valid' => 'Validation failed.',
-    'unauthorized' => 'Unauthorized.',
+    'unauthorized' => 'Unauthorized',
 ];

--- a/packages/EasyErrorHandler/tests/Unit/bundle/TestRenderWithDefaultBuilderDataProvider.php
+++ b/packages/EasyErrorHandler/tests/Unit/bundle/TestRenderWithDefaultBuilderDataProvider.php
@@ -144,7 +144,7 @@ final class TestRenderWithDefaultBuilderDataProvider
                 /** @var array $content */
                 $content = \json_decode((string)$response->getContent(), true);
                 TestCase::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-                TestCase::assertSame('Not found.', $content['custom_message']);
+                TestCase::assertSame('Not Found', $content['custom_message']);
                 TestCase::assertSame(1, $content['custom_code']);
             },
             'translations' => null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->