### PR TITLE
[EasyApiPlatform] Fix API response API docs schema when pagination disabled

### DIFF
--- a/packages/EasyApiPlatform/src/Common/Factory/PaginationSchemaFactory.php
+++ b/packages/EasyApiPlatform/src/Common/Factory/PaginationSchemaFactory.php
@@ -40,7 +40,10 @@ final readonly class PaginationSchemaFactory implements SchemaFactoryInterface, 
             return $schema;
         }
 
-        if ($forceCollection) {
+        $paginationEnabled = $operation?->getPaginationEnabled()
+            ?? $this->paginationOptions->isPaginationEnabled();
+
+        if ($forceCollection && $paginationEnabled) {
             $itemsPerPageSchema = [
                 'default' => $operation?->getPaginationItemsPerPage() ?? $this->paginationOptions->getItemsPerPage(),
                 'minimum' => 0,

--- a/packages/EasyApiPlatform/tests/Fixture/OpenApi/v3/with_custom_pagination.json
+++ b/packages/EasyApiPlatform/tests/Fixture/OpenApi/v3/with_custom_pagination.json
@@ -504,6 +504,215 @@
                 },
                 "deprecated": false
             }
+        },
+        "/open-api-categories-without-pagination": {
+            "get": {
+                "operationId": "api_open-api-categories-without-pagination_get_collection",
+                "tags": [
+                    "CategoryWithoutPagination"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CategoryWithoutPagination collection",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "hydra:member": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CategoryWithoutPagination.jsonld"
+                                            }
+                                        },
+                                        "hydra:totalItems": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                        },
+                                        "hydra:view": {
+                                            "type": "object",
+                                            "properties": {
+                                                "@id": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "@type": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:first": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "hydra:last": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "hydra:previous": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "hydra:next": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                }
+                                            },
+                                            "example": {
+                                                "@id": "string",
+                                                "type": "string",
+                                                "hydra:first": "string",
+                                                "hydra:last": "string",
+                                                "hydra:previous": "string",
+                                                "hydra:next": "string"
+                                            }
+                                        },
+                                        "hydra:search": {
+                                            "type": "object",
+                                            "properties": {
+                                                "@type": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:template": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:variableRepresentation": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:mapping": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "@type": {
+                                                                "type": "string"
+                                                            },
+                                                            "variable": {
+                                                                "type": "string"
+                                                            },
+                                                            "property": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "required": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "hydra:member"
+                                    ]
+                                }
+                            },
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "self": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "first": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "prev": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "next": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "last": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                }
+                                            },
+                                            "example": {
+                                                "self": "string",
+                                                "first": "string",
+                                                "prev": "string",
+                                                "next": "string",
+                                                "last": "string"
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "properties": {
+                                                "totalItems": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                "itemsPerPage": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                "currentPage": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                }
+                                            }
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CategoryWithoutPagination.jsonapi"
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            },
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "text/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "text/html": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "description": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "parameters": [],
+                "deprecated": false
+            }
         }
     },
     "components": {
@@ -580,6 +789,64 @@
                             }
                         ]
                     },
+                    "@id": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "@type": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination.jsonapi": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "attributes": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "id"
+                        ]
+                    }
+                }
+            },
+            "CategoryWithoutPagination.jsonld": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
                     "@id": {
                         "readOnly": true,
                         "type": "string"

--- a/packages/EasyApiPlatform/tests/Fixture/OpenApi/v3/with_default_pagination.json
+++ b/packages/EasyApiPlatform/tests/Fixture/OpenApi/v3/with_default_pagination.json
@@ -470,6 +470,215 @@
                 },
                 "deprecated": false
             }
+        },
+        "/open-api-categories-without-pagination": {
+            "get": {
+                "operationId": "api_open-api-categories-without-pagination_get_collection",
+                "tags": [
+                    "CategoryWithoutPagination"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CategoryWithoutPagination collection",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "hydra:member": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CategoryWithoutPagination.jsonld"
+                                            }
+                                        },
+                                        "hydra:totalItems": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                        },
+                                        "hydra:view": {
+                                            "type": "object",
+                                            "properties": {
+                                                "@id": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "@type": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:first": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "hydra:last": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "hydra:previous": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "hydra:next": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                }
+                                            },
+                                            "example": {
+                                                "@id": "string",
+                                                "type": "string",
+                                                "hydra:first": "string",
+                                                "hydra:last": "string",
+                                                "hydra:previous": "string",
+                                                "hydra:next": "string"
+                                            }
+                                        },
+                                        "hydra:search": {
+                                            "type": "object",
+                                            "properties": {
+                                                "@type": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:template": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:variableRepresentation": {
+                                                    "type": "string"
+                                                },
+                                                "hydra:mapping": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "@type": {
+                                                                "type": "string"
+                                                            },
+                                                            "variable": {
+                                                                "type": "string"
+                                                            },
+                                                            "property": {
+                                                                "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "required": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "hydra:member"
+                                    ]
+                                }
+                            },
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "links": {
+                                            "type": "object",
+                                            "properties": {
+                                                "self": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "first": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "prev": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "next": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                },
+                                                "last": {
+                                                    "type": "string",
+                                                    "format": "iri-reference"
+                                                }
+                                            },
+                                            "example": {
+                                                "self": "string",
+                                                "first": "string",
+                                                "prev": "string",
+                                                "next": "string",
+                                                "last": "string"
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object",
+                                            "properties": {
+                                                "totalItems": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                "itemsPerPage": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                "currentPage": {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                }
+                                            }
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CategoryWithoutPagination.jsonapi"
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            },
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "text/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "text/html": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "description": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "parameters": [],
+                "deprecated": false
+            }
         }
     },
     "components": {
@@ -546,6 +755,64 @@
                             }
                         ]
                     },
