### PR TITLE
[EasyLock] Register lock factory under own service id

### DIFF
--- a/packages/EasyLock/bundle/Enum/ConfigServiceId.php
+++ b/packages/EasyLock/bundle/Enum/ConfigServiceId.php
@@ -7,5 +7,7 @@ enum ConfigServiceId: string
 {
     case Connection = 'easy_lock.connection';
 
+    case LockFactory = 'easy_lock.lock_factory';
+
     case Store = 'easy_lock.store';
 }

--- a/packages/EasyLock/bundle/config/services.php
+++ b/packages/EasyLock/bundle/config/services.php
@@ -18,7 +18,7 @@ return static function (ContainerConfigurator $container): void {
         ->autoconfigure();
 
     $services
-        ->set(LockFactory::class)
+        ->set(ConfigServiceId::LockFactory->value, LockFactory::class)
         ->arg('$store', service(ConfigServiceId::Store->value))
         ->call('setLogger', [service('logger')->ignoreOnInvalid()])
         ->tag('monolog.logger', ['channel' => BundleParam::LogChannel->value]);
@@ -26,7 +26,7 @@ return static function (ContainerConfigurator $container): void {
     $services
         ->set(LockerInterface::class, Locker::class)
         ->arg('$store', service(ConfigServiceId::Store->value))
-        ->arg('$lockFactory', service(LockFactory::class))
+        ->arg('$lockFactory', service(ConfigServiceId::LockFactory->value))
         ->tag('monolog.logger', ['channel' => BundleParam::LogChannel->value]);
 
     $services

--- a/packages/EasyLock/laravel/EasyLockServiceProvider.php
+++ b/packages/EasyLock/laravel/EasyLockServiceProvider.php
@@ -47,8 +47,6 @@ final class EasyLockServiceProvider extends ServiceProvider
             }
         );
 
-        $this->app->alias(ConfigServiceId::LockFactory->value, LockFactory::class);
-
         $this->app->singleton(
             LockerInterface::class,
             static fn (Container $app): LockerInterface => new Locker(

--- a/packages/EasyLock/laravel/EasyLockServiceProvider.php
+++ b/packages/EasyLock/laravel/EasyLockServiceProvider.php
@@ -38,7 +38,7 @@ final class EasyLockServiceProvider extends ServiceProvider
         );
 
         $this->app->singleton(
-            LockFactory::class,
+            ConfigServiceId::LockFactory->value,
             static function (Container $app) use ($loggerParams): LockFactory {
                 $lockFactory = new LockFactory($app->make(ConfigServiceId::Store->value));
                 $lockFactory->setLogger($app->make(LoggerInterface::class, $loggerParams));
@@ -47,12 +47,14 @@ final class EasyLockServiceProvider extends ServiceProvider
             }
         );
 
+        $this->app->alias(ConfigServiceId::LockFactory->value, LockFactory::class);
+
         $this->app->singleton(
             LockerInterface::class,
             static fn (Container $app): LockerInterface => new Locker(
                 $app->make(ConfigServiceId::Store->value),
                 $app->make(LoggerInterface::class, $loggerParams),
-                $app->make(LockFactory::class)
+                $app->make(ConfigServiceId::LockFactory->value)
             )
         );
     }

--- a/packages/EasyLock/readme.md
+++ b/packages/EasyLock/readme.md
@@ -34,9 +34,9 @@ the `easy_lock.store` id.
 
 ###### Lock factory
 
-The package registers `Symfony\Component\Lock\LockFactory` as a service, configured with the package's store and
-logger, so there is no need to create your own instance of the lock factory. You can simply inject it into your
-services:
+The package registers a `Symfony\Component\Lock\LockFactory` built on its own store and logger under the
+`easy_lock.lock_factory` id, so there is no need to create your own instance of the lock factory. Wire it explicitly
+where you need it:
 
 ```php
 use Symfony\Component\Lock\LockFactory;
@@ -57,7 +57,18 @@ final readonly class MyService
 }
 ```
 
+```php
+// config/services.php
+$services->set(MyService::class)
+    ->arg('$lockFactory', service('easy_lock.lock_factory'));
+```
+
 The same lock factory instance is used by `EonX\EasyLock\Common\Locker\LockerInterface` internally.
+
+Nothing is registered under the `Symfony\Component\Lock\LockFactory` class name on purpose. FrameworkBundle claims
+that name as soon as `framework.lock` is enabled, which is the default once `symfony/lock` is installed, and its
+default factory uses a **flock** store that does not lock across application instances. A plain `LockFactory`
+type-hint therefore resolves to whatever the application configured, which is why the wiring above is explicit.
 
 [1]: https://getcomposer.org/
 [2]: https://symfony.com/doc/current/components/lock.html

--- a/packages/EasyLock/tests/Unit/bundle/EasyLockBundleTest.php
+++ b/packages/EasyLock/tests/Unit/bundle/EasyLockBundleTest.php
@@ -31,8 +31,6 @@ final class EasyLockBundleTest extends AbstractSymfonyTestCase
         $locker = $container->get(LockerInterface::class);
 
         self::assertInstanceOf(LockFactory::class, $lockFactory);
-        // The locker must always use the factory built on the package's store, never the one the
-        // LockFactory class name happens to point at
         self::assertSame($lockFactory, (new ReflectionProperty(Locker::class, 'lockFactory'))->getValue($locker));
         self::assertSame(
             $container->get(ConfigServiceId::Store->value),

--- a/packages/EasyLock/tests/Unit/bundle/EasyLockBundleTest.php
+++ b/packages/EasyLock/tests/Unit/bundle/EasyLockBundleTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyLock\Tests\Unit\Bundle;
 
+use EonX\EasyLock\Bundle\Enum\ConfigServiceId;
 use EonX\EasyLock\Common\Locker\Locker;
 use EonX\EasyLock\Common\Locker\LockerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -26,11 +27,17 @@ final class EasyLockBundleTest extends AbstractSymfonyTestCase
         $container = $this->getKernel()
             ->getContainer();
 
-        $lockFactory = $container->get(LockFactory::class);
+        $lockFactory = $container->get(ConfigServiceId::LockFactory->value);
         $locker = $container->get(LockerInterface::class);
 
         self::assertInstanceOf(LockFactory::class, $lockFactory);
+        // The locker must always use the factory built on the package's store, never the one the
+        // LockFactory class name happens to point at
         self::assertSame($lockFactory, (new ReflectionProperty(Locker::class, 'lockFactory'))->getValue($locker));
+        self::assertSame(
+            $container->get(ConfigServiceId::Store->value),
+            (new ReflectionProperty(LockFactory::class, 'store'))->getValue($lockFactory)
+        );
     }
 
     /**

--- a/packages/EasyLock/tests/Unit/laravel/EasyLockServiceProviderTest.php
+++ b/packages/EasyLock/tests/Unit/laravel/EasyLockServiceProviderTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace EonX\EasyLock\Tests\Unit\Laravel;
 
+use EonX\EasyLock\Bundle\Enum\ConfigServiceId;
 use EonX\EasyLock\Common\Locker\Locker;
 use EonX\EasyLock\Common\Locker\LockerInterface;
 use ReflectionProperty;
@@ -21,10 +22,11 @@ final class EasyLockServiceProviderTest extends AbstractLaravelTestCase
     {
         $app = $this->getApp();
 
-        $lockFactory = $app->get(LockFactory::class);
+        $lockFactory = $app->get(ConfigServiceId::LockFactory->value);
         $locker = $app->get(LockerInterface::class);
 
         self::assertInstanceOf(LockFactory::class, $lockFactory);
         self::assertSame($lockFactory, (new ReflectionProperty(Locker::class, 'lockFactory'))->getValue($locker));
+        self::assertSame($lockFactory, $app->get(LockFactory::class));
     }
 }

--- a/packages/EasyLock/tests/Unit/laravel/EasyLockServiceProviderTest.php
+++ b/packages/EasyLock/tests/Unit/laravel/EasyLockServiceProviderTest.php
@@ -27,6 +27,5 @@ final class EasyLockServiceProviderTest extends AbstractLaravelTestCase
 
         self::assertInstanceOf(LockFactory::class, $lockFactory);
         self::assertSame($lockFactory, (new ReflectionProperty(Locker::class, 'lockFactory'))->getValue($locker));
-        self::assertSame($lockFactory, $app->get(LockFactory::class));
     }
 }


### PR DESCRIPTION
[EasyLock] Register the lock factory under its own service id

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (see below)
| Deprecations? | no
| Tests pass?   | yes

Since 6.23.0 (#1816) the bundle registers the lock factory under the
`Symfony\Component\Lock\LockFactory` class name. FrameworkBundle uses the same name for its own
factory as soon as `framework.lock` is enabled, which is the default once `symfony/lock` is
installed. The two definitions overwrite each other and the winner depends on bundle order: in a
Flex app the EonX bundles load before FrameworkBundle, so Symfony's alias wins and `Locker` gets
the framework factory, which is backed by a **flock** store.

The result is silent: locks stop working across application instances. Every consumer of
`LockerInterface` is affected — `ProcessWithLockMiddleware`, `EasySchedule` and `EasyWebhook`'s
lock middleware. On Lambda or ECS this means the same resource can be processed twice, and
messages that cannot take their lock are acknowledged without being handled.

This PR registers the factory as `easy_lock.lock_factory` and injects that id into `Locker`. The
package no longer claims the `LockFactory` class name, so there is no conflict in either
direction. Tests now assert that the locker's factory is built on `easy_lock.store`.

**BC:** projects that autowired `Symfony\Component\Lock\LockFactory` to get the package factory
must inject `easy_lock.lock_factory` explicitly. With `framework.lock` enabled they were already
getting Symfony's factory, so nothing changes for them; with it disabled the container now fails
at build time with a clear "cannot autowire" error instead of using the wrong store.