+                    "@id": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "@type": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination.jsonapi": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "attributes": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "id"
+                        ]
+                    }
+                }
+            },
+            "CategoryWithoutPagination.jsonld": {
+                "type": "object",
+                "description": "",
+                "deprecated": false,
+                "properties": {
                     "@id": {
                         "readOnly": true,
                         "type": "string"

--- a/packages/EasyApiPlatform/tests/Fixture/OpenApi/v4/with_custom_pagination.json
+++ b/packages/EasyApiPlatform/tests/Fixture/OpenApi/v4/with_custom_pagination.json
@@ -446,6 +446,122 @@
                     "required": true
                 }
             }
+        },
+        "/open-api-categories-without-pagination": {
+            "get": {
+                "operationId": "api_open-api-categories-without-pagination_get_collection",
+                "tags": [
+                    "CategoryWithoutPagination"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CategoryWithoutPagination collection",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "CategoryWithoutPagination.jsonld collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchemaNoPagination"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "hydra:member"
+                                            ],
+                                            "properties": {
+                                                "hydra:member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/CategoryWithoutPagination.jsonld"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "description": "CategoryWithoutPagination.jsonapi collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/JsonApiCollectionBaseSchemaNoPagination"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "type": "string"
+                                                            },
+                                                            "attributes": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "id"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination.xml"
+                                    }
+                                }
+                            },
+                            "text/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination.xml"
+                                    }
+                                }
+                            },
+                            "text/html": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination.html"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "description": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "parameters": []
+            }
         }
     },
     "components": {
@@ -517,6 +633,45 @@
                 ]
             },
             "Category.xml": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination.html": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination.jsonld": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            },
+            "CategoryWithoutPagination.xml": {
                 "type": "object",
                 "properties": {
                     "name": {
@@ -889,6 +1044,10 @@
         {
             "name": "Category",
             "description": "Resource 'Category' operations."
+        },
+        {
+            "name": "CategoryWithoutPagination",
+            "description": "Resource 'CategoryWithoutPagination' operations."
         }
     ],
     "webhooks": {}

--- a/packages/EasyApiPlatform/tests/Fixture/OpenApi/v4/with_default_pagination.json
+++ b/packages/EasyApiPlatform/tests/Fixture/OpenApi/v4/with_default_pagination.json
@@ -412,6 +412,122 @@
                     "required": true
                 }
             }
+        },
+        "/open-api-categories-without-pagination": {
+            "get": {
+                "operationId": "api_open-api-categories-without-pagination_get_collection",
+                "tags": [
+                    "CategoryWithoutPagination"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CategoryWithoutPagination collection",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination"
+                                    }
+                                }
+                            },
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "CategoryWithoutPagination.jsonld collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchemaNoPagination"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "hydra:member"
+                                            ],
+                                            "properties": {
+                                                "hydra:member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/CategoryWithoutPagination.jsonld"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "description": "CategoryWithoutPagination.jsonapi collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/JsonApiCollectionBaseSchemaNoPagination"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "type": "string"
+                                                            },
+                                                            "attributes": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "id"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination.xml"
+                                    }
+                                }
+                            },
+                            "text/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination.xml"
+                                    }
+                                }
+                            },
+                            "text/html": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CategoryWithoutPagination.html"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "description": "Retrieves the collection of CategoryWithoutPagination resources.",
+                "parameters": []
+            }
         }
     },
     "components": {
@@ -483,6 +599,45 @@
                 ]
             },
             "Category.xml": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination.html": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CategoryWithoutPagination.jsonld": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            },
+            "CategoryWithoutPagination.xml": {
                 "type": "object",
                 "properties": {
                     "name": {
@@ -855,6 +1010,10 @@
         {
             "name": "Category",
             "description": "Resource 'Category' operations."
+        },
+        {
+            "name": "CategoryWithoutPagination",
+            "description": "Resource 'CategoryWithoutPagination' operations."
         }
     ],
     "webhooks": {}

--- a/packages/EasyApiPlatform/tests/Fixture/app/src/OpenApi/ApiResource/CategoryWithoutPagination.php
+++ b/packages/EasyApiPlatform/tests/Fixture/app/src/OpenApi/ApiResource/CategoryWithoutPagination.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace EonX\EasyApiPlatform\Tests\Fixture\App\OpenApi\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+
+#[ApiResource(
+    uriTemplate: 'open-api-categories-without-pagination',
+    operations: [new GetCollection()],
+    paginationEnabled: false,
+)]
+final class CategoryWithoutPagination
+{
+    public string $name;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->

Fix API response API docs schema when pagination disabled to show it as a plain array